### PR TITLE
Simplify plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dsh-usage-stats
 
 [![CI](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml/badge.svg)](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml)
-[![version](https://img.shields.io/badge/version-0.1.0-1f6feb)](https://github.com/Ychris12138/dsh-usage-stats/releases)
+[![version](https://img.shields.io/badge/version-0.1.1-1f6feb)](https://github.com/Ychris12138/dsh-usage-stats/releases)
 [![license](https://img.shields.io/badge/license-MIT-2da44e)](LICENSE)
 
 为 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 网页端提供 Token 用量热图、分模型统计和 DeepSeek 账户余额。
@@ -186,7 +186,7 @@ scripts/verify-raw.mjs    four-path raw-data verification
 
 ## 兼容性说明
 
-当前版本为 `0.1.0`。插件依赖 DeepSeek Harness 的客户端模块加载器、Cordis 服务和 session persistence 接口；Harness 预发布版本升级后如这些内部接口变化，可能需要同步适配。
+当前版本为 `0.1.1`。插件依赖 DeepSeek Harness 的客户端模块加载器、Cordis 服务和 session persistence 接口；Harness 预发布版本升级后如这些内部接口变化，可能需要同步适配。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,61 +25,56 @@ Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the 
 
 ## 安装 / Installation
 
-### 前置条件
+### 一条命令安装
 
-- DeepSeek Harness 的 `web` profile（面向 `@deepseek-ai/dsh >= 0.1.0-rc.6`）。
-- DeepSeek API key 仅在需要余额功能时配置；用量统计本身不依赖该 key。
+需要 DeepSeek Harness 的 `web` profile（面向 `@deepseek-ai/dsh >= 0.1.0-rc.6`），以及随 Node.js 提供的 `npx`。
 
-### 1. 获取源码并复制插件
-
-```powershell
-git clone https://github.com/Ychris12138/dsh-usage-stats.git
-Set-Location dsh-usage-stats
-
-$target = Join-Path $env:USERPROFILE ".dsh\profiles\node_modules\dsh-usage-stats"
-New-Item -ItemType Directory -Force $target | Out-Null
-Copy-Item -Recurse -Force .\lib, .\package.json, .\README.md, .\LICENSE $target
-```
-
-macOS/Linux：
+在 PowerShell、命令提示符或 macOS/Linux 终端运行同一条命令：
 
 ```bash
-git clone https://github.com/Ychris12138/dsh-usage-stats.git
-cd dsh-usage-stats
-
-target="$HOME/.dsh/profiles/node_modules/dsh-usage-stats"
-mkdir -p "$target"
-cp -R lib package.json README.md LICENSE "$target/"
+npx --yes github:Ychris12138/dsh-usage-stats
 ```
 
-### 2. 启用插件
+安装器会自动完成两件事：把运行文件复制到 `~/.dsh/profiles/node_modules/dsh-usage-stats`，并在 `profiles/web/cordis.patch.yml` 中幂等启用插件。重复运行同一命令即可更新，不会重复添加配置。
 
-在 `~/.dsh/profiles/web/cordis.patch.yml` 末尾加入：
+如设置了 `DSH_HOME`，安装器会使用该目录而不是 `~/.dsh`。可先预览或只检查现有安装：
 
-```yaml
-# Token usage heatmap + DeepSeek balance panel
-- insert:
-    - id: usage-stats
-      name: dsh-usage-stats
+```bash
+npx --yes github:Ychris12138/dsh-usage-stats --dry-run
+npx --yes github:Ychris12138/dsh-usage-stats --check
 ```
 
-### 3. 可选：配置余额查询
+如果不希望安装器修改 Cordis patch，可加 `--no-enable`，再自行配置。
 
-在 `~/.dsh/.credentials.yaml` 中配置：
+### 可选：配置余额查询
+
+只有余额查询需要 DeepSeek API key。用量统计无需 key；未配置时余额卡会显示凭据缺失。
 
 ```yaml
+# ~/.dsh/.credentials.yaml
 DEEPSEEK_API_KEY: sk-your-key-here
 ```
 
-不要把凭据文件或真实 key 提交到 Git。未配置时，用量功能正常，余额卡会显示凭据缺失。
+安装器不会读取、创建或修改凭据文件。不要把真实 key 提交到 Git，也不要把它粘贴给编码 Agent。
 
-### 4. 重启
+### 重启
 
 ```bash
 dsh web
 ```
 
 浏览器硬刷新后，侧边栏底部会出现“用量/余额”（Usage/Balance）入口。
+
+<details>
+<summary>无法使用 npx 时：从源码安装</summary>
+
+```bash
+git clone https://github.com/Ychris12138/dsh-usage-stats.git
+cd dsh-usage-stats
+node scripts/install.mjs
+```
+
+</details>
 
 ## 使用 / Usage
 
@@ -89,6 +84,36 @@ dsh web
 - 标题栏刷新按钮会同时重新请求用量和余额。
 
 “最近 14 天”按本地日历计算，只显示窗口内存在用量的日期；未来时间戳不会计入该列表。
+
+## Agent 友好安装 / Agent-friendly installation
+
+可以把下面整段直接交给 Codex、Claude Code 或其他本地编码 Agent：
+
+```text
+Install or update dsh-usage-stats from:
+https://github.com/Ychris12138/dsh-usage-stats
+
+Constraints:
+- Resolve DSH_HOME from the environment; otherwise use ~/.dsh.
+- Do not read, print, edit, or request .credentials.yaml or any API key.
+- Do not expose the plugin through a reverse proxy.
+- Do not restart or terminate an existing dsh process without asking me.
+
+Procedure:
+1. Confirm node, npx, and dsh are available.
+2. Run: npx --yes github:Ychris12138/dsh-usage-stats
+3. Require the installer to report a verified package and exactly one Cordis patch entry.
+4. Report the resolved install and patch paths.
+5. If dsh web is already running, tell me a restart is needed and stop.
+```
+
+安装器本身提供清晰的退出码：未知参数返回 `2`；文件、版本或配置验证失败返回非零；成功时输出已验证版本、安装路径和 patch 路径。因此 Agent 不需要自行解析或重写 YAML。
+
+Agent 如果只获准检查而不能修改，应运行：
+
+```bash
+npx --yes github:Ychris12138/dsh-usage-stats --check
+```
 
 ## 隐私与安全 / Privacy & security
 
@@ -152,6 +177,8 @@ lib/index.js              server routes, incremental cache, balance fetch
 lib/usage.js              pure token-usage aggregation
 lib/client.js             sidebar panel and heatmap
 scripts/smoke-client.mjs  offline client regressions
+scripts/install.mjs       cross-platform idempotent installer
+scripts/test-install.mjs  installer regression and idempotency test
 scripts/test-server.mjs   offline server regressions
 scripts/validate-fold.mjs live projection comparison
 scripts/verify-raw.mjs    four-path raw-data verification

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-usage-stats",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-usage-stats",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "dsh-usage-stats",
       "version": "0.1.0",
       "license": "MIT",
+      "bin": {
+        "dsh-usage-stats-install": "scripts/install.mjs"
+      },
       "devDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-usage-stats",
   "description": "Token usage heatmap + DeepSeek account balance for the dsh web GUI",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,13 @@
     "dsh",
     "token-usage"
   ],
+  "bin": {
+    "dsh-usage-stats-install": "scripts/install.mjs"
+  },
   "files": [
     "lib/",
     "docs/images/usage-panel.png",
+    "scripts/install.mjs",
     "README.md",
     "LICENSE",
     "SECURITY.md"
@@ -41,9 +45,10 @@
     }
   },
   "scripts": {
-    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/client.js && node --check scripts/smoke-client.mjs && node --check scripts/test-server.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
-    "test": "npm run test:client && npm run test:server",
+    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
+    "test": "npm run test:client && npm run test:server && npm run test:install",
     "test:client": "node scripts/smoke-client.mjs",
+    "test:install": "node scripts/test-install.mjs",
     "test:server": "node scripts/test-server.mjs",
     "validate:live": "node scripts/validate-fold.mjs && node scripts/verify-raw.mjs"
   },

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const knownFlags = new Set(["--check", "--dry-run", "--no-enable", "--help"]);
+const args = new Set(process.argv.slice(2));
+for (const arg of args) {
+	if (!knownFlags.has(arg)) {
+		console.error(`Unknown option: ${arg}`);
+		process.exit(2);
+	}
+}
+
+if (args.has("--help")) {
+	console.log(`dsh-usage-stats installer
+
+Usage:
+  npx --yes github:Ychris12138/dsh-usage-stats [options]
+
+Options:
+  --check      Verify the installed package and Cordis patch without changing them
+  --dry-run    Print the resolved paths and planned changes
+  --no-enable  Install files without editing cordis.patch.yml
+  --help       Show this help
+
+Set DSH_HOME to override the default ~/.dsh location.`);
+	process.exit(0);
+}
+
+const sourceRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const sourcePackage = JSON.parse(await readFile(join(sourceRoot, "package.json"), "utf8"));
+const dshHome = process.env.DSH_HOME ?? join(homedir(), ".dsh");
+const target = join(dshHome, "profiles", "node_modules", "dsh-usage-stats");
+const patchPath = join(dshHome, "profiles", "web", "cordis.patch.yml");
+const pluginLine = /^\s+name:\s*dsh-usage-stats\s*$/gm;
+const patchBlock = `# dsh-usage-stats: token usage heatmap + DeepSeek balance
+- insert:
+    - id: usage-stats
+      name: dsh-usage-stats
+`;
+
+async function readOptional(path) {
+	try {
+		return await readFile(path, "utf8");
+	} catch (error) {
+		if (error?.code === "ENOENT") return null;
+		throw error;
+	}
+}
+
+async function verify(expectEnabled) {
+	const installedRaw = await readOptional(join(target, "package.json"));
+	if (installedRaw === null) throw new Error(`package is not installed at ${target}`);
+	const installed = JSON.parse(installedRaw);
+	if (installed.name !== sourcePackage.name || installed.version !== sourcePackage.version) {
+		throw new Error(`installed package is ${installed.name ?? "unknown"}@${installed.version ?? "unknown"}; expected ${sourcePackage.name}@${sourcePackage.version}`);
+	}
+	if (expectEnabled) {
+		const patch = await readOptional(patchPath);
+		const count = patch === null ? 0 : [...patch.matchAll(pluginLine)].length;
+		if (count !== 1) throw new Error(`expected exactly one dsh-usage-stats entry in ${patchPath}; found ${count}`);
+	}
+	console.log(`Verified ${sourcePackage.name}@${sourcePackage.version}`);
+	console.log(`  package: ${target}`);
+	if (expectEnabled) console.log(`  patch:   ${patchPath}`);
+}
+
+const enable = !args.has("--no-enable");
+if (args.has("--dry-run")) {
+	console.log(`Would install ${sourcePackage.name}@${sourcePackage.version}`);
+	console.log(`  package: ${target}`);
+	console.log(`  patch:   ${enable ? patchPath : "unchanged (--no-enable)"}`);
+	process.exit(0);
+}
+
+if (args.has("--check")) {
+	await verify(enable);
+	process.exit(0);
+}
+
+await mkdir(target, { recursive: true });
+for (const entry of ["lib", "package.json", "README.md", "LICENSE", "SECURITY.md"]) {
+	await cp(join(sourceRoot, entry), join(target, entry), { recursive: true, force: true });
+}
+await mkdir(join(target, "scripts"), { recursive: true });
+await cp(fileURLToPath(import.meta.url), join(target, "scripts", "install.mjs"), { force: true });
+
+if (enable) {
+	await mkdir(dirname(patchPath), { recursive: true });
+	const current = await readOptional(patchPath) ?? "";
+	if (![...current.matchAll(pluginLine)].length) {
+		const separator = current === "" || current.endsWith("\n") ? "" : "\n";
+		const leading = current === "" ? "" : "\n";
+		await writeFile(patchPath, `${current}${separator}${leading}${patchBlock}`, "utf8");
+	}
+}
+
+await verify(enable);
+console.log("Installation complete. Restart dsh web, then hard-refresh the browser.");
+console.log("Balance is optional: configure DEEPSEEK_API_KEY in <DSH_HOME>/.credentials.yaml.");

--- a/scripts/test-install.mjs
+++ b/scripts/test-install.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const home = await mkdtemp(join(tmpdir(), "dsh-usage-stats-install-"));
+const installer = fileURLToPath(new URL("./install.mjs", import.meta.url));
+
+function run(...args) {
+	const result = spawnSync(process.execPath, [installer, ...args], {
+		env: { ...process.env, DSH_HOME: home },
+		encoding: "utf8"
+	});
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+	return result.stdout;
+}
+
+try {
+	run();
+	run();
+	assert.match(run("--check"), /Verified dsh-usage-stats@/);
+	const patch = await readFile(join(home, "profiles", "web", "cordis.patch.yml"), "utf8");
+	assert.equal([...patch.matchAll(/^\s+name:\s*dsh-usage-stats\s*$/gm)].length, 1, "installer must be idempotent");
+	const installed = JSON.parse(await readFile(join(home, "profiles", "node_modules", "dsh-usage-stats", "package.json"), "utf8"));
+	assert.equal(installed.name, "dsh-usage-stats");
+	assert.equal(await readFile(join(home, "profiles", "node_modules", "dsh-usage-stats", "lib", "index.js"), "utf8").then((text) => text.length > 1000), true);
+	console.log("INSTALLER REGRESSION TESTS PASSED");
+} finally {
+	await rm(home, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What changed

- add a cross-platform, idempotent installer exposed through `npx`
- automatically copy runtime files and add exactly one Cordis patch entry
- add dry-run, check-only, and no-enable modes
- replace the manual README workflow with a one-command install
- add a copy-ready, credential-safe workflow for coding agents
- add isolated installer regression tests

## Why

The previous installation required cloning the repository, manually copying files, and editing YAML. That was easy to get wrong and difficult for agents to verify safely.

## Validation

- `npm run check`
- `npm test`
- `npm audit --omit=dev`
- `npm pack --dry-run`
- packaged CLI dry-run with an isolated `DSH_HOME`
