### PR TITLE
Add provider balances and subscription quota cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dsh-usage-stats
 
 [![CI](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml/badge.svg)](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml)
-[![version](https://img.shields.io/badge/version-0.2.0-1f6feb)](https://github.com/Ychris12138/dsh-usage-stats/releases)
+[![version](https://img.shields.io/badge/version-0.1.2-1f6feb)](https://github.com/Ychris12138/dsh-usage-stats/releases)
 [![license](https://img.shields.io/badge/license-MIT-2da44e)](LICENSE)
 
 为 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 网页端提供 Token 用量热图、多供应商余额与订阅额度。
@@ -238,7 +238,7 @@ scripts/verify-raw.mjs    four-path raw-data verification
 
 ## 兼容性说明
 
-当前版本为 `0.2.0`。插件依赖 DeepSeek Harness 的客户端模块加载器、Cordis 服务和 session persistence 接口；Harness 预发布版本升级后如这些内部接口变化，可能需要同步适配。
+当前版本为 `0.1.2`。插件依赖 DeepSeek Harness 的客户端模块加载器、Cordis 服务和 session persistence 接口；Harness 预发布版本升级后如这些内部接口变化，可能需要同步适配。
 
 ## 参考与致谢 / References
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # dsh-usage-stats
 
 [![CI](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml/badge.svg)](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml)
-[![version](https://img.shields.io/badge/version-0.1.1-1f6feb)](https://github.com/Ychris12138/dsh-usage-stats/releases)
+[![version](https://img.shields.io/badge/version-0.2.0-1f6feb)](https://github.com/Ychris12138/dsh-usage-stats/releases)
 [![license](https://img.shields.io/badge/license-MIT-2da44e)](LICENSE)
 
-为 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 网页端提供 Token 用量热图、分模型统计和 DeepSeek 账户余额。
+为 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 网页端提供 Token 用量热图、多供应商余额与订阅额度。
 
-Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the DeepSeek Harness Web GUI (`dsh web`).
+Token usage heatmap, provider/model breakdowns, account balances, and subscription quotas for the DeepSeek Harness Web GUI (`dsh web`).
 
 ![dsh-usage-stats panel](docs/images/usage-panel.png)
 
@@ -14,14 +14,15 @@ Token usage heatmap, per-model breakdowns, and DeepSeek account balance for the 
 
 | 功能 | 说明 |
 | --- | --- |
-| 账户余额 | 通过 DeepSeek 官方 `/user/balance` API 查询充值、赠送和总余额 |
+| 多供应商余额 | 余额卡可选供应商；内置 DeepSeek、OpenRouter、Moonshot/Kimi、Z.AI 查询方案，其余供应商显示"无公开余额接口" |
+| 订阅额度 | OpenCode Go 显示 5 小时/每周/每月窗口；Z.ai Coding Plan 显示会话、周额度与 MCP 月度额度 |
 | 用量概览 | 今日、本月、累计 Token，以及今日缓存命中率 |
 | 月历热图 | 按月浏览；颜色越深表示用量越高 |
-| 日期下钻 | 点击日期查看分模型 Token、占比和输入/输出/缓存明细 |
+| 日期下钻 | 点击日期查看分供应商/分模型 Token、占比和输入/输出/缓存明细 |
 | 增量聚合 | 只折叠新增事件；检测到日志截断或重写时自动从头计算 |
 | 本机边界 | API 同时校验 peer socket 与 Host；浏览器永远拿不到 API key |
 
-界面支持中文和英文，余额与用量独立刷新；打开面板后立即加载，之后用量每分钟刷新、余额每五分钟刷新。
+界面支持中文和英文。余额采用金额卡片，订阅采用分窗口进度条；各类请求独立刷新，打开面板后立即加载，之后 Token 用量每分钟刷新、余额和订阅额度每五分钟刷新。
 
 ## 安装 / Installation
 
@@ -48,14 +49,49 @@ npx --yes github:Ychris12138/dsh-usage-stats --check
 
 ### 可选：配置余额查询
 
-只有余额查询需要 DeepSeek API key。用量统计无需 key；未配置时余额卡会显示凭据缺失。
+余额查询会**自动读取 Harness 中已配置的供应商**：官方 DeepSeek 路由（`llm-deepseek`）以及每个 pi-ai 供应商 profile（`llm-pi-ai`，如 `opencode`、`opencode-go`、`openrouter`、`ark` 等）。每个供应商的 API key 由 Harness 的凭据服务按需解析，插件不存储任何 key。用量统计无需 key。
+
+内置的余额查询方案：
+
+| 供应商 id | 余额接口 |
+| --- | --- |
+| `deepseek` / `deepseek-official` | `{baseURL}/user/balance` |
+| `openrouter` | `{baseURL}/api/v1/credits` |
+| `moonshotai` / `moonshotai-cn` / `kimi` | `{baseURL}/v1/users/me/balance` |
+| `zai` / `zai-coding-cn` | `{baseURL}/api/paas/v4/balance` |
+
+其余供应商（如 OpenCode Go、火山方舟、OpenAI、Anthropic 等）没有公开的余额查询接口，面板会明确显示"该供应商没有公开的余额查询接口"，而不是报错。
+
+以 DeepSeek 为例，凭据保存在：
 
 ```yaml
 # ~/.dsh/.credentials.yaml
 DEEPSEEK_API_KEY: sk-your-key-here
 ```
 
-安装器不会读取、创建或修改凭据文件。不要把真实 key 提交到 Git，也不要把它粘贴给编码 Agent。
+pi-ai 供应商（如 ark）的凭据按其 profile 里的 `apiKeyEnv` 保存（例如 `ARK_API_KEY`）。安装器不会读取、创建或修改凭据文件。不要把真实 key 提交到 Git，也不要把它粘贴给编码 Agent。
+
+### 可选：配置订阅额度
+
+订阅额度不是账户余额，因此使用独立的进度条界面。只配置你实际使用的供应商即可：
+
+```yaml
+# ~/.dsh/.credentials.yaml
+OPENCODE_GO_API_KEY: sk-opencode-your-key
+ZAI_API_KEY: your-zai-key
+# 中国区 Z.ai 用户可选；默认 global
+ZAI_API_REGION: bigmodel-cn
+```
+
+OpenCode Go 按以下顺序寻找凭据：
+
+1. Harness 凭据 `OPENCODE_GO_API_KEY`；
+2. OpenCode 自己的 `~/.local/share/opencode/auth.json`（`opencode-go`，回退 `opencode`）；
+3. 高级兼容回退：`OPENCODE_GO_AUTH_COOKIE` + `OPENCODE_GO_WORKSPACE_ID`。
+
+前两种方式调用 `https://opencode.ai/zen/go/v1/usage`。它使用 `sk-opencode-…` Bearer Key，安装最简单，但目前仍是 OpenCode 自用的**未公开文档接口**，将来可能变化。第三种方式读取登录后的 workspace 页面，只建议接口发生兼容问题时临时使用；浏览器 Cookie 等同登录凭据，不应提交到 Git、日志或 issue。
+
+Z.ai 使用 Coding Plan 的 quota/subscription 接口；全球区请求 `api.z.ai`，中国区请求 `open.bigmodel.cn`。如果同一个 Z.ai key 同时支持余额接口，面板会分别显示“金额余额”和“订阅比例”，二者不会混为一项。
 
 ### 重启
 
@@ -79,9 +115,11 @@ node scripts/install.mjs
 ## 使用 / Usage
 
 - 点击侧边栏入口打开面板。
+- 余额卡顶部可切换供应商；切换后自动查询该供应商余额。
+- 订阅额度卡独立显示 OpenCode Go 与 Z.ai；未配置、凭据失效、限流和接口不可用会显示不同状态。
 - 使用 `‹`、`›` 切换月份，点击“今天”返回当前月份。
-- 点击热图日期或最近 14 个日历日列表，查看当天的模型明细。
-- 标题栏刷新按钮会同时重新请求用量和余额。
+- 点击热图日期或最近 14 个日历日列表，查看当天的分供应商/分模型明细（同一模型来自不同供应商会分开显示，如 `deepseek-official · deepseek-v4-flash` 与 `ark · deepseek-v4-flash`）。
+- 标题栏刷新按钮会同时重新请求用量、供应商列表、当前供应商余额和订阅额度。
 
 “最近 14 天”按本地日历计算，只显示窗口内存在用量的日期；未来时间戳不会计入该列表。
 
@@ -95,7 +133,7 @@ https://github.com/Ychris12138/dsh-usage-stats
 
 Constraints:
 - Resolve DSH_HOME from the environment; otherwise use ~/.dsh.
-- Do not read, print, edit, or request .credentials.yaml or any API key.
+- Do not read, print, edit, or request .credentials.yaml, auth.json, cookies, or any API key.
 - Do not expose the plugin through a reverse proxy.
 - Do not restart or terminate an existing dsh process without asking me.
 
@@ -104,7 +142,13 @@ Procedure:
 2. Run: npx --yes github:Ychris12138/dsh-usage-stats
 3. Require the installer to report a verified package and exactly one Cordis patch entry.
 4. Report the resolved install and patch paths.
-5. If dsh web is already running, tell me a restart is needed and stop.
+5. Run the installer again with --check and require a zero exit code.
+6. If dsh web is already running, tell me a restart is needed and stop.
+
+Optional subscription setup (do not handle secrets yourself):
+- Tell me that OpenCode Go can reuse its local auth.json automatically, or I can add OPENCODE_GO_API_KEY to the Harness credentials file myself.
+- Tell me that Z.ai requires ZAI_API_KEY; China-region accounts may also set ZAI_API_REGION=bigmodel-cn.
+- Never ask me to paste a key or browser cookie into chat.
 ```
 
 安装器本身提供清晰的退出码：未知参数返回 `2`；文件、版本或配置验证失败返回非零；成功时输出已验证版本、安装路径和 patch 路径。因此 Agent 不需要自行解析或重写 YAML。
@@ -117,10 +161,11 @@ npx --yes github:Ychris12138/dsh-usage-stats --check
 
 ## 隐私与安全 / Privacy & security
 
-- API key 不会发送到浏览器、写入插件缓存或日志。服务端只把它作为 Bearer token，通过 HTTPS 发往 DeepSeek 官方余额 API。
+- API key、OpenCode auth.json 内容与兼容 Cookie 不会发送到浏览器、写入插件缓存或日志。服务端只通过 HTTPS 把相应凭据发往对应供应商域名。
 - 余额响应只包含 `isAvailable`、`currency`、`total`、`granted`、`toppedUp` 和 `fetchedAt`，不包含 key。
-- 用量缓存在 `~/.dsh/storages/usage-stats-cache.json`，只保存按日期/模型聚合的 Token、会话 id、不透明修订号与折叠游标，不保存提示词、回复正文或文件路径。
-- 两个端点仅接受 GET，并同时校验 `req.socket.remoteAddress` 与 Host；支持 IPv4、IPv4-mapped IPv6 和 `[::1]:port`。
+- 订阅响应只包含供应商、计划、状态、额度窗口百分比和重置时间，不包含 key、Cookie 或 workspace 页面正文。
+- 用量缓存在 `~/.dsh/storages/usage-stats-cache.json`，只保存按日期/供应商/模型聚合的 Token、会话 id、不透明修订号与折叠游标，不保存提示词、回复正文或文件路径。
+- 四个端点仅接受 GET，并同时校验 `req.socket.remoteAddress` 与 Host；支持 IPv4、IPv4-mapped IPv6 和 `[::1]:port`。
 
 本机反向代理会让插件看到代理自身的回环地址。请勿把这些端点经反向代理暴露到局域网或公网；如确需代理，请在代理层增加可靠的认证与访问控制。
 
@@ -128,7 +173,7 @@ npx --yes github:Ychris12138/dsh-usage-stats --check
 
 ## 聚合与正确性 / Aggregation & correctness
 
-统计值来自 `assistant/chunk` 或 `assistant/message` 事件中的 provider-reported `usage`，不是本地估算。相同 turn/step 的后续 usage 样本会替换前一个样本，与 Harness 的 token usage projection 语义一致。
+统计值来自 `assistant/chunk` 或 `assistant/message` 事件中的 provider-reported `usage`，不是本地估算。相同 turn/step 的后续 usage 样本会替换前一个样本，与 Harness 的 token usage projection 语义一致。每个样本按 `provider/model` 归集（取自 `data.message.source`，兜底 `request/header` 的 `data.header.config`），因此同一模型在不同供应商下会分开统计。
 
 - 活跃会话只处理内存中新追加的事件。
 - 持久化会话优先使用 `sessionPersistence.listSnapshots()` 的不透明 revision；revision 未变化时不读取日志。
@@ -165,28 +210,41 @@ node scripts/check-balance.mjs
 
 | Method | Path | Response |
 | --- | --- | --- |
-| `GET` | `/api/usage-stats/usage` | 按日期/模型统计的 Token、缓存命中率与更新时间 |
-| `GET` | `/api/usage-stats/balance` | 脱敏后的 DeepSeek 余额与获取时间 |
+| `GET` | `/api/usage-stats/usage` | 按日期/供应商/模型统计的 Token、缓存命中率与更新时间 |
+| `GET` | `/api/usage-stats/providers` | 已配置的供应商列表（含余额方案与凭据是否已配置） |
+| `GET` | `/api/usage-stats/balance?provider=<id>` | 所选供应商的脱敏余额与获取时间；省略 `provider` 时默认官方 DeepSeek 路由 |
+| `GET` | `/api/usage-stats/subscriptions` | OpenCode Go 与 Z.ai 的脱敏订阅状态、百分比窗口和重置时间 |
 
 其他方法返回 `405`，非回环请求返回 `403`。响应均为 JSON，并带 `Cache-Control: no-cache`。
 
 ## 项目结构
 
 ```text
-lib/index.js              server routes, incremental cache, balance fetch
-lib/usage.js              pure token-usage aggregation
-lib/client.js             sidebar panel and heatmap
+lib/index.js              server routes, incremental cache, provider-aware balance
+lib/usage.js              pure token-usage aggregation (provider/model keys)
+lib/balance.js            provider balance schemes (deepseek/openrouter/moonshot/zai)
+lib/subscriptions.js      normalized OpenCode Go and Z.ai quota adapters
+lib/client.js             balance and subscription UIs, provider picker, heatmap
 scripts/smoke-client.mjs  offline client regressions
 scripts/install.mjs       cross-platform idempotent installer
 scripts/test-install.mjs  installer regression and idempotency test
 scripts/test-server.mjs   offline server regressions
+scripts/test-balance.mjs  offline balance-scheme unit tests
+scripts/test-subscriptions.mjs offline subscription-adapter tests
 scripts/validate-fold.mjs live projection comparison
 scripts/verify-raw.mjs    four-path raw-data verification
 ```
 
 ## 兼容性说明
 
-当前版本为 `0.1.1`。插件依赖 DeepSeek Harness 的客户端模块加载器、Cordis 服务和 session persistence 接口；Harness 预发布版本升级后如这些内部接口变化，可能需要同步适配。
+当前版本为 `0.2.0`。插件依赖 DeepSeek Harness 的客户端模块加载器、Cordis 服务和 session persistence 接口；Harness 预发布版本升级后如这些内部接口变化，可能需要同步适配。
+
+## 参考与致谢 / References
+
+- [Javis603/token-monitor](https://github.com/Javis603/token-monitor)：参考其多 provider 配额归一化与 Z.ai 限额解析。
+- [xiaoqi20/dsh-opencode-go-usage](https://github.com/xiaoqi20/dsh-opencode-go-usage)：参考其 DSH 凭据接入、OpenCode `auth.json` 回退与 Bearer usage endpoint。
+
+本项目重新实现统一的 subscription adapter 和同屏卡片，不复制上述项目的 UI；OpenCode Go 的 usage endpoint 尚未公开文档，因此保留 dashboard 兼容回退并由测试锁定两种响应格式。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Token usage heatmap, provider/model breakdowns, account balances, and subscripti
 
 | 功能 | 说明 |
 | --- | --- |
-| 多供应商余额 | 余额卡可选供应商；内置 DeepSeek、OpenRouter、Moonshot/Kimi、Z.AI 查询方案，其余供应商显示"无公开余额接口" |
+| 统一供应商账户卡 | 一次只显示当前选择的供应商；DeepSeek 等展示余额，OpenCode Go、Z.ai 展示订阅额度 |
 | 订阅额度 | OpenCode Go 显示 5 小时/每周/每月窗口；Z.ai Coding Plan 显示会话、周额度与 MCP 月度额度 |
 | 用量概览 | 今日、本月、累计 Token，以及今日缓存命中率 |
 | 月历热图 | 按月浏览；颜色越深表示用量越高 |
@@ -22,7 +22,7 @@ Token usage heatmap, provider/model breakdowns, account balances, and subscripti
 | 增量聚合 | 只折叠新增事件；检测到日志截断或重写时自动从头计算 |
 | 本机边界 | API 同时校验 peer socket 与 Host；浏览器永远拿不到 API key |
 
-界面支持中文和英文。余额采用金额卡片，订阅采用分窗口进度条；各类请求独立刷新，打开面板后立即加载，之后 Token 用量每分钟刷新、余额和订阅额度每五分钟刷新。
+界面支持中文和英文。余额与订阅共用同一套供应商卡片框架：余额型供应商在卡内显示金额，订阅型供应商显示分窗口进度条；选择器切换后只渲染当前供应商。各类请求独立刷新，打开面板后立即加载，之后 Token 用量每分钟刷新、余额和订阅额度每五分钟刷新。
 
 ## 安装 / Installation
 
@@ -91,7 +91,7 @@ OpenCode Go 按以下顺序寻找凭据：
 
 前两种方式调用 `https://opencode.ai/zen/go/v1/usage`。它使用 `sk-opencode-…` Bearer Key，安装最简单，但目前仍是 OpenCode 自用的**未公开文档接口**，将来可能变化。第三种方式读取登录后的 workspace 页面，只建议接口发生兼容问题时临时使用；浏览器 Cookie 等同登录凭据，不应提交到 Git、日志或 issue。
 
-Z.ai 使用 Coding Plan 的 quota/subscription 接口；全球区请求 `api.z.ai`，中国区请求 `open.bigmodel.cn`。如果同一个 Z.ai key 同时支持余额接口，面板会分别显示“金额余额”和“订阅比例”，二者不会混为一项。
+Z.ai 使用 Coding Plan 的 quota/subscription 接口；全球区请求 `api.z.ai`，中国区请求 `open.bigmodel.cn`。选择 Z.ai 时优先展示更适合订阅计划的比例窗口，不会同时再堆叠一张余额卡。
 
 ### 重启
 
@@ -115,8 +115,9 @@ node scripts/install.mjs
 ## 使用 / Usage
 
 - 点击侧边栏入口打开面板。
-- 余额卡顶部可切换供应商；切换后自动查询该供应商余额。
-- 订阅额度卡独立显示 OpenCode Go 与 Z.ai；未配置、凭据失效、限流和接口不可用会显示不同状态。
+- 使用“当前供应商”选择器切换账户视图；面板一次只显示一个供应商。
+- DeepSeek、OpenRouter、Moonshot/Kimi 等余额型供应商显示金额；OpenCode Go 与 Z.ai 显示订阅比例、窗口和重置时间。
+- 未配置、凭据失效、限流和接口不可用会在同一张供应商卡片中显示不同状态。
 - 使用 `‹`、`›` 切换月份，点击“今天”返回当前月份。
 - 点击热图日期或最近 14 个日历日列表，查看当天的分供应商/分模型明细（同一模型来自不同供应商会分开显示，如 `deepseek-official · deepseek-v4-flash` 与 `ark · deepseek-v4-flash`）。
 - 标题栏刷新按钮会同时重新请求用量、供应商列表、当前供应商余额和订阅额度。
@@ -244,7 +245,7 @@ scripts/verify-raw.mjs    four-path raw-data verification
 - [Javis603/token-monitor](https://github.com/Javis603/token-monitor)：参考其多 provider 配额归一化与 Z.ai 限额解析。
 - [xiaoqi20/dsh-opencode-go-usage](https://github.com/xiaoqi20/dsh-opencode-go-usage)：参考其 DSH 凭据接入、OpenCode `auth.json` 回退与 Bearer usage endpoint。
 
-本项目重新实现统一的 subscription adapter 和同屏卡片，不复制上述项目的 UI；OpenCode Go 的 usage endpoint 尚未公开文档，因此保留 dashboard 兼容回退并由测试锁定两种响应格式。
+本项目重新实现统一的 subscription adapter 和单供应商账户卡片，不复制上述项目的 UI；OpenCode Go 的 usage endpoint 尚未公开文档，因此保留 dashboard 兼容回退并由测试锁定两种响应格式。
 
 ## License
 

--- a/lib/balance.js
+++ b/lib/balance.js
@@ -1,0 +1,103 @@
+/**
+ * dsh-usage-stats — provider balance schemes.
+ *
+ * Pure, testable balance-query registry. Each scheme knows the endpoint path
+ * (relative to the provider's configured base URL) and how to parse the
+ * response into a normalized `{ isAvailable, currency, total, granted,
+ * toppedUp }` view. Providers without a public balance API (OpenCode Go,
+ * Volcano Ark, OpenAI, Anthropic, …) map to no scheme — the UI shows an
+ * explicit "no public balance interface" state instead of guessing.
+ *
+ * @module dsh-usage-stats/balance
+ */
+
+const SCHEMES = {
+	/** DeepSeek: GET {origin}/user/balance — CNY balance_infos entry. */
+	deepseek: {
+		url: (baseURL) => new URL("/user/balance", baseURL).href,
+		parse: (json) => {
+			const infos = Array.isArray(json?.balance_infos) ? json.balance_infos : [];
+			const info = infos.find((entry) => entry?.currency === "CNY") ?? infos[0];
+			return {
+				isAvailable: json?.is_available === true,
+				currency: info?.currency ?? void 0,
+				total: info?.total_balance ?? void 0,
+				granted: info?.granted_balance ?? void 0,
+				toppedUp: info?.topped_up_balance ?? void 0
+			};
+		}
+	},
+	/** OpenRouter: GET {origin}/api/v1/credits — `credits` is the remaining balance. */
+	openrouter: {
+		url: (baseURL) => new URL("/api/v1/credits", baseURL).href,
+		parse: (json) => {
+			const credits = json?.credits;
+			return {
+				isAvailable: typeof credits === "number" ? credits > 0 : void 0,
+				currency: "USD",
+				total: typeof credits === "number" ? credits : void 0,
+				granted: void 0,
+				toppedUp: void 0
+			};
+		}
+	},
+	/** Moonshot / Kimi: GET {origin}/v1/users/me/balance — available/cash/voucher. */
+	moonshot: {
+		url: (baseURL) => new URL("/v1/users/me/balance", baseURL).href,
+		parse: (json) => {
+			const data = json?.data;
+			const available = typeof data?.available_balance === "number" ? data.available_balance : void 0;
+			const cash = typeof data?.cash_balance === "number" ? data.cash_balance : void 0;
+			const voucher = typeof data?.voucher_balance === "number" ? data.voucher_balance : void 0;
+			return {
+				isAvailable: available !== void 0 ? available > 0 : void 0,
+				currency: typeof data?.currency === "string" ? data.currency : void 0,
+				total: available,
+				granted: voucher,
+				toppedUp: cash
+			};
+		}
+	},
+	/** Z.AI / GLM: GET {origin}/api/paas/v4/balance — total + available. */
+	zai: {
+		url: (baseURL) => new URL("/api/paas/v4/balance", baseURL).href,
+		parse: (json) => {
+			const data = json?.data;
+			const total = typeof data?.total_balance === "number" ? data.total_balance : typeof data?.available_balance === "number" ? data.available_balance : void 0;
+			const available = typeof data?.available_balance === "number" ? data.available_balance : void 0;
+			return {
+				isAvailable: total !== void 0 ? total > 0 : void 0,
+				currency: typeof data?.currency === "string" ? data.currency : void 0,
+				total,
+				granted: void 0,
+				toppedUp: available
+			};
+		}
+	}
+};
+
+/** Map a provider id (dsh adapter id or pi-ai route) to a balance scheme id. */
+export function balanceSchemeOf(providerId) {
+	if (providerId === "deepseek-official" || providerId === "deepseek") return "deepseek";
+	if (providerId === "openrouter") return "openrouter";
+	if (providerId === "moonshotai" || providerId === "moonshotai-cn" || providerId === "kimi" || providerId === "kimi-coding") return "moonshot";
+	if (providerId === "zai" || providerId === "zai-coding-cn") return "zai";
+	return null;
+}
+
+/** Query one provider's balance. Throws on transport/HTTP errors. */
+export async function queryBalance(scheme, baseURL, apiKey, timeoutMs = 15000) {
+	const spec = SCHEMES[scheme];
+	if (spec === void 0) throw new Error(`no balance scheme "${scheme}"`);
+	const response = await fetch(spec.url(baseURL), {
+		headers: { authorization: `Bearer ${apiKey}` },
+		signal: AbortSignal.timeout(timeoutMs)
+	});
+	if (!response.ok) throw new Error(`balance API returned HTTP ${response.status}`);
+	return spec.parse(await response.json());
+}
+
+/** Scheme ids with built-in support (for docs/tests). */
+export function supportedBalanceSchemes() {
+	return Object.keys(SCHEMES);
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -2,10 +2,10 @@
  * dsh-usage-stats — browser half.
  *
  * Hand-written `__ModuleLoader__` bundle (no build step): a sidebar footer
- * action that opens a floating panel with the DeepSeek account balance, a
- * Codex-style blue daily token-usage heatmap, per-day per-model breakdowns
- * (click a day), and cache hit rates. Data comes from the server half's two
- * endpoints via same-origin fetch.
+ * action that opens a floating panel with provider balances, subscription
+ * quota windows, a Codex-style blue daily token-usage heatmap, per-day
+ * provider/model breakdowns, and cache hit rates. Data comes from the server
+ * half's loopback-only endpoints via same-origin fetch.
  */
 window.__ModuleLoader__.load({
 	id: "dsh-usage-stats",
@@ -51,6 +51,29 @@ window.__ModuleLoader__.load({
 			".usg_balanceBad{color:var(--dsw-alias-state-error-primary)}",
 			".usg_balanceRows{color:var(--dsw-alias-label-secondary);flex-direction:column;gap:2px;font-size:12px;line-height:18px;display:flex}",
 			".usg_balanceRow{justify-content:space-between;display:flex}",
+			".usg_providerPicker{align-items:center;gap:8px;margin:6px 0 8px;font-size:12px;line-height:18px;display:flex}",
+			".usg_providerPickerLabel{color:var(--dsw-alias-label-tertiary);flex:none}",
+			".usg_providerSelect{box-sizing:border-box;min-width:0;flex:1;color:var(--dsw-alias-label-primary);background:var(--dsw-alias-bg-base);border:1px solid var(--dsw-alias-border-l2);border-radius:8px;padding:4px 6px;font:inherit;font-size:12px;line-height:18px}",
+			".usg_subscriptionGrid{flex-direction:column;gap:8px;display:flex}",
+			".usg_subscriptionCard{--usg-quotaAccent:#1f6feb;box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);background:linear-gradient(135deg,color-mix(in srgb,var(--usg-quotaAccent) 8%,transparent),transparent 42%);border-radius:12px;padding:10px 11px;display:flex;flex-direction:column;gap:9px}",
+			".usg_subscriptionCard[data-provider=opencode-go]{--usg-quotaAccent:#00a67d}",
+			".usg_subscriptionCard[data-provider=zai]{--usg-quotaAccent:#7656e8}",
+			".usg_subscriptionHead{align-items:center;gap:8px;display:flex}",
+			".usg_subscriptionMark{width:24px;height:24px;color:#fff;background:var(--usg-quotaAccent);border-radius:7px;justify-content:center;align-items:center;font-size:11px;font-weight:700;display:flex;box-shadow:0 4px 12px color-mix(in srgb,var(--usg-quotaAccent) 25%,transparent)}",
+			".usg_subscriptionIdentity{min-width:0;flex:1;display:flex;flex-direction:column}",
+			".usg_subscriptionName{color:var(--dsw-alias-label-primary);font-size:13px;font-weight:600;line-height:18px}",
+			".usg_subscriptionPlan{color:var(--dsw-alias-label-tertiary);text-overflow:ellipsis;white-space:nowrap;font-size:10px;line-height:14px;overflow:hidden}",
+			".usg_subscriptionStatus{color:var(--dsw-alias-label-tertiary);background:var(--dsw-alias-fill-l2);border-radius:999px;padding:2px 7px;font-size:10px;line-height:16px;white-space:nowrap}",
+			".usg_subscriptionStatus[data-status=ok]{color:var(--usg-quotaAccent);background:color-mix(in srgb,var(--usg-quotaAccent) 12%,transparent)}",
+			".usg_quotaList{flex-direction:column;gap:8px;display:flex}",
+			".usg_quotaRow{display:flex;flex-direction:column;gap:4px}",
+			".usg_quotaMeta{align-items:baseline;gap:8px;display:flex}",
+			".usg_quotaLabel{color:var(--dsw-alias-label-secondary);font-size:11px;line-height:16px}",
+			".usg_quotaValue{color:var(--dsw-alias-label-primary);margin-left:auto;font-size:12px;font-weight:600;line-height:16px;font-variant-numeric:tabular-nums}",
+			".usg_quotaReset{color:var(--dsw-alias-label-caption);font-size:9px;line-height:14px;white-space:nowrap}",
+			".usg_quotaTrack{height:6px;background:var(--dsw-alias-fill-l2);border-radius:999px;overflow:hidden}",
+			".usg_quotaFill{height:100%;background:var(--usg-quotaAccent);border-radius:inherit;min-width:2px;transition:width .2s ease}",
+			".usg_quotaEmpty{color:var(--dsw-alias-label-tertiary);margin:0;font-size:11px;line-height:17px}",
 			".usg_statsRow{display:flex;gap:8px}",
 			".usg_stat{box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);border-radius:10px;flex:1;flex-direction:column;gap:1px;padding:8px 10px;display:flex}",
 			".usg_statValue{color:var(--dsw-alias-label-primary);font-size:15px;font-weight:600;line-height:22px;font-variant-numeric:tabular-nums;white-space:nowrap}",
@@ -133,6 +156,26 @@ window.__ModuleLoader__.load({
 			note: "usg_note",
 			error: "usg_error",
 			retry: "usg_retry",
+			providerPicker: "usg_providerPicker",
+			providerPickerLabel: "usg_providerPickerLabel",
+			providerSelect: "usg_providerSelect",
+			subscriptionGrid: "usg_subscriptionGrid",
+			subscriptionCard: "usg_subscriptionCard",
+			subscriptionHead: "usg_subscriptionHead",
+			subscriptionMark: "usg_subscriptionMark",
+			subscriptionIdentity: "usg_subscriptionIdentity",
+			subscriptionName: "usg_subscriptionName",
+			subscriptionPlan: "usg_subscriptionPlan",
+			subscriptionStatus: "usg_subscriptionStatus",
+			quotaList: "usg_quotaList",
+			quotaRow: "usg_quotaRow",
+			quotaMeta: "usg_quotaMeta",
+			quotaLabel: "usg_quotaLabel",
+			quotaValue: "usg_quotaValue",
+			quotaReset: "usg_quotaReset",
+			quotaTrack: "usg_quotaTrack",
+			quotaFill: "usg_quotaFill",
+			quotaEmpty: "usg_quotaEmpty",
 			balanceCard: "usg_balanceCard",
 			balanceMain: "usg_balanceMain",
 			balanceAmount: "usg_balanceAmount",
@@ -345,17 +388,23 @@ window.__ModuleLoader__.load({
 			const [open, setOpen] = react.useState(false);
 			const [usage, setUsage] = react.useState(null);
 			const [usageError, setUsageError] = react.useState(null);
-			const [balance, setBalance] = react.useState(null);
-			const [balanceError, setBalanceError] = react.useState(null);
-			const [noCredential, setNoCredential] = react.useState(false);
-			const [refreshedAt, setRefreshedAt] = react.useState(null);
 			const [selectedDay, setSelectedDay] = react.useState(null);
 			const [viewMonth, setViewMonth] = react.useState(() => currentMonthKey());
+			const [providers, setProviders] = react.useState([]);
+			const [selectedProvider, setSelectedProvider] = react.useState(null);
+			const [subscriptions, setSubscriptions] = react.useState(null);
+			const [subscriptionError, setSubscriptionError] = react.useState(null);
+			const [balance, setBalance] = react.useState(null);
+			const [balanceState, setBalanceState] = react.useState("loading"); // loading | ok | unsupported | no-credential | error
+			const [balanceMessage, setBalanceMessage] = react.useState(null);
+			const [refreshedAt, setRefreshedAt] = react.useState(null);
 			const mountedRef = react.useRef(true);
 			const usageLoaderRef = react.useRef(null);
 			const balanceLoaderRef = react.useRef(null);
+			const subscriptionLoaderRef = react.useRef(null);
 			if (usageLoaderRef.current === null) usageLoaderRef.current = createLoader();
 			if (balanceLoaderRef.current === null) balanceLoaderRef.current = createLoader();
+			if (subscriptionLoaderRef.current === null) subscriptionLoaderRef.current = createLoader();
 
 			const loadUsage = react.useCallback(() => {
 				const seq = usageLoaderRef.current.start();
@@ -374,24 +423,70 @@ window.__ModuleLoader__.load({
 				});
 			}, []);
 
-			const loadBalance = react.useCallback(() => {
+			const loadProviders = react.useCallback(() => {
+				fetchJson("/api/usage-stats/providers").then((payload) => {
+					if (!mountedRef.current) return;
+					if (payload.ok !== true) return;
+					const list = Array.isArray(payload.providers) ? payload.providers : [];
+					setProviders(list);
+					setSelectedProvider((current) => {
+						if (current !== null && list.some((entry) => entry.id === current)) return current;
+						// Prefer a configured provider with a balance scheme (DeepSeek official first).
+						return list.find((entry) => entry.id === "deepseek-official" && entry.scheme !== null && entry.configured)?.id
+							?? list.find((entry) => entry.scheme !== null && entry.configured)?.id
+							?? list.find((entry) => entry.scheme !== null)?.id
+							?? list[0]?.id
+							?? null;
+					});
+				}).catch(() => { /* balance section shows a retry state */ });
+			}, []);
+
+			const loadSubscriptions = react.useCallback(() => {
+				const seq = subscriptionLoaderRef.current.start();
+				setSubscriptionError(null);
+				fetchJson("/api/usage-stats/subscriptions").then((payload) => {
+					if (!mountedRef.current || !subscriptionLoaderRef.current.isCurrent(seq)) return;
+					if (payload.ok !== true) {
+						setSubscriptionError(payload.message ?? "subscription usage failed");
+						return;
+					}
+					setSubscriptions(Array.isArray(payload.subscriptions) ? payload.subscriptions : []);
+					setRefreshedAt(Date.now());
+				}).catch((error) => {
+					if (!mountedRef.current || !subscriptionLoaderRef.current.isCurrent(seq)) return;
+					setSubscriptionError(error instanceof Error ? error.message : String(error));
+				});
+			}, []);
+
+			const loadBalance = react.useCallback((providerId) => {
 				const seq = balanceLoaderRef.current.start();
-				setBalanceError(null);
-				setNoCredential(false);
-				fetchJson("/api/usage-stats/balance").then((payload) => {
+				setBalanceState("loading");
+				setBalanceMessage(null);
+				const target = providerId ?? selectedProvider;
+				if (target === null) {
+					setBalanceState("error");
+					setBalanceMessage("no providers");
+					return;
+				}
+				const query = target === "deepseek-official" ? "" : `?provider=${encodeURIComponent(target)}`;
+				fetchJson(`/api/usage-stats/balance${query}`).then((payload) => {
 					if (!mountedRef.current || !balanceLoaderRef.current.isCurrent(seq)) return;
 					if (payload.ok !== true) {
-						if (payload.error === "no-credential") setNoCredential(true);
-						else setBalanceError(payload.message ?? "balance fetch failed");
+						if (payload.error === "unsupported") setBalanceState("unsupported");
+						else if (payload.error === "no-credential") setBalanceState("no-credential");
+						else setBalanceState("error");
+						setBalanceMessage(payload.message ?? "balance fetch failed");
 						return;
 					}
 					setBalance(payload.balance);
+					setBalanceState("ok");
 					setRefreshedAt(Date.now());
 				}).catch((error) => {
 					if (!mountedRef.current || !balanceLoaderRef.current.isCurrent(seq)) return;
-					setBalanceError(error instanceof Error ? error.message : String(error));
+					setBalanceState("error");
+					setBalanceMessage(error instanceof Error ? error.message : String(error));
 				});
-			}, []);
+			}, [selectedProvider]);
 
 			react.useEffect(() => {
 				mountedRef.current = true;
@@ -403,14 +498,27 @@ window.__ModuleLoader__.load({
 			react.useEffect(() => {
 				if (!open) return;
 				loadUsage();
-				loadBalance();
+				loadProviders();
+				loadSubscriptions();
 				const usageTimer = window.setInterval(loadUsage, 60000);
-				const balanceTimer = window.setInterval(loadBalance, 300000);
+				const providerTimer = window.setInterval(loadProviders, 300000);
+				const subscriptionTimer = window.setInterval(loadSubscriptions, 300000);
 				return () => {
 					window.clearInterval(usageTimer);
-					window.clearInterval(balanceTimer);
+					window.clearInterval(providerTimer);
+					window.clearInterval(subscriptionTimer);
 				};
-			}, [open, loadUsage, loadBalance]);
+			}, [open, loadUsage, loadProviders, loadSubscriptions]);
+
+			// Fetch the selected provider's balance whenever it changes.
+			react.useEffect(() => {
+				if (!open || selectedProvider === null) return;
+				loadBalance(selectedProvider);
+				const timer = window.setInterval(() => loadBalance(selectedProvider), 300000);
+				return () => {
+					window.clearInterval(timer);
+				};
+			}, [open, selectedProvider, loadBalance]);
 
 			const dayMap = react.useMemo(() => {
 				const map = new Map();
@@ -470,7 +578,9 @@ window.__ModuleLoader__.load({
 
 			const retry = () => {
 				loadUsage();
-				loadBalance();
+				loadProviders();
+				loadSubscriptions();
+				loadBalance(selectedProvider);
 			};
 
 			const updatedLabel = refreshedAt === null ? "" : translate("panel.updatedAt", {
@@ -539,28 +649,49 @@ window.__ModuleLoader__.load({
 												className: S.section,
 												children: react_jsx_runtime.jsx("h3", { className: S.sectionTitle, children: translate("balance.title") })
 											}),
-											noCredential ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("balance.noCredential", { ref: "DEEPSEEK_API_KEY" }) }) : balanceError === null ? react_jsx_runtime.jsx(BalanceCard, {
+											react_jsx_runtime.jsx(ProviderPicker, {
+												providers,
+												selectedProvider,
+												onSelect: (id) => setSelectedProvider(id),
+												translate
+											}),
+											balanceState === "loading" ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("balance.loading") }) : balanceState === "unsupported" ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("balance.unsupported") }) : balanceState === "no-credential" ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("balance.noCredential", { ref: balanceMessage ?? "" }) }) : balanceState === "error" ? react_jsx_runtime.jsxs("div", {
+												className: S.error,
+												children: [
+													react_jsx_runtime.jsx("span", { children: translate("balance.error", { message: balanceMessage ?? "" }) }),
+													react_jsx_runtime.jsx("button", {
+														type: "button",
+														className: S.retry,
+														onClick: () => loadBalance(selectedProvider),
+														children: translate("action.retry")
+													})
+												]
+											}) : react_jsx_runtime.jsx(BalanceCard, {
 												balance,
 												translate,
 												className: S.balanceCard,
-												loadingText: translate("balance.loading"),
 												okText: translate("balance.available"),
 												badText: translate("balance.unavailable"),
 												rows: [
 													{ key: "toppedUp", label: translate("balance.toppedUp") },
 													{ key: "granted", label: translate("balance.granted") }
 												]
-											}) : react_jsx_runtime.jsxs("div", {
+											}),
+											react_jsx_runtime.jsx("section", {
+												className: S.section,
+												children: react_jsx_runtime.jsx("h3", { className: S.sectionTitle, children: translate("subscription.title") })
+											}),
+											subscriptions === null && subscriptionError === null ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("subscription.loading") }) : null,
+											subscriptionError !== null ? react_jsx_runtime.jsxs("div", {
 												className: S.error,
 												children: [
-													react_jsx_runtime.jsx("span", { children: translate("balance.error", { message: balanceError }) }),
-													react_jsx_runtime.jsx("button", {
-														type: "button",
-														className: S.retry,
-														onClick: loadBalance,
-														children: translate("action.retry")
-													})
+													react_jsx_runtime.jsx("span", { children: translate("subscription.error", { message: subscriptionError }) }),
+													react_jsx_runtime.jsx("button", { type: "button", className: S.retry, onClick: loadSubscriptions, children: translate("action.retry") })
 												]
+											}) : null,
+											subscriptions !== null && react_jsx_runtime.jsx("div", {
+												className: S.subscriptionGrid,
+												children: subscriptions.map((provider) => react_jsx_runtime.jsx(SubscriptionCard, { provider, translate }, provider.id))
 											}),
 											react_jsx_runtime.jsx("section", {
 												className: S.section,
@@ -702,9 +833,9 @@ window.__ModuleLoader__.load({
 			});
 		}
 
-		/** Balance card with loading and unavailable states. */
-		function BalanceCard({ balance, translate, className, loadingText, okText, badText, rows }) {
-			if (balance === null) return react_jsx_runtime.jsx("p", { className: S.note, children: loadingText });
+		/** Balance card for the selected provider. */
+		function BalanceCard({ balance, translate, className, okText, badText, rows }) {
+			if (balance === null) return react_jsx_runtime.jsx("p", { className: S.note, children: translate("balance.loading") });
 			return react_jsx_runtime.jsxs("div", {
 				className,
 				children: [
@@ -741,6 +872,111 @@ window.__ModuleLoader__.load({
 							]
 						}, row.key))
 					})
+				]
+			});
+		}
+
+		/** Provider selector for the balance card. */
+		function ProviderPicker({ providers, selectedProvider, onSelect, translate }) {
+			if (providers.length === 0) return null;
+			return react_jsx_runtime.jsxs("label", {
+				className: S.providerPicker,
+				children: [
+					react_jsx_runtime.jsx("span", { className: S.providerPickerLabel, children: translate("balance.provider") }),
+					react_jsx_runtime.jsx("select", {
+						className: S.providerSelect,
+						value: selectedProvider ?? "",
+						"aria-label": translate("balance.provider"),
+						onChange: (event) => onSelect(event.target.value),
+						children: providers.map((provider) => react_jsx_runtime.jsx("option", {
+							value: provider.id,
+							children: `${provider.displayName}${provider.scheme === null ? ` (${translate("balance.noSchemeTag")})` : ""}`
+						}, provider.id))
+					})
+				]
+			});
+		}
+
+		function subscriptionStatusLabel(status, translate) {
+			if (status === "ok") return translate("subscription.status.ok");
+			if (status === "not-configured") return translate("subscription.status.notConfigured");
+			if (status === "unauthorized") return translate("subscription.status.unauthorized");
+			if (status === "rate-limited") return translate("subscription.status.rateLimited");
+			return translate("subscription.status.unavailable");
+		}
+
+		function quotaLabel(kind, translate) {
+			if (kind === "session") return translate("subscription.window.session");
+			if (kind === "weekly") return translate("subscription.window.weekly");
+			if (kind === "monthly") return translate("subscription.window.monthly");
+			if (kind === "billing") return translate("subscription.window.mcp");
+			return kind;
+		}
+
+		function resetLabel(resetsAt, translate) {
+			if (typeof resetsAt !== "string") return "";
+			const date = new Date(resetsAt);
+			if (Number.isNaN(date.getTime())) return "";
+			return translate("subscription.resets", {
+				time: date.toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+			});
+		}
+
+		/** Percentage-window card for subscription-style providers. */
+		function SubscriptionCard({ provider, translate }) {
+			const windows = Array.isArray(provider.windows) ? provider.windows : [];
+			const status = typeof provider.status === "string" ? provider.status : "unavailable";
+			const emptyMessage = status === "not-configured"
+				? translate("subscription.notConfigured", { refs: Array.isArray(provider.missingCredentials) ? provider.missingCredentials.join(" + ") : "" })
+				: status === "unauthorized" ? translate("subscription.unauthorized")
+					: status === "rate-limited" ? translate("subscription.rateLimited")
+						: translate("subscription.unavailable");
+			return react_jsx_runtime.jsxs("article", {
+				className: S.subscriptionCard,
+				"data-provider": provider.id,
+				children: [
+					react_jsx_runtime.jsxs("div", {
+						className: S.subscriptionHead,
+						children: [
+							react_jsx_runtime.jsx("span", { className: S.subscriptionMark, "aria-hidden": true, children: provider.id === "opencode-go" ? "GO" : "Z" }),
+							react_jsx_runtime.jsxs("span", {
+								className: S.subscriptionIdentity,
+								children: [
+									react_jsx_runtime.jsx("span", { className: S.subscriptionName, children: provider.displayName }),
+									react_jsx_runtime.jsx("span", { className: S.subscriptionPlan, children: provider.plan ?? translate("subscription.planUnknown") })
+								]
+							}),
+							react_jsx_runtime.jsx("span", { className: S.subscriptionStatus, "data-status": status, children: subscriptionStatusLabel(status, translate) })
+						]
+					}),
+					status === "ok" && windows.length > 0 ? react_jsx_runtime.jsx("div", {
+						className: S.quotaList,
+						children: windows.map((window) => {
+							const used = Math.max(0, Math.min(100, Number(window.usedPercent) || 0));
+							return react_jsx_runtime.jsxs("div", {
+								className: S.quotaRow,
+								children: [
+									react_jsx_runtime.jsxs("div", {
+										className: S.quotaMeta,
+										children: [
+											react_jsx_runtime.jsx("span", { className: S.quotaLabel, children: quotaLabel(window.kind, translate) }),
+											react_jsx_runtime.jsx("span", { className: S.quotaReset, children: resetLabel(window.resetsAt, translate) }),
+											react_jsx_runtime.jsx("span", { className: S.quotaValue, children: translate("subscription.used", { value: used.toFixed(used % 1 === 0 ? 0 : 1) }) })
+										]
+									}),
+									react_jsx_runtime.jsx("div", {
+										className: S.quotaTrack,
+										role: "progressbar",
+										"aria-label": quotaLabel(window.kind, translate),
+										"aria-valuemin": 0,
+										"aria-valuemax": 100,
+										"aria-valuenow": used,
+										children: react_jsx_runtime.jsx("div", { className: S.quotaFill, style: { width: `${used}%` } })
+									})
+								]
+							}, window.kind);
+						})
+					}) : react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: emptyMessage })
 				]
 			});
 		}
@@ -782,7 +1018,7 @@ window.__ModuleLoader__.load({
 									react_jsx_runtime.jsxs("div", {
 										className: S.modelHead,
 										children: [
-											react_jsx_runtime.jsx("span", { className: S.modelName, title: model.model, children: model.model === "unknown" ? translate("usage.unknownModel") : model.model }),
+											react_jsx_runtime.jsx("span", { className: S.modelName, title: model.model, children: modelLabelOf(model.model, translate) }),
 											react_jsx_runtime.jsx("span", { className: S.modelTokens, children: fmt(model.tokens ?? 0) }),
 											react_jsx_runtime.jsx("span", { className: S.modelHit, children: fmtHit(model.cacheHitRate) })
 										]
@@ -876,6 +1112,21 @@ window.__ModuleLoader__.load({
 			const names = translate("month.names").split(",");
 			return names[month] ?? String(month + 1);
 		}
+
+		/**
+		 * Display label for a `provider/model` attribution key (the same model
+		 * served by different providers must stay distinguishable).
+		 */
+		function modelLabelOf(key, translate) {
+			if (typeof key !== "string") return "";
+			const slash = key.indexOf("/");
+			if (slash === -1) return key;
+			const provider = key.slice(0, slash);
+			const model = key.slice(slash + 1);
+			const providerLabel = provider === "unknown" ? translate("usage.unknownModel") : provider;
+			const modelLabel = model === "unknown" || model === "" ? translate("usage.unknownModel") : model;
+			return `${providerLabel} · ${modelLabel}`;
+		}
 		//#endregion
 
 		//#region locales
@@ -884,7 +1135,10 @@ window.__ModuleLoader__.load({
 		const zh = {
 			"panel.title": "用量与余额",
 			"panel.badge": "用量/余额",
-			"balance.title": "DeepSeek 账户余额",
+			"balance.title": "账户余额",
+			"balance.provider": "供应商",
+			"balance.noSchemeTag": "无余额接口",
+			"balance.unsupported": "该供应商没有公开的余额查询接口。",
 			"balance.total": "总余额",
 			"balance.toppedUp": "充值余额",
 			"balance.granted": "赠送余额",
@@ -893,6 +1147,25 @@ window.__ModuleLoader__.load({
 			"balance.loading": "正在查询余额…",
 			"balance.noCredential": "未配置 {ref}（请编辑 ~/.dsh/.credentials.yaml）",
 			"balance.error": "余额获取失败：{message}",
+			"subscription.title": "订阅额度",
+			"subscription.loading": "正在查询订阅额度…",
+			"subscription.error": "订阅额度获取失败：{message}",
+			"subscription.status.ok": "实时",
+			"subscription.status.notConfigured": "未配置",
+			"subscription.status.unauthorized": "需重新登录",
+			"subscription.status.rateLimited": "请求受限",
+			"subscription.status.unavailable": "暂不可用",
+			"subscription.window.session": "5 小时窗口",
+			"subscription.window.weekly": "每周窗口",
+			"subscription.window.monthly": "每月窗口",
+			"subscription.window.mcp": "MCP 月度额度",
+			"subscription.used": "已用 {value}%",
+			"subscription.resets": "{time} 重置",
+			"subscription.notConfigured": "配置 {refs} 后显示真实订阅比例。",
+			"subscription.unauthorized": "凭据已失效，请更新后重试。",
+			"subscription.rateLimited": "供应商暂时限制查询，请稍后重试。",
+			"subscription.unavailable": "供应商没有返回可识别的额度窗口。",
+			"subscription.planUnknown": "订阅计划",
 			"usage.title": "Token 用量",
 			"usage.today": "今日",
 			"usage.month": "本月",
@@ -931,7 +1204,10 @@ window.__ModuleLoader__.load({
 		const en = {
 			"panel.title": "Usage & Balance",
 			"panel.badge": "Usage/Balance",
-			"balance.title": "DeepSeek account balance",
+			"balance.title": "Account balance",
+			"balance.provider": "Provider",
+			"balance.noSchemeTag": "no balance API",
+			"balance.unsupported": "This provider has no public balance interface.",
 			"balance.total": "Total balance",
 			"balance.toppedUp": "Topped up",
 			"balance.granted": "Granted",
@@ -940,6 +1216,25 @@ window.__ModuleLoader__.load({
 			"balance.loading": "Fetching balance…",
 			"balance.noCredential": "{ref} is not configured (edit ~/.dsh/.credentials.yaml)",
 			"balance.error": "Balance fetch failed: {message}",
+			"subscription.title": "Subscription usage",
+			"subscription.loading": "Fetching subscription usage…",
+			"subscription.error": "Subscription usage failed: {message}",
+			"subscription.status.ok": "Live",
+			"subscription.status.notConfigured": "Not configured",
+			"subscription.status.unauthorized": "Sign in again",
+			"subscription.status.rateLimited": "Rate limited",
+			"subscription.status.unavailable": "Unavailable",
+			"subscription.window.session": "5-hour window",
+			"subscription.window.weekly": "Weekly window",
+			"subscription.window.monthly": "Monthly window",
+			"subscription.window.mcp": "Monthly MCP quota",
+			"subscription.used": "{value}% used",
+			"subscription.resets": "Resets {time}",
+			"subscription.notConfigured": "Configure {refs} to show live subscription usage.",
+			"subscription.unauthorized": "The credential has expired; update it and retry.",
+			"subscription.rateLimited": "The provider is rate limiting checks; retry later.",
+			"subscription.unavailable": "The provider returned no recognizable quota windows.",
+			"subscription.planUnknown": "Subscription plan",
 			"usage.title": "Token usage",
 			"usage.today": "Today",
 			"usage.month": "This month",
@@ -1000,10 +1295,12 @@ window.__ModuleLoader__.load({
 		exports.inject = inject;
 		exports.UsageStatsPanel = UsageStatsPanel;
 		exports.DayDetail = DayDetail;
+		exports.SubscriptionCard = SubscriptionCard;
 		exports.MonthHeatmap = MonthHeatmap;
 		exports.buildMonthHeatmap = buildMonthHeatmap;
 		exports.cellColor = cellColor;
 		exports.createLoader = createLoader;
+		exports.modelLabelOf = modelLabelOf;
 		exports.fmt = fmt;
 		exports.fmtCurrency = fmtCurrency;
 		return module.exports;

--- a/lib/client.js
+++ b/lib/client.js
@@ -54,17 +54,20 @@ window.__ModuleLoader__.load({
 			".usg_providerPicker{align-items:center;gap:8px;margin:6px 0 8px;font-size:12px;line-height:18px;display:flex}",
 			".usg_providerPickerLabel{color:var(--dsw-alias-label-tertiary);flex:none}",
 			".usg_providerSelect{box-sizing:border-box;min-width:0;flex:1;color:var(--dsw-alias-label-primary);background:var(--dsw-alias-bg-base);border:1px solid var(--dsw-alias-border-l2);border-radius:8px;padding:4px 6px;font:inherit;font-size:12px;line-height:18px}",
-			".usg_subscriptionGrid{flex-direction:column;gap:8px;display:flex}",
-			".usg_subscriptionCard{--usg-quotaAccent:#1f6feb;box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);background:linear-gradient(135deg,color-mix(in srgb,var(--usg-quotaAccent) 8%,transparent),transparent 42%);border-radius:12px;padding:10px 11px;display:flex;flex-direction:column;gap:9px}",
-			".usg_subscriptionCard[data-provider=opencode-go]{--usg-quotaAccent:#00a67d}",
-			".usg_subscriptionCard[data-provider=zai]{--usg-quotaAccent:#7656e8}",
-			".usg_subscriptionHead{align-items:center;gap:8px;display:flex}",
-			".usg_subscriptionMark{width:24px;height:24px;color:#fff;background:var(--usg-quotaAccent);border-radius:7px;justify-content:center;align-items:center;font-size:11px;font-weight:700;display:flex;box-shadow:0 4px 12px color-mix(in srgb,var(--usg-quotaAccent) 25%,transparent)}",
-			".usg_subscriptionIdentity{min-width:0;flex:1;display:flex;flex-direction:column}",
-			".usg_subscriptionName{color:var(--dsw-alias-label-primary);font-size:13px;font-weight:600;line-height:18px}",
-			".usg_subscriptionPlan{color:var(--dsw-alias-label-tertiary);text-overflow:ellipsis;white-space:nowrap;font-size:10px;line-height:14px;overflow:hidden}",
-			".usg_subscriptionStatus{color:var(--dsw-alias-label-tertiary);background:var(--dsw-alias-fill-l2);border-radius:999px;padding:2px 7px;font-size:10px;line-height:16px;white-space:nowrap}",
-			".usg_subscriptionStatus[data-status=ok]{color:var(--usg-quotaAccent);background:color-mix(in srgb,var(--usg-quotaAccent) 12%,transparent)}",
+			".usg_accountGrid{flex-direction:column;gap:8px;display:flex}",
+			".usg_accountCard{--usg-providerAccent:#1f6feb;box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);background:linear-gradient(135deg,color-mix(in srgb,var(--usg-providerAccent) 8%,transparent),transparent 42%);border-radius:12px;padding:10px 11px;display:flex;flex-direction:column;gap:9px}",
+			".usg_accountCard[data-provider=deepseek],.usg_accountCard[data-provider=deepseek-official]{--usg-providerAccent:#1f6feb}",
+			".usg_accountCard[data-provider=opencode-go]{--usg-providerAccent:#00a67d}",
+			".usg_accountCard[data-provider=zai],.usg_accountCard[data-provider=zai-coding-cn]{--usg-providerAccent:#7656e8}",
+			".usg_accountCard[data-provider=openrouter]{--usg-providerAccent:#6366f1}",
+			".usg_accountCard[data-provider=moonshotai],.usg_accountCard[data-provider=moonshotai-cn],.usg_accountCard[data-provider=kimi],.usg_accountCard[data-provider=kimi-coding]{--usg-providerAccent:#e07a1f}",
+			".usg_accountHead{align-items:center;gap:8px;display:flex}",
+			".usg_accountMark{width:24px;height:24px;color:#fff;background:var(--usg-providerAccent);border-radius:7px;justify-content:center;align-items:center;font-size:10px;font-weight:700;display:flex;box-shadow:0 4px 12px color-mix(in srgb,var(--usg-providerAccent) 25%,transparent)}",
+			".usg_accountIdentity{min-width:0;flex:1;display:flex;flex-direction:column}",
+			".usg_accountName{color:var(--dsw-alias-label-primary);font-size:13px;font-weight:600;line-height:18px}",
+			".usg_accountPlan{color:var(--dsw-alias-label-tertiary);text-overflow:ellipsis;white-space:nowrap;font-size:10px;line-height:14px;overflow:hidden}",
+			".usg_accountStatus{color:var(--dsw-alias-label-tertiary);background:var(--dsw-alias-fill-l2);border-radius:999px;padding:2px 7px;font-size:10px;line-height:16px;white-space:nowrap}",
+			".usg_accountStatus[data-status=ok]{color:var(--usg-providerAccent);background:color-mix(in srgb,var(--usg-providerAccent) 12%,transparent)}",
 			".usg_quotaList{flex-direction:column;gap:8px;display:flex}",
 			".usg_quotaRow{display:flex;flex-direction:column;gap:4px}",
 			".usg_quotaMeta{align-items:baseline;gap:8px;display:flex}",
@@ -72,7 +75,7 @@ window.__ModuleLoader__.load({
 			".usg_quotaValue{color:var(--dsw-alias-label-primary);margin-left:auto;font-size:12px;font-weight:600;line-height:16px;font-variant-numeric:tabular-nums}",
 			".usg_quotaReset{color:var(--dsw-alias-label-caption);font-size:9px;line-height:14px;white-space:nowrap}",
 			".usg_quotaTrack{height:6px;background:var(--dsw-alias-fill-l2);border-radius:999px;overflow:hidden}",
-			".usg_quotaFill{height:100%;background:var(--usg-quotaAccent);border-radius:inherit;min-width:2px;transition:width .2s ease}",
+			".usg_quotaFill{height:100%;background:var(--usg-providerAccent);border-radius:inherit;min-width:2px;transition:width .2s ease}",
 			".usg_quotaEmpty{color:var(--dsw-alias-label-tertiary);margin:0;font-size:11px;line-height:17px}",
 			".usg_statsRow{display:flex;gap:8px}",
 			".usg_stat{box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);border-radius:10px;flex:1;flex-direction:column;gap:1px;padding:8px 10px;display:flex}",
@@ -159,14 +162,14 @@ window.__ModuleLoader__.load({
 			providerPicker: "usg_providerPicker",
 			providerPickerLabel: "usg_providerPickerLabel",
 			providerSelect: "usg_providerSelect",
-			subscriptionGrid: "usg_subscriptionGrid",
-			subscriptionCard: "usg_subscriptionCard",
-			subscriptionHead: "usg_subscriptionHead",
-			subscriptionMark: "usg_subscriptionMark",
-			subscriptionIdentity: "usg_subscriptionIdentity",
-			subscriptionName: "usg_subscriptionName",
-			subscriptionPlan: "usg_subscriptionPlan",
-			subscriptionStatus: "usg_subscriptionStatus",
+			accountGrid: "usg_accountGrid",
+			accountCard: "usg_accountCard",
+			accountHead: "usg_accountHead",
+			accountMark: "usg_accountMark",
+			accountIdentity: "usg_accountIdentity",
+			accountName: "usg_accountName",
+			accountPlan: "usg_accountPlan",
+			accountStatus: "usg_accountStatus",
 			quotaList: "usg_quotaList",
 			quotaRow: "usg_quotaRow",
 			quotaMeta: "usg_quotaMeta",
@@ -304,6 +307,46 @@ window.__ModuleLoader__.load({
 			};
 		}
 
+		/** Canonical subscription record id for a provider, or null for balance-mode providers. */
+		function subscriptionIdFor(providerId) {
+			if (providerId === "opencode-go") return "opencode-go";
+			if (providerId === "zai" || providerId === "zai-coding-cn") return "zai";
+			return null;
+		}
+
+		/**
+		 * Merge configured balance providers with subscription adapters into the
+		 * single selector interface. Z.ai CN/global aliases collapse to one row.
+		 */
+		function buildProviderChoices(providers, subscriptions) {
+			const choices = Array.isArray(providers) ? providers.map((provider) => ({
+				...provider,
+				accountMode: subscriptionIdFor(provider.id) === null ? "balance" : "subscription",
+				subscriptionId: subscriptionIdFor(provider.id)
+			})) : [];
+			const byId = new Map(choices.map((provider) => [provider.id, provider]));
+			for (const subscription of Array.isArray(subscriptions) ? subscriptions : []) {
+				let target = byId.get(subscription.id);
+				if (subscription.id === "zai") target = byId.get("zai") ?? byId.get("zai-coding-cn") ?? target;
+				if (target !== void 0) {
+					target.accountMode = "subscription";
+					target.subscriptionId = subscription.id;
+					continue;
+				}
+				const choice = {
+					id: subscription.id,
+					displayName: subscription.displayName,
+					configured: subscription.status !== "not-configured",
+					scheme: null,
+					accountMode: "subscription",
+					subscriptionId: subscription.id
+				};
+				choices.push(choice);
+				byId.set(choice.id, choice);
+			}
+			return choices;
+		}
+
 		/** Locale-safe template interpolation: `t("key", {a})` replaces `{a}`. */
 		function interpolate(template, params) {
 			if (params === void 0) return template;
@@ -391,6 +434,7 @@ window.__ModuleLoader__.load({
 			const [selectedDay, setSelectedDay] = react.useState(null);
 			const [viewMonth, setViewMonth] = react.useState(() => currentMonthKey());
 			const [providers, setProviders] = react.useState([]);
+			const [providersLoaded, setProvidersLoaded] = react.useState(false);
 			const [selectedProvider, setSelectedProvider] = react.useState(null);
 			const [subscriptions, setSubscriptions] = react.useState(null);
 			const [subscriptionError, setSubscriptionError] = react.useState(null);
@@ -405,6 +449,12 @@ window.__ModuleLoader__.load({
 			if (usageLoaderRef.current === null) usageLoaderRef.current = createLoader();
 			if (balanceLoaderRef.current === null) balanceLoaderRef.current = createLoader();
 			if (subscriptionLoaderRef.current === null) subscriptionLoaderRef.current = createLoader();
+			const providerChoices = react.useMemo(() => buildProviderChoices(providers, subscriptions), [providers, subscriptions]);
+			const selectedProviderInfo = providerChoices.find((provider) => provider.id === selectedProvider) ?? null;
+			const selectedAccountMode = selectedProviderInfo?.accountMode ?? null;
+			const selectedSubscription = selectedProviderInfo?.subscriptionId === null || selectedProviderInfo?.subscriptionId === void 0
+				? null
+				: subscriptions?.find((subscription) => subscription.id === selectedProviderInfo.subscriptionId) ?? null;
 
 			const loadUsage = react.useCallback(() => {
 				const seq = usageLoaderRef.current.start();
@@ -426,19 +476,14 @@ window.__ModuleLoader__.load({
 			const loadProviders = react.useCallback(() => {
 				fetchJson("/api/usage-stats/providers").then((payload) => {
 					if (!mountedRef.current) return;
-					if (payload.ok !== true) return;
+					if (payload.ok !== true) {
+						setProvidersLoaded(true);
+						return;
+					}
 					const list = Array.isArray(payload.providers) ? payload.providers : [];
 					setProviders(list);
-					setSelectedProvider((current) => {
-						if (current !== null && list.some((entry) => entry.id === current)) return current;
-						// Prefer a configured provider with a balance scheme (DeepSeek official first).
-						return list.find((entry) => entry.id === "deepseek-official" && entry.scheme !== null && entry.configured)?.id
-							?? list.find((entry) => entry.scheme !== null && entry.configured)?.id
-							?? list.find((entry) => entry.scheme !== null)?.id
-							?? list[0]?.id
-							?? null;
-					});
-				}).catch(() => { /* balance section shows a retry state */ });
+					setProvidersLoaded(true);
+				}).catch(() => { setProvidersLoaded(true); });
 			}, []);
 
 			const loadSubscriptions = react.useCallback(() => {
@@ -495,6 +540,19 @@ window.__ModuleLoader__.load({
 				};
 			}, []);
 
+			// Keep exactly one valid provider selected across independent provider
+			// and subscription responses. DeepSeek remains the initial preference.
+			react.useEffect(() => {
+				if (!providersLoaded || providerChoices.length === 0) return;
+				setSelectedProvider((current) => {
+					if (current !== null && providerChoices.some((provider) => provider.id === current)) return current;
+					return providerChoices.find((provider) => provider.id === "deepseek-official" && provider.configured)?.id
+						?? providerChoices.find((provider) => provider.id === "deepseek")?.id
+						?? providerChoices.find((provider) => provider.configured)?.id
+						?? providerChoices[0].id;
+				});
+			}, [providerChoices, providersLoaded]);
+
 			react.useEffect(() => {
 				if (!open) return;
 				loadUsage();
@@ -510,15 +568,16 @@ window.__ModuleLoader__.load({
 				};
 			}, [open, loadUsage, loadProviders, loadSubscriptions]);
 
-			// Fetch the selected provider's balance whenever it changes.
+			// Subscription providers are satisfied by the shared subscription fetch;
+			// only balance-mode providers issue a balance request.
 			react.useEffect(() => {
-				if (!open || selectedProvider === null) return;
+				if (!open || selectedProvider === null || selectedAccountMode !== "balance") return;
 				loadBalance(selectedProvider);
 				const timer = window.setInterval(() => loadBalance(selectedProvider), 300000);
 				return () => {
 					window.clearInterval(timer);
 				};
-			}, [open, selectedProvider, loadBalance]);
+			}, [open, selectedProvider, selectedAccountMode, loadBalance]);
 
 			const dayMap = react.useMemo(() => {
 				const map = new Map();
@@ -580,7 +639,7 @@ window.__ModuleLoader__.load({
 				loadUsage();
 				loadProviders();
 				loadSubscriptions();
-				loadBalance(selectedProvider);
+				if (selectedAccountMode === "balance") loadBalance(selectedProvider);
 			};
 
 			const updatedLabel = refreshedAt === null ? "" : translate("panel.updatedAt", {
@@ -647,51 +706,27 @@ window.__ModuleLoader__.load({
 										children: [
 											react_jsx_runtime.jsx("section", {
 												className: S.section,
-												children: react_jsx_runtime.jsx("h3", { className: S.sectionTitle, children: translate("balance.title") })
+												children: react_jsx_runtime.jsx("h3", { className: S.sectionTitle, children: translate("account.title") })
 											}),
 											react_jsx_runtime.jsx(ProviderPicker, {
-												providers,
+												providers: providerChoices,
 												selectedProvider,
 												onSelect: (id) => setSelectedProvider(id),
 												translate
 											}),
-											balanceState === "loading" ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("balance.loading") }) : balanceState === "unsupported" ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("balance.unsupported") }) : balanceState === "no-credential" ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("balance.noCredential", { ref: balanceMessage ?? "" }) }) : balanceState === "error" ? react_jsx_runtime.jsxs("div", {
-												className: S.error,
-												children: [
-													react_jsx_runtime.jsx("span", { children: translate("balance.error", { message: balanceMessage ?? "" }) }),
-													react_jsx_runtime.jsx("button", {
-														type: "button",
-														className: S.retry,
-														onClick: () => loadBalance(selectedProvider),
-														children: translate("action.retry")
-													})
-												]
-											}) : react_jsx_runtime.jsx(BalanceCard, {
-												balance,
-												translate,
-												className: S.balanceCard,
-												okText: translate("balance.available"),
-												badText: translate("balance.unavailable"),
-												rows: [
-													{ key: "toppedUp", label: translate("balance.toppedUp") },
-													{ key: "granted", label: translate("balance.granted") }
-												]
-											}),
-											react_jsx_runtime.jsx("section", {
-												className: S.section,
-												children: react_jsx_runtime.jsx("h3", { className: S.sectionTitle, children: translate("subscription.title") })
-											}),
-											subscriptions === null && subscriptionError === null ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("subscription.loading") }) : null,
-											subscriptionError !== null ? react_jsx_runtime.jsxs("div", {
-												className: S.error,
-												children: [
-													react_jsx_runtime.jsx("span", { children: translate("subscription.error", { message: subscriptionError }) }),
-													react_jsx_runtime.jsx("button", { type: "button", className: S.retry, onClick: loadSubscriptions, children: translate("action.retry") })
-												]
-											}) : null,
-											subscriptions !== null && react_jsx_runtime.jsx("div", {
-												className: S.subscriptionGrid,
-												children: subscriptions.map((provider) => react_jsx_runtime.jsx(SubscriptionCard, { provider, translate }, provider.id))
+											selectedProviderInfo === null ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("account.loading") }) : react_jsx_runtime.jsx("div", {
+												className: S.accountGrid,
+												children: react_jsx_runtime.jsx(ProviderAccountCard, {
+													provider: selectedProviderInfo,
+													subscription: selectedSubscription,
+													subscriptionLoading: selectedAccountMode === "subscription" && subscriptions === null,
+													subscriptionError: selectedAccountMode === "subscription" ? subscriptionError : null,
+													balance,
+													balanceState,
+													balanceMessage,
+													translate,
+													onRetry: selectedAccountMode === "subscription" ? loadSubscriptions : () => loadBalance(selectedProvider)
+												}, selectedProviderInfo.id)
 											}),
 											react_jsx_runtime.jsx("section", {
 												className: S.section,
@@ -833,38 +868,49 @@ window.__ModuleLoader__.load({
 			});
 		}
 
-		/** Balance card for the selected provider. */
-		function BalanceCard({ balance, translate, className, okText, badText, rows }) {
-			if (balance === null) return react_jsx_runtime.jsx("p", { className: S.note, children: translate("balance.loading") });
-			return react_jsx_runtime.jsxs("div", {
-				className,
+		function providerMark(provider) {
+			const known = {
+				"deepseek-official": "DS",
+				deepseek: "DS",
+				"opencode-go": "GO",
+				openrouter: "OR",
+				moonshotai: "K",
+				"moonshotai-cn": "K",
+				kimi: "K",
+				"kimi-coding": "K",
+				zai: "Z",
+				"zai-coding-cn": "Z"
+			};
+			return known[provider.id] ?? String(provider.displayName ?? provider.id).replace(/[^A-Za-z0-9]/g, "").slice(0, 2).toUpperCase();
+		}
+
+		/** Balance-mode body rendered inside the shared provider account frame. */
+		function BalanceContent({ balance, state, message, translate, onRetry }) {
+			if (state === "loading" || balance === null && state === "ok") return react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: translate("balance.loading") });
+			if (state === "unsupported") return react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: translate("balance.unsupported") });
+			if (state === "no-credential") return react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: translate("balance.noCredential", { ref: message ?? "" }) });
+			if (state === "error") return react_jsx_runtime.jsxs("div", {
+				className: S.error,
+				children: [
+					react_jsx_runtime.jsx("span", { children: translate("balance.error", { message: message ?? "" }) }),
+					react_jsx_runtime.jsx("button", { type: "button", className: S.retry, onClick: onRetry, children: translate("action.retry") })
+				]
+			});
+			return react_jsx_runtime.jsxs(react_jsx_runtime.Fragment, {
 				children: [
 					react_jsx_runtime.jsxs("div", {
 						className: S.balanceMain,
 						children: [
 							react_jsx_runtime.jsx("span", { className: S.balanceAmount, children: fmtCurrency(balance.total, balance.currency) }),
-							react_jsx_runtime.jsxs("span", {
-								className: `${S.balanceStatus} ${balance.isAvailable ? S.balanceOk : S.balanceBad}`,
-								children: [
-									react_jsx_runtime.jsx("span", {
-										"aria-hidden": true,
-										style: {
-											width: 8,
-											height: 8,
-											borderRadius: "50%",
-											background: balance.isAvailable ? "var(--dsw-alias-state-success-primary)" : "var(--dsw-alias-state-error-primary)",
-											flex: "none",
-											display: "inline-block"
-										}
-									}),
-									react_jsx_runtime.jsx("span", { children: balance.isAvailable ? okText : badText })
-								]
-							})
+							react_jsx_runtime.jsx("span", { className: S.accountPlan, children: translate("balance.total") })
 						]
 					}),
 					react_jsx_runtime.jsx("div", {
 						className: S.balanceRows,
-						children: rows.map((row) => react_jsx_runtime.jsxs("div", {
+						children: [
+							{ key: "toppedUp", label: translate("balance.toppedUp") },
+							{ key: "granted", label: translate("balance.granted") }
+						].map((row) => react_jsx_runtime.jsxs("div", {
 							className: S.balanceRow,
 							children: [
 								react_jsx_runtime.jsx("span", { children: row.label }),
@@ -876,21 +922,21 @@ window.__ModuleLoader__.load({
 			});
 		}
 
-		/** Provider selector for the balance card. */
+		/** Provider selector shared by monetary and subscription account modes. */
 		function ProviderPicker({ providers, selectedProvider, onSelect, translate }) {
 			if (providers.length === 0) return null;
 			return react_jsx_runtime.jsxs("label", {
 				className: S.providerPicker,
 				children: [
-					react_jsx_runtime.jsx("span", { className: S.providerPickerLabel, children: translate("balance.provider") }),
+					react_jsx_runtime.jsx("span", { className: S.providerPickerLabel, children: translate("account.provider") }),
 					react_jsx_runtime.jsx("select", {
 						className: S.providerSelect,
 						value: selectedProvider ?? "",
-						"aria-label": translate("balance.provider"),
+						"aria-label": translate("account.provider"),
 						onChange: (event) => onSelect(event.target.value),
 						children: providers.map((provider) => react_jsx_runtime.jsx("option", {
 							value: provider.id,
-							children: `${provider.displayName}${provider.scheme === null ? ` (${translate("balance.noSchemeTag")})` : ""}`
+							children: provider.displayName
 						}, provider.id))
 					})
 				]
@@ -922,8 +968,8 @@ window.__ModuleLoader__.load({
 			});
 		}
 
-		/** Percentage-window card for subscription-style providers. */
-		function SubscriptionCard({ provider, translate }) {
+		/** Percentage-window body rendered inside the shared provider account frame. */
+		function SubscriptionContent({ provider, translate }) {
 			const windows = Array.isArray(provider.windows) ? provider.windows : [];
 			const status = typeof provider.status === "string" ? provider.status : "unavailable";
 			const emptyMessage = status === "not-configured"
@@ -931,25 +977,7 @@ window.__ModuleLoader__.load({
 				: status === "unauthorized" ? translate("subscription.unauthorized")
 					: status === "rate-limited" ? translate("subscription.rateLimited")
 						: translate("subscription.unavailable");
-			return react_jsx_runtime.jsxs("article", {
-				className: S.subscriptionCard,
-				"data-provider": provider.id,
-				children: [
-					react_jsx_runtime.jsxs("div", {
-						className: S.subscriptionHead,
-						children: [
-							react_jsx_runtime.jsx("span", { className: S.subscriptionMark, "aria-hidden": true, children: provider.id === "opencode-go" ? "GO" : "Z" }),
-							react_jsx_runtime.jsxs("span", {
-								className: S.subscriptionIdentity,
-								children: [
-									react_jsx_runtime.jsx("span", { className: S.subscriptionName, children: provider.displayName }),
-									react_jsx_runtime.jsx("span", { className: S.subscriptionPlan, children: provider.plan ?? translate("subscription.planUnknown") })
-								]
-							}),
-							react_jsx_runtime.jsx("span", { className: S.subscriptionStatus, "data-status": status, children: subscriptionStatusLabel(status, translate) })
-						]
-					}),
-					status === "ok" && windows.length > 0 ? react_jsx_runtime.jsx("div", {
+			return status === "ok" && windows.length > 0 ? react_jsx_runtime.jsx("div", {
 						className: S.quotaList,
 						children: windows.map((window) => {
 							const used = Math.max(0, Math.min(100, Number(window.usedPercent) || 0));
@@ -976,7 +1004,71 @@ window.__ModuleLoader__.load({
 								]
 							}, window.kind);
 						})
-					}) : react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: emptyMessage })
+					}) : react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: emptyMessage });
+		}
+
+		/**
+		 * The single account-card interface. Provider identity/colour/status live
+		 * in the shared frame; only the inner balance/quota data varies by mode.
+		 */
+		function ProviderAccountCard({ provider, subscription, subscriptionLoading, subscriptionError, balance, balanceState, balanceMessage, translate, onRetry }) {
+			const subscriptionMode = provider.accountMode === "subscription";
+			let status = "unavailable";
+			let statusText = translate("subscription.status.unavailable");
+			let subtitle = translate("account.balanceMode");
+			if (subscriptionMode) {
+				if (subscriptionLoading) {
+					status = "loading";
+					statusText = translate("account.status.loading");
+				} else if (subscriptionError !== null) {
+					statusText = translate("subscription.status.unavailable");
+				} else if (subscription !== null) {
+					status = subscription.status;
+					statusText = subscriptionStatusLabel(status, translate);
+					subtitle = subscription.plan ?? translate("subscription.planUnknown");
+				}
+			} else if (balanceState === "ok") {
+				status = balance?.isAvailable ? "ok" : "unavailable";
+				statusText = balance?.isAvailable ? translate("balance.available") : translate("balance.unavailable");
+			} else if (balanceState === "loading") {
+				status = "loading";
+				statusText = translate("account.status.loading");
+			} else if (balanceState === "no-credential") {
+				status = "not-configured";
+				statusText = translate("subscription.status.notConfigured");
+			} else if (balanceState === "unsupported") {
+				statusText = translate("account.status.unsupported");
+			}
+			return react_jsx_runtime.jsxs("article", {
+				className: S.accountCard,
+				"data-provider": provider.id,
+				"data-account-mode": provider.accountMode,
+				children: [
+					react_jsx_runtime.jsxs("div", {
+						className: S.accountHead,
+						children: [
+							react_jsx_runtime.jsx("span", { className: S.accountMark, "aria-hidden": true, children: providerMark(provider) }),
+							react_jsx_runtime.jsxs("span", {
+								className: S.accountIdentity,
+								children: [
+									react_jsx_runtime.jsx("span", { className: S.accountName, children: provider.displayName }),
+									react_jsx_runtime.jsx("span", { className: S.accountPlan, children: subtitle })
+								]
+							}),
+							react_jsx_runtime.jsx("span", { className: S.accountStatus, "data-status": status, children: statusText })
+						]
+					}),
+					subscriptionMode
+						? subscriptionError !== null ? react_jsx_runtime.jsxs("div", {
+							className: S.error,
+							children: [
+								react_jsx_runtime.jsx("span", { children: translate("subscription.error", { message: subscriptionError }) }),
+								react_jsx_runtime.jsx("button", { type: "button", className: S.retry, onClick: onRetry, children: translate("action.retry") })
+							]
+						}) : subscriptionLoading || subscription === null
+							? react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: translate("subscription.loading") })
+							: react_jsx_runtime.jsx(SubscriptionContent, { provider: subscription, translate })
+						: react_jsx_runtime.jsx(BalanceContent, { balance, state: balanceState, message: balanceMessage, translate, onRetry })
 				]
 			});
 		}
@@ -1135,6 +1227,12 @@ window.__ModuleLoader__.load({
 		const zh = {
 			"panel.title": "用量与余额",
 			"panel.badge": "用量/余额",
+			"account.title": "供应商账户",
+			"account.provider": "当前供应商",
+			"account.balanceMode": "API 余额",
+			"account.loading": "正在加载供应商…",
+			"account.status.loading": "查询中",
+			"account.status.unsupported": "不支持余额",
 			"balance.title": "账户余额",
 			"balance.provider": "供应商",
 			"balance.noSchemeTag": "无余额接口",
@@ -1204,6 +1302,12 @@ window.__ModuleLoader__.load({
 		const en = {
 			"panel.title": "Usage & Balance",
 			"panel.badge": "Usage/Balance",
+			"account.title": "Provider account",
+			"account.provider": "Current provider",
+			"account.balanceMode": "API balance",
+			"account.loading": "Loading providers…",
+			"account.status.loading": "Loading",
+			"account.status.unsupported": "Balance unsupported",
 			"balance.title": "Account balance",
 			"balance.provider": "Provider",
 			"balance.noSchemeTag": "no balance API",
@@ -1295,11 +1399,13 @@ window.__ModuleLoader__.load({
 		exports.inject = inject;
 		exports.UsageStatsPanel = UsageStatsPanel;
 		exports.DayDetail = DayDetail;
-		exports.SubscriptionCard = SubscriptionCard;
+		exports.ProviderAccountCard = ProviderAccountCard;
 		exports.MonthHeatmap = MonthHeatmap;
 		exports.buildMonthHeatmap = buildMonthHeatmap;
 		exports.cellColor = cellColor;
 		exports.createLoader = createLoader;
+		exports.buildProviderChoices = buildProviderChoices;
+		exports.subscriptionIdFor = subscriptionIdFor;
 		exports.modelLabelOf = modelLabelOf;
 		exports.fmt = fmt;
 		exports.fmtCurrency = fmtCurrency;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,17 @@
 /**
  * dsh-usage-stats — server half.
  *
- * Registers two read-only, loopback-only endpoints on the web server:
- *   GET /api/usage-stats/usage   — per-day token usage across every session
- *   GET /api/usage-stats/balance — DeepSeek account balance
+ * Registers four read-only, loopback-only endpoints on the web server:
+ *   GET /api/usage-stats/usage         — per-day token usage across every session
+ *   GET /api/usage-stats/providers     — configured providers + balance schemes
+ *   GET /api/usage-stats/balance       — balance for one provider (?provider=<id>)
+ *   GET /api/usage-stats/subscriptions — OpenCode Go + Z.ai quota windows
+ *
+ * Provider configuration is read straight from the harness settings
+ * (`llm-deepseek` for the official DeepSeek route, `llm-pi-ai` for every
+ * configured pi-ai provider profile), and each provider's API key is resolved
+ * through the credentials seam at request time — nothing is stored by this
+ * plugin.
  *
  * The endpoints live under the `/api` prefix as exact routes, so they win
  * over the connection plugin's `/api` prefix handler; each handler applies
@@ -25,19 +33,27 @@ import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { applyUsageDelta, createUsageState, mergeInto, renderUsage, totalTokens, zeroBuckets } from "./usage.js";
+import { balanceSchemeOf, queryBalance } from "./balance.js";
+import { collectSubscriptions } from "./subscriptions.js";
 
 /** Stable Cordis plugin name. */
 const name = "usage-stats";
 
 /** Services required before this plugin activates. */
-const inject = ["webServer", "credentials", "sessions", "sessionPersistence"];
+const inject = ["webServer", "credentials", "sessions", "sessionPersistence", "settings", "llm"];
 
 const USAGE_PATH = "/api/usage-stats/usage";
+const PROVIDERS_PATH = "/api/usage-stats/providers";
 const BALANCE_PATH = "/api/usage-stats/balance";
-const DEEPSEEK_BALANCE_URL = "https://api.deepseek.com/user/balance";
-const CREDENTIAL_REF = "DEEPSEEK_API_KEY";
+const SUBSCRIPTIONS_PATH = "/api/usage-stats/subscriptions";
 const UPSTREAM_TIMEOUT_MS = 15000;
-const CACHE_VERSION = 2;
+const CACHE_VERSION = 3;
+
+/** Default DeepSeek connection facts when the settings namespace is absent. */
+const DEEPSEEK_DEFAULTS = {
+	apiKeyEnv: "DEEPSEEK_API_KEY",
+	baseURL: "https://api.deepseek.com"
+};
 
 /** Write a JSON response. */
 function json(res, status, value) {
@@ -351,53 +367,148 @@ async function handleUsage(ctx, req, res) {
 	}
 }
 
+/**
+ * Enumerate the harness's configured providers: the official DeepSeek route
+ * (`llm-deepseek` settings namespace) plus every pi-ai provider profile
+ * (`llm-pi-ai` settings namespace). Each entry carries the connection facts
+ * (credential ref + base URL) needed to query a balance — no keys here.
+ */
+async function configuredProviders(ctx) {
+	const settings = ctx.get("settings");
+	const providers = [];
+	const deepseek = settings?.get?.("llm-deepseek");
+	if (deepseek !== void 0 && deepseek !== null && typeof deepseek === "object") {
+		providers.push({
+			id: "deepseek-official",
+			displayName: "DeepSeek",
+			apiKeyEnv: typeof deepseek.apiKeyEnv === "string" ? deepseek.apiKeyEnv : DEEPSEEK_DEFAULTS.apiKeyEnv,
+			baseURL: typeof deepseek.baseURL === "string" ? deepseek.baseURL : DEEPSEEK_DEFAULTS.baseURL
+		});
+	} else {
+		providers.push({
+			id: "deepseek-official",
+			displayName: "DeepSeek",
+			apiKeyEnv: DEEPSEEK_DEFAULTS.apiKeyEnv,
+			baseURL: DEEPSEEK_DEFAULTS.baseURL
+		});
+	}
+	const pi = settings?.get?.("llm-pi-ai");
+	if (pi !== void 0 && pi !== null && typeof pi === "object" && pi.providers !== void 0 && typeof pi.providers === "object") {
+		for (const [route, profile] of Object.entries(pi.providers)) {
+			if (profile === null || typeof profile !== "object") continue;
+			providers.push({
+				id: route,
+				displayName: typeof profile.displayName === "string" && profile.displayName.length > 0 ? profile.displayName : route,
+				apiKeyEnv: typeof profile.apiKeyEnv === "string" ? profile.apiKeyEnv : void 0,
+				baseURL: typeof profile.baseURL === "string" ? profile.baseURL : void 0
+			});
+		}
+	}
+	return providers;
+}
+
+/** Resolve one provider entry by id (undefined when unknown). */
+async function providerById(ctx, id) {
+	const providers = await configuredProviders(ctx);
+	return providers.find((provider) => provider.id === id);
+}
+
+async function handleProviders(ctx, req, res) {
+	if (rejectForeignCaller(req, res)) return;
+	try {
+		const credentials = ctx.get("credentials");
+		const providers = await configuredProviders(ctx);
+		const views = [];
+		for (const provider of providers) {
+			const scheme = balanceSchemeOf(provider.id);
+			let configured = false;
+			if (credentials !== void 0 && provider.apiKeyEnv !== void 0) {
+				try {
+					const hit = await credentials.resolve(provider.apiKeyEnv);
+					configured = hit !== void 0 && typeof hit.value === "string" && hit.value.length > 0;
+				} catch {
+					configured = false;
+				}
+			}
+			views.push({
+				id: provider.id,
+				displayName: provider.displayName,
+				scheme,
+				configured
+			});
+		}
+		json(res, 200, { ok: true, providers: views });
+	} catch (error) {
+		ctx.logger.warn(`usage-stats: providers enumeration failed: ${String(error)}`);
+		json(res, 500, { ok: false, error: "internal", message: error instanceof Error ? error.message : String(error) });
+	}
+}
+
 async function handleBalance(ctx, req, res) {
 	if (rejectForeignCaller(req, res)) return;
 	try {
-		const credential = await ctx.credentials.resolve(CREDENTIAL_REF);
+		const url = new URL(req.url ?? "/", "http://x");
+		let providerId = url.searchParams.get("provider") ?? void 0;
+		const all = await configuredProviders(ctx);
+		if (providerId === void 0 || providerId === null || providerId === "") {
+			// Default: the official DeepSeek route, else the first provider with a scheme.
+			providerId = all.find((entry) => entry.id === "deepseek-official")?.id
+				?? all.find((entry) => balanceSchemeOf(entry.id) !== null)?.id;
+		}
+		const provider = all.find((entry) => entry.id === providerId);
+		if (provider === void 0) {
+			json(res, 200, { ok: false, error: "unknown-provider", message: `provider "${providerId}" is not configured` });
+			return;
+		}
+		const scheme = balanceSchemeOf(provider.id);
+		if (scheme === null) {
+			json(res, 200, {
+				ok: false,
+				error: "unsupported",
+				message: `${provider.displayName} has no public balance interface`,
+				provider: provider.id
+			});
+			return;
+		}
+		const credential = provider.apiKeyEnv === void 0 ? void 0 : await ctx.credentials.resolve(provider.apiKeyEnv);
 		if (credential === void 0 || typeof credential.value !== "string" || credential.value.length === 0) {
 			json(res, 200, {
 				ok: false,
 				error: "no-credential",
-				message: `${CREDENTIAL_REF} is not configured`
+				message: provider.apiKeyEnv ?? "api key",
+				provider: provider.id
 			});
 			return;
 		}
-		const upstream = await fetch(DEEPSEEK_BALANCE_URL, {
-			headers: { authorization: `Bearer ${credential.value}` },
-			signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS)
-		});
-		if (!upstream.ok) {
-			json(res, 502, {
-				ok: false,
-				error: "upstream",
-				message: `DeepSeek balance API returned HTTP ${upstream.status}`
-			});
-			return;
-		}
-		const payload = await upstream.json();
-		const infos = Array.isArray(payload?.balance_infos) ? payload.balance_infos : [];
-		const info = infos.find((entry) => entry?.currency === "CNY") ?? infos[0];
-		json(res, 200, {
-			ok: true,
-			balance: {
-				isAvailable: payload?.is_available === true,
-				currency: info?.currency ?? void 0,
-				total: info?.total_balance ?? void 0,
-				granted: info?.granted_balance ?? void 0,
-				toppedUp: info?.topped_up_balance ?? void 0
-			},
-			fetchedAt: Date.now()
-		});
+		const balance = await queryBalance(scheme, provider.baseURL, credential.value, UPSTREAM_TIMEOUT_MS);
+		json(res, 200, { ok: true, provider: provider.id, balance, fetchedAt: Date.now() });
 	} catch (error) {
 		ctx.logger.warn(`usage-stats: balance fetch failed: ${String(error)}`);
 		json(res, 502, { ok: false, error: "failed", message: error instanceof Error ? error.message : String(error) });
 	}
 }
 
+/** Query normalized percentage windows for subscription-style providers. */
+async function handleSubscriptions(ctx, req, res) {
+	if (rejectForeignCaller(req, res)) return;
+	try {
+		const configured = await configuredProviders(ctx);
+		const zai = configured.find((provider) => provider.id === "zai" || provider.id === "zai-coding-cn");
+		const zaiDefaultRegion = zai?.id === "zai-coding-cn" || String(zai?.baseURL ?? "").includes("bigmodel.cn") ? "bigmodel-cn" : "global";
+		const subscriptions = await collectSubscriptions(ctx.get("credentials") ?? ctx.credentials, {
+			zaiApiKeyRef: zai?.apiKeyEnv ?? "ZAI_API_KEY",
+			zaiDefaultRegion
+		}, { timeoutMs: UPSTREAM_TIMEOUT_MS });
+		json(res, 200, { ok: true, subscriptions, fetchedAt: Date.now() });
+	} catch (error) {
+		ctx.logger.warn(`usage-stats: subscription usage failed: ${String(error)}`);
+		json(res, 500, { ok: false, error: "internal", message: error instanceof Error ? error.message : String(error) });
+	}
+}
+
 /**
- * Plugin body: register the two exact routes on the web server.
- * @param ctx - plugin context carrying webServer, credentials, sessions, and sessionPersistence.
+ * Plugin body: register the four exact routes on the web server.
+ * @param ctx - plugin context carrying webServer, credentials, sessions, sessionPersistence, settings, and llm.
  */
 function apply(ctx) {
 	ctx.effect(() => ctx.webServer.register({
@@ -407,9 +518,19 @@ function apply(ctx) {
 	}), "usage-stats: usage route");
 	ctx.effect(() => ctx.webServer.register({
 		kind: "exact",
+		path: PROVIDERS_PATH,
+		handler: (req, res) => handleProviders(ctx, req, res)
+	}), "usage-stats: providers route");
+	ctx.effect(() => ctx.webServer.register({
+		kind: "exact",
 		path: BALANCE_PATH,
 		handler: (req, res) => handleBalance(ctx, req, res)
 	}), "usage-stats: balance route");
+	ctx.effect(() => ctx.webServer.register({
+		kind: "exact",
+		path: SUBSCRIPTIONS_PATH,
+		handler: (req, res) => handleSubscriptions(ctx, req, res)
+	}), "usage-stats: subscriptions route");
 }
 
-export { apply, inject, name, USAGE_PATH, BALANCE_PATH, totalTokens, zeroBuckets };
+export { apply, inject, name, USAGE_PATH, PROVIDERS_PATH, BALANCE_PATH, SUBSCRIPTIONS_PATH, configuredProviders, totalTokens, zeroBuckets };

--- a/lib/subscriptions.js
+++ b/lib/subscriptions.js
@@ -1,0 +1,383 @@
+/**
+ * Subscription-quota module for providers that expose percentage windows.
+ *
+ * The external interface is deliberately small: callers provide the Harness
+ * credentials seam and optional transport/time dependencies, and receive two
+ * normalized provider records. Provider credentials, upstream response shapes,
+ * parsing quirks, and error mapping remain inside this module.
+ *
+ * OpenCode Go's documented provider API does not include usage, but its
+ * first-party client currently exposes an undocumented Bearer-key endpoint.
+ * The adapter prefers that simpler path, can reuse OpenCode's local auth.json,
+ * and keeps the authenticated workspace dashboard as a compatibility fallback.
+ * Z.ai uses its Coding Plan quota endpoints with a normal API key.
+ *
+ * @module dsh-usage-stats/subscriptions
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const OPENCODE_GO_URL = "https://opencode.ai";
+const OPENCODE_GO_USAGE_URL = `${OPENCODE_GO_URL}/zen/go/v1/usage`;
+const ZAI_HOSTS = {
+	global: "https://api.z.ai",
+	"bigmodel-cn": "https://open.bigmodel.cn"
+};
+const ZAI_QUOTA_PATH = "/api/monitor/usage/quota/limit";
+const ZAI_SUBSCRIPTION_PATH = "/api/biz/subscription/list";
+const DEFAULT_TIMEOUT_MS = 15000;
+
+const REFS = {
+	openCodeApiKey: "OPENCODE_GO_API_KEY",
+	openCodeCookie: "OPENCODE_GO_AUTH_COOKIE",
+	openCodeWorkspace: "OPENCODE_GO_WORKSPACE_ID",
+	zaiApiKey: "ZAI_API_KEY",
+	zaiRegion: "ZAI_API_REGION"
+};
+
+function numberOrNull(value) {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim() !== "") {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed)) return parsed;
+	}
+	return null;
+}
+
+function clampPercent(value) {
+	const parsed = numberOrNull(value);
+	return parsed === null ? null : Math.max(0, Math.min(100, parsed));
+}
+
+function round1(value) {
+	return Math.round(value * 10) / 10;
+}
+
+function toIso(value) {
+	if (value === null || value === void 0 || value === "") return null;
+	if (typeof value === "number" && Number.isFinite(value)) {
+		const date = new Date(value < 20000000000 ? value * 1000 : value);
+		return Number.isNaN(date.getTime()) ? null : date.toISOString();
+	}
+	const date = new Date(String(value));
+	return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+async function resolveCredential(credentials, ref) {
+	if (credentials === void 0 || credentials === null || typeof credentials.resolve !== "function") return "";
+	try {
+		const hit = await credentials.resolve(ref);
+		return typeof hit?.value === "string" ? hit.value.trim() : "";
+	} catch {
+		return "";
+	}
+}
+
+function normalizedStatus(error) {
+	if (error?.name === "TimeoutError" || error?.name === "AbortError") return "unavailable";
+	if (error?.providerStatus) return error.providerStatus;
+	return "unavailable";
+}
+
+async function request(url, init, deps, type) {
+	const response = await (deps.fetch ?? fetch)(url, {
+		...init,
+		signal: AbortSignal.timeout(deps.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+	});
+	if (!response.ok) {
+		const error = new Error(`upstream returned HTTP ${response.status}`);
+		error.providerStatus = response.status === 401 || response.status === 403
+			? "unauthorized"
+			: response.status === 429 ? "rate-limited" : "unavailable";
+		throw error;
+	}
+	return type === "text" ? response.text() : response.json();
+}
+
+function sanitizeCookie(raw) {
+	let value = String(raw ?? "").trim().replace(/^cookie\s*:\s*/i, "");
+	value = value.split(";").map((part) => part.trim()).filter(Boolean).join("; ");
+	return value !== "" && !value.includes("=") ? `auth=${value}` : value;
+}
+
+function workspaceIdOf(raw) {
+	return String(raw ?? "").match(/wrk_[A-Za-z0-9]+/)?.[0] ?? "";
+}
+
+function looksSignedOut(text) {
+	const lower = String(text).toLowerCase();
+	return lower.includes("sign in") || lower.includes("login") || lower.includes("auth/authorize") || lower.includes('actor of type "public"');
+}
+
+function goWindowFromObject(value, kind, now) {
+	if (value === null || typeof value !== "object") return null;
+	const percentSource = value.usagePercent ?? value.usedPercent ?? value.percentUsed ?? value.percentage ?? value.percent;
+	let usedPercent = clampPercent(percentSource);
+	if (usedPercent === null) {
+		const used = numberOrNull(value.used ?? value.consumed);
+		const limit = numberOrNull(value.limit ?? value.total ?? value.quota);
+		if (used !== null && limit !== null && limit > 0) usedPercent = clampPercent((used / limit) * 100);
+	}
+	if (usedPercent === null) return null;
+	// The dashboard embeds usagePercent as a 0..1 ratio. The Bearer endpoint's
+	// `percent` is already 0..100, so only scale ratio-named dashboard fields.
+	if (usedPercent <= 1 && usedPercent >= 0 && value.percent === void 0 && percentSource !== void 0) usedPercent *= 100;
+	const resetSeconds = numberOrNull(value.resetInSec ?? value.resetInSeconds ?? value.resetSeconds);
+	const resetsAt = resetSeconds === null ? toIso(value.resetAt ?? value.resetsAt ?? value.nextReset) : new Date(now + Math.max(0, resetSeconds) * 1000).toISOString();
+	return {
+		kind,
+		usedPercent: round1(clampPercent(usedPercent)),
+		remainingPercent: round1(100 - clampPercent(usedPercent)),
+		...(resetsAt === null ? {} : { resetsAt })
+	};
+}
+
+function parseOpenCodeGoApi(body, now) {
+	const usage = body?.usage ?? body;
+	if (usage === null || typeof usage !== "object") return [];
+	return [
+		goWindowFromObject(usage.rolling, "session", now),
+		goWindowFromObject(usage.weekly, "weekly", now),
+		goWindowFromObject(usage.monthly, "monthly", now)
+	].filter(Boolean);
+}
+
+function findObject(root, keyword, depth = 0) {
+	if (root === null || typeof root !== "object" || depth > 5) return null;
+	for (const [key, value] of Object.entries(root)) {
+		if (key.toLowerCase().includes(keyword) && value !== null && typeof value === "object") return value;
+	}
+	for (const value of Object.values(root)) {
+		const found = findObject(value, keyword, depth + 1);
+		if (found !== null) return found;
+	}
+	return null;
+}
+
+function goWindowFromText(text, key, kind, now) {
+	const percent = new RegExp(`${key}[^}]*?usagePercent\\s*[:=]\\s*([0-9]+(?:\\.[0-9]+)?)`, "i").exec(text);
+	if (percent === null) return null;
+	const reset = new RegExp(`${key}[^}]*?resetInSec\\s*[:=]\\s*([0-9]+)`, "i").exec(text);
+	const usedPercent = round1(clampPercent(Number(percent[1])));
+	return {
+		kind,
+		usedPercent,
+		remainingPercent: round1(100 - usedPercent),
+		...(reset === null ? {} : { resetsAt: new Date(now + Number(reset[1]) * 1000).toISOString() })
+	};
+}
+
+function parseOpenCodeGo(text, now) {
+	let windows = [];
+	try {
+		const root = JSON.parse(text);
+		windows = [
+			goWindowFromObject(findObject(root, "rolling"), "session", now),
+			goWindowFromObject(findObject(root, "weekly") ?? findObject(root, "week"), "weekly", now),
+			goWindowFromObject(findObject(root, "monthly") ?? findObject(root, "month"), "monthly", now)
+		].filter(Boolean);
+	} catch {
+		/* The dashboard may embed text/javascript rather than strict JSON. */
+	}
+	if (!windows.some((window) => window.kind === "session") || !windows.some((window) => window.kind === "weekly")) {
+		windows = [
+			goWindowFromText(text, "rollingUsage", "session", now),
+			goWindowFromText(text, "weeklyUsage", "weekly", now),
+			goWindowFromText(text, "monthlyUsage", "monthly", now)
+		].filter(Boolean);
+	}
+	return windows.some((window) => window.kind === "session") && windows.some((window) => window.kind === "weekly") ? windows : [];
+}
+
+async function localOpenCodeApiKey(deps) {
+	try {
+		const home = typeof deps.homedir === "function" ? deps.homedir() : homedir();
+		const load = deps.readFile ?? readFile;
+		const raw = JSON.parse(await load(join(home, ".local", "share", "opencode", "auth.json"), "utf8"));
+		const entry = raw?.["opencode-go"] ?? raw?.opencode;
+		return entry?.type === "api" && typeof entry.key === "string" ? entry.key.trim() : "";
+	} catch {
+		return "";
+	}
+}
+
+async function collectOpenCodeGoFromDashboard(cookie, workspaceId, deps) {
+	try {
+		const text = await request(`${OPENCODE_GO_URL}/workspace/${workspaceId}/go`, {
+			headers: {
+				cookie,
+				accept: "text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8"
+			}
+		}, deps, "text");
+		if (looksSignedOut(text)) return { status: "unauthorized", windows: [] };
+		const windows = parseOpenCodeGo(text, deps.now());
+		return { status: windows.length > 0 ? "ok" : "unavailable", windows };
+	} catch (error) {
+		return { status: normalizedStatus(error), windows: [] };
+	}
+}
+
+async function collectOpenCodeGo(credentials, deps) {
+	const [configuredApiKey, cookieRaw, workspaceRaw] = await Promise.all([
+		resolveCredential(credentials, REFS.openCodeApiKey),
+		resolveCredential(credentials, REFS.openCodeCookie),
+		resolveCredential(credentials, REFS.openCodeWorkspace)
+	]);
+	const apiKey = configuredApiKey || await localOpenCodeApiKey(deps);
+	const cookie = sanitizeCookie(cookieRaw);
+	const workspaceId = workspaceIdOf(workspaceRaw);
+	if (apiKey === "" && (cookie === "" || workspaceId === "")) {
+		return {
+			id: "opencode-go",
+			displayName: "OpenCode Go",
+			mode: "subscription",
+			status: "not-configured",
+			plan: "Go",
+			missingCredentials: [REFS.openCodeApiKey],
+			windows: []
+		};
+	}
+
+	let apiStatus = "unavailable";
+	if (apiKey !== "") {
+		try {
+			const body = await request(OPENCODE_GO_USAGE_URL, {
+				headers: { authorization: `Bearer ${apiKey}`, accept: "application/json" }
+			}, deps, "json");
+			const windows = parseOpenCodeGoApi(body, deps.now());
+			if (windows.length > 0) {
+				return { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: "ok", plan: "Go", windows };
+			}
+		} catch (error) {
+			apiStatus = normalizedStatus(error);
+		}
+	}
+	if (cookie !== "" && workspaceId !== "") {
+		const dashboard = await collectOpenCodeGoFromDashboard(cookie, workspaceId, deps);
+		return { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: dashboard.status, plan: "Go", windows: dashboard.windows };
+	}
+	return { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: apiStatus, plan: "Go", windows: [] };
+}
+
+function zaiRegionOf(raw, fallback = "global") {
+	const value = String(raw || fallback).trim().toLowerCase();
+	return value === "bigmodel-cn" || value === "cn" || value.includes("bigmodel.cn") ? "bigmodel-cn" : "global";
+}
+
+function zaiWindowMinutes(limit) {
+	const unit = numberOrNull(limit?.unit);
+	const number = numberOrNull(limit?.number);
+	if (unit === null || number === null || number <= 0) return null;
+	if (unit === 5) return number;
+	if (unit === 3) return number * 60;
+	if (unit === 1) return number * 24 * 60;
+	if (unit === 6) return number * 7 * 24 * 60;
+	return null;
+}
+
+function zaiUsedPercent(limit) {
+	const total = numberOrNull(limit?.usage);
+	const remaining = numberOrNull(limit?.remaining);
+	const current = numberOrNull(limit?.currentValue ?? limit?.current_value);
+	if (total !== null && total > 0) {
+		const used = remaining === null ? current : current === null ? total - remaining : Math.max(total - remaining, current);
+		if (used !== null) return clampPercent((Math.max(0, Math.min(total, used)) / total) * 100);
+	}
+	return clampPercent(limit?.percentage ?? limit?.usedPercent ?? limit?.used_percent);
+}
+
+function displayPlan(value) {
+	return String(value ?? "").trim().replace(/[_-]+/g, " ").replace(/\s+/g, " ").replace(/\bglm\b/gi, "GLM").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function zaiPlan(quota, subscription) {
+	const row = Array.isArray(subscription?.data) ? subscription.data.find((entry) => entry && typeof entry === "object") : null;
+	for (const source of [row, quota?.data]) {
+		for (const key of ["product_name", "productName", "plan_name", "planName", "package_name", "packageName", "plan_type", "planType", "level"]) {
+			const value = displayPlan(source?.[key]);
+			if (value !== "") return value;
+		}
+	}
+	return "GLM Coding Plan";
+}
+
+function zaiWindow(limit, kind, fallbackReset = null) {
+	const usedPercent = zaiUsedPercent(limit);
+	if (usedPercent === null) return null;
+	const resetsAt = toIso(limit.nextResetTime ?? limit.next_reset_time) ?? fallbackReset;
+	return {
+		kind,
+		usedPercent: round1(usedPercent),
+		remainingPercent: round1(100 - usedPercent),
+		...(resetsAt === null ? {} : { resetsAt }),
+		...(numberOrNull(limit.remaining) === null ? {} : { remaining: numberOrNull(limit.remaining) })
+	};
+}
+
+function parseZai(quota, subscription) {
+	const limits = Array.isArray(quota?.data?.limits) ? quota.data.limits : [];
+	const tokenLimits = limits.filter((limit) => ["TOKENS_LIMIT", "CREDIT_LIMIT"].includes(String(limit?.type ?? limit?.limit_type ?? "").toUpperCase()) && zaiUsedPercent(limit) !== null)
+		.sort((a, b) => (zaiWindowMinutes(a) ?? Number.MAX_SAFE_INTEGER) - (zaiWindowMinutes(b) ?? Number.MAX_SAFE_INTEGER));
+	const timeLimit = limits.find((limit) => String(limit?.type ?? limit?.limit_type ?? "").toUpperCase() === "TIME_LIMIT" && zaiUsedPercent(limit) !== null) ?? null;
+	const first = tokenLimits[0] ?? null;
+	const session = tokenLimits.length >= 2 ? first : zaiWindowMinutes(first) !== null && zaiWindowMinutes(first) <= 360 ? first : null;
+	const weekly = tokenLimits.length >= 2 ? tokenLimits[tokenLimits.length - 1] : session === null ? first : null;
+	const subscriptionRow = Array.isArray(subscription?.data) ? subscription.data[0] : null;
+	const renewAt = toIso(subscriptionRow?.next_renew_time ?? subscriptionRow?.nextRenewTime);
+	return {
+		plan: zaiPlan(quota, subscription),
+		windows: [
+			session === null ? null : zaiWindow(session, "session"),
+			weekly === null ? null : zaiWindow(weekly, "weekly"),
+			timeLimit === null ? null : zaiWindow(timeLimit, "billing", renewAt)
+		].filter(Boolean)
+	};
+}
+
+async function collectZai(credentials, deps) {
+	const apiKeyRef = deps.zaiApiKeyRef ?? REFS.zaiApiKey;
+	const [apiKey, configuredRegion] = await Promise.all([
+		resolveCredential(credentials, apiKeyRef),
+		resolveCredential(credentials, REFS.zaiRegion)
+	]);
+	const region = zaiRegionOf(configuredRegion, deps.zaiDefaultRegion);
+	if (apiKey === "") {
+		return { id: "zai", displayName: "Z.ai", mode: "subscription", status: "not-configured", plan: "GLM Coding Plan", region, missingCredentials: [apiKeyRef], windows: [] };
+	}
+	const host = ZAI_HOSTS[region];
+	const init = { headers: { authorization: `Bearer ${apiKey}`, accept: "application/json" } };
+	try {
+		const quota = await request(`${host}${ZAI_QUOTA_PATH}`, init, deps, "json");
+		let subscription = null;
+		try {
+			subscription = await request(`${host}${ZAI_SUBSCRIPTION_PATH}`, init, deps, "json");
+		} catch {
+			/* Plan label/reset metadata is optional when quota succeeded. */
+		}
+		const parsed = parseZai(quota, subscription);
+		return { id: "zai", displayName: "Z.ai", mode: "subscription", status: parsed.windows.length > 0 ? "ok" : "unavailable", plan: parsed.plan, region, windows: parsed.windows };
+	} catch (error) {
+		return { id: "zai", displayName: "Z.ai", mode: "subscription", status: normalizedStatus(error), plan: "GLM Coding Plan", region, windows: [] };
+	}
+}
+
+/** Collect every supported subscription provider concurrently. */
+export async function collectSubscriptions(credentials, options = {}, deps = {}) {
+	const shared = {
+		fetch: deps.fetch,
+		readFile: deps.readFile,
+		homedir: deps.homedir,
+		timeoutMs: deps.timeoutMs,
+		now: deps.now ?? Date.now,
+		zaiApiKeyRef: options.zaiApiKeyRef,
+		zaiDefaultRegion: options.zaiDefaultRegion ?? "global"
+	};
+	return Promise.all([
+		collectOpenCodeGo(credentials, shared),
+		collectZai(credentials, shared)
+	]);
+}
+
+export const subscriptionCredentialRefs = { ...REFS };

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -97,10 +97,24 @@ function sampleOf(event) {
 	return void 0;
 }
 
-/** The model a usage sample belongs to, when the event names one. */
+/**
+ * The `provider/model` attribution key of a usage sample: the exact provider
+ * route (dsh adapter id or pi-ai route) plus the model id, so the SAME model
+ * served by different providers stays distinct. `assistant/message` names
+ * its provider via `data.message.source`; usage chunks fall back to the last
+ * `request/header` `data.header.config`; samples with no model information
+ * land in the `unknown/unknown` bucket.
+ */
 function modelOf(event) {
-	const model = event.data?.message?.source?.model ?? event.data?.header?.config?.model;
-	return typeof model === "string" && model.length > 0 ? model : void 0;
+	const source = event.data?.message?.source;
+	if (source !== void 0 && typeof source.model === "string") {
+		return `${typeof source.provider === "string" && source.provider.length > 0 ? source.provider : "unknown"}/${source.model}`;
+	}
+	const config = event.data?.header?.config;
+	if (config !== void 0 && typeof config.model === "string") {
+		return `${typeof config.provider === "string" && config.provider.length > 0 ? config.provider : "unknown"}/${config.model}`;
+	}
+	return void 0;
 }
 
 /** Day entry: totals plus a per-model bucket map. */
@@ -151,7 +165,7 @@ export function applyUsageDelta(state, events) {
 		const sample = sampleOf(event);
 		if (sample === void 0) continue;
 		const buckets = bucketsOf(sample.usage);
-		const model = modelOf(event) ?? currentModel ?? "unknown";
+		const model = modelOf(event) ?? currentModel ?? "unknown/unknown";
 		const day = dayKey(event.time);
 		const entry = entryOf(state.days, day);
 		if (last !== null && last.key === sample.key) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-usage-stats",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-usage-stats",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-usage-stats",
-  "version": "0.2.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-usage-stats",
-      "version": "0.2.0",
+      "version": "0.1.2",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-usage-stats",
   "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI",
-  "version": "0.2.0",
+  "version": "0.1.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-usage-stats",
-  "description": "Token usage heatmap + DeepSeek account balance for the dsh web GUI",
-  "version": "0.1.1",
+  "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI",
+  "version": "0.2.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -45,11 +45,13 @@
     }
   },
   "scripts": {
-    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
-    "test": "npm run test:client && npm run test:server && npm run test:install",
+    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
+    "test": "npm run test:client && npm run test:server && npm run test:balance && npm run test:subscriptions && npm run test:install",
     "test:client": "node scripts/smoke-client.mjs",
     "test:install": "node scripts/test-install.mjs",
     "test:server": "node scripts/test-server.mjs",
+    "test:balance": "node scripts/test-balance.mjs",
+    "test:subscriptions": "node scripts/test-subscriptions.mjs",
     "validate:live": "node scripts/validate-fold.mjs && node scripts/verify-raw.mjs"
   },
   "devDependencies": {

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -126,16 +126,48 @@ const dayDetail = renderToStaticMarkup(react.createElement(DayDetail, {
 		cacheWriteTokens: 0,
 		cacheHitRate: 99.4,
 		models: [
-			{ model: "deepseek-v4-flash", tokens: 30000000, inputTokens: 100000, outputTokens: 50000, cacheReadTokens: 29000000, cacheWriteTokens: 0, cacheHitRate: 99.6 },
-			{ model: "deepseek-reasoner", tokens: 4333358, inputTokens: 99382, outputTokens: 66824, cacheReadTokens: 5017152, cacheWriteTokens: 0, cacheHitRate: 98.1 }
+			{ model: "deepseek-official/deepseek-v4-flash", tokens: 30000000, inputTokens: 100000, outputTokens: 50000, cacheReadTokens: 29000000, cacheWriteTokens: 0, cacheHitRate: 99.6 },
+			{ model: "ark/deepseek-v4-flash", tokens: 4333358, inputTokens: 99382, outputTokens: 66824, cacheReadTokens: 5017152, cacheWriteTokens: 0, cacheHitRate: 98.1 }
 		]
 	},
 	translate: (key) => key,
 	onBack: () => {}
 }));
 if (!dayDetail.includes("deepseek-v4-flash")) throw new Error("day detail missing model rows");
+if (!dayDetail.includes("deepseek-official · deepseek-v4-flash")) throw new Error("day detail must prefix the provider");
+if (!dayDetail.includes("ark · deepseek-v4-flash")) throw new Error("same model from another provider must stay distinct");
 if (dayDetail.length < 500) throw new Error("day detail markup too small");
-console.log("day detail render ok, markup length:", dayDetail.length);
+console.log("day detail render ok (provider-prefixed models), markup length:", dayDetail.length);
+
+// Subscription UI is intentionally distinct from the monetary balance card:
+// each provider gets branded multi-window progress meters and reset metadata.
+const { SubscriptionCard } = exports_;
+const subscriptionMarkup = renderToStaticMarkup(react.createElement("div", null, [
+	react.createElement(SubscriptionCard, {
+		key: "go",
+		provider: {
+			id: "opencode-go",
+			displayName: "OpenCode Go",
+			status: "ok",
+			plan: "Go",
+			windows: [
+				{ kind: "session", usedPercent: 12, remainingPercent: 88, resetsAt: "2026-08-14T01:00:00Z" },
+				{ kind: "weekly", usedPercent: 34, remainingPercent: 66 },
+				{ kind: "monthly", usedPercent: 56, remainingPercent: 44 }
+			]
+		},
+		translate: (key, params) => params?.value === void 0 ? key : `${key}:${params.value}`
+	}),
+	react.createElement(SubscriptionCard, {
+		key: "zai",
+		provider: { id: "zai", displayName: "Z.ai", status: "not-configured", plan: "GLM Coding Plan", missingCredentials: ["ZAI_API_KEY"], windows: [] },
+		translate: (key, params) => params?.refs === void 0 ? key : `${key}:${params.refs}`
+	})
+]));
+if (!subscriptionMarkup.includes("OpenCode Go") || !subscriptionMarkup.includes("Z.ai")) throw new Error("subscription cards missing provider identities");
+if ((subscriptionMarkup.match(/role="progressbar"/g) ?? []).length !== 3) throw new Error("OpenCode Go must render three quota meters");
+if (!subscriptionMarkup.includes("width:12%") || !subscriptionMarkup.includes("ZAI_API_KEY")) throw new Error("subscription meter/config state missing");
+console.log("subscription cards render ok, markup length:", subscriptionMarkup.length);
 
 // Race regression (P1): usage and balance must each keep their OWN staleness
 // counter, so a balance request issued right after a usage request must NOT
@@ -143,13 +175,17 @@ console.log("day detail render ok, markup length:", dayDetail.length);
 const { createLoader, fmtCurrency } = exports_;
 const usageLoader = createLoader();
 const balanceLoader = createLoader();
+const subscriptionLoader = createLoader();
 const usageId = usageLoader.start();
 const balanceId = balanceLoader.start();
+const subscriptionId = subscriptionLoader.start();
 if (!usageLoader.isCurrent(usageId)) throw new Error("race: balance start invalidated the usage request");
 if (!balanceLoader.isCurrent(balanceId)) throw new Error("balance request must stay current");
+if (!subscriptionLoader.isCurrent(subscriptionId)) throw new Error("subscription request must stay current");
 usageLoader.start(); // a newer usage refresh supersedes the old one
 if (usageLoader.isCurrent(usageId)) throw new Error("a newer usage start must supersede the previous usage request");
 if (!balanceLoader.isCurrent(balanceId)) throw new Error("balance must not be affected by usage refreshes");
+if (!subscriptionLoader.isCurrent(subscriptionId)) throw new Error("subscription must not be affected by usage refreshes");
 console.log("loader race regression ok (independent usage/balance counters)");
 
 // Currency formatting must respect the reported currency, not hardcode ¥.

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -139,35 +139,62 @@ if (!dayDetail.includes("ark · deepseek-v4-flash")) throw new Error("same model
 if (dayDetail.length < 500) throw new Error("day detail markup too small");
 console.log("day detail render ok (provider-prefixed models), markup length:", dayDetail.length);
 
-// Subscription UI is intentionally distinct from the monetary balance card:
-// each provider gets branded multi-window progress meters and reset metadata.
-const { SubscriptionCard } = exports_;
-const subscriptionMarkup = renderToStaticMarkup(react.createElement("div", null, [
-	react.createElement(SubscriptionCard, {
-		key: "go",
-		provider: {
-			id: "opencode-go",
-			displayName: "OpenCode Go",
-			status: "ok",
-			plan: "Go",
-			windows: [
-				{ kind: "session", usedPercent: 12, remainingPercent: 88, resetsAt: "2026-08-14T01:00:00Z" },
-				{ kind: "weekly", usedPercent: 34, remainingPercent: 66 },
-				{ kind: "monthly", usedPercent: 56, remainingPercent: 44 }
-			]
-		},
-		translate: (key, params) => params?.value === void 0 ? key : `${key}:${params.value}`
-	}),
-	react.createElement(SubscriptionCard, {
-		key: "zai",
-		provider: { id: "zai", displayName: "Z.ai", status: "not-configured", plan: "GLM Coding Plan", missingCredentials: ["ZAI_API_KEY"], windows: [] },
-		translate: (key, params) => params?.refs === void 0 ? key : `${key}:${params.refs}`
-	})
-]));
-if (!subscriptionMarkup.includes("OpenCode Go") || !subscriptionMarkup.includes("Z.ai")) throw new Error("subscription cards missing provider identities");
-if ((subscriptionMarkup.match(/role="progressbar"/g) ?? []).length !== 3) throw new Error("OpenCode Go must render three quota meters");
-if (!subscriptionMarkup.includes("width:12%") || !subscriptionMarkup.includes("ZAI_API_KEY")) throw new Error("subscription meter/config state missing");
-console.log("subscription cards render ok, markup length:", subscriptionMarkup.length);
+// Balance and subscription providers share one account-card frame. Only the
+// selected provider is rendered; the inner payload varies by account mode.
+const { ProviderAccountCard, buildProviderChoices } = exports_;
+const translateAccount = (key, params) => {
+	if (params?.value !== void 0) return `${key}:${params.value}`;
+	if (params?.refs !== void 0) return `${key}:${params.refs}`;
+	if (params?.ref !== void 0) return `${key}:${params.ref}`;
+	return key;
+};
+const deepseekMarkup = renderToStaticMarkup(react.createElement(ProviderAccountCard, {
+	provider: { id: "deepseek-official", displayName: "DeepSeek", accountMode: "balance" },
+	subscription: null,
+	subscriptionLoading: false,
+	subscriptionError: null,
+	balance: { isAvailable: true, currency: "CNY", total: "36.44", toppedUp: "20", granted: "16.44" },
+	balanceState: "ok",
+	balanceMessage: null,
+	translate: translateAccount,
+	onRetry: () => {}
+}));
+const goSubscription = {
+	id: "opencode-go",
+	displayName: "OpenCode Go",
+	status: "ok",
+	plan: "Go",
+	windows: [
+		{ kind: "session", usedPercent: 12, remainingPercent: 88, resetsAt: "2026-08-14T01:00:00Z" },
+		{ kind: "weekly", usedPercent: 34, remainingPercent: 66 },
+		{ kind: "monthly", usedPercent: 56, remainingPercent: 44 }
+	]
+};
+const goMarkup = renderToStaticMarkup(react.createElement(ProviderAccountCard, {
+	provider: { id: "opencode-go", displayName: "OpenCode Go", accountMode: "subscription", subscriptionId: "opencode-go" },
+	subscription: goSubscription,
+	subscriptionLoading: false,
+	subscriptionError: null,
+	balance: null,
+	balanceState: "loading",
+	balanceMessage: null,
+	translate: translateAccount,
+	onRetry: () => {}
+}));
+if (!deepseekMarkup.includes("usg_accountCard") || !goMarkup.includes("usg_accountCard")) throw new Error("both account modes must use the shared card frame");
+if (!deepseekMarkup.includes("data-account-mode=\"balance\"") || !deepseekMarkup.includes("DeepSeek") || deepseekMarkup.includes("progressbar")) throw new Error("DeepSeek must render only monetary balance data");
+if (!goMarkup.includes("data-account-mode=\"subscription\"") || !goMarkup.includes("OpenCode Go")) throw new Error("OpenCode Go must render the subscription account mode");
+if ((goMarkup.match(/role="progressbar"/g) ?? []).length !== 3 || !goMarkup.includes("width:12%")) throw new Error("OpenCode Go must render three quota meters");
+
+const choices = buildProviderChoices([
+	{ id: "deepseek-official", displayName: "DeepSeek", scheme: "deepseek", configured: true },
+	{ id: "zai-coding-cn", displayName: "Z.ai CN", scheme: "zai", configured: true }
+], [goSubscription, { id: "zai", displayName: "Z.ai", status: "ok", windows: [] }]);
+if (choices.length !== 3) throw new Error(`provider merge must collapse Z.ai aliases, got ${choices.length}`);
+if (choices.find((provider) => provider.id === "zai-coding-cn")?.accountMode !== "subscription") throw new Error("Z.ai must prefer its subscription presentation");
+const selectedMarkup = goMarkup;
+if (selectedMarkup.includes("DeepSeek") || selectedMarkup.includes("Z.ai")) throw new Error("the account area must render only the selected provider");
+console.log("unified single-provider account card ok, balance:", deepseekMarkup.length, "subscription:", goMarkup.length);
 
 // Race regression (P1): usage and balance must each keep their OWN staleness
 // counter, so a balance request issued right after a usage request must NOT

--- a/scripts/test-balance.mjs
+++ b/scripts/test-balance.mjs
@@ -1,0 +1,73 @@
+// Unit tests for lib/balance.js (offline: no network).
+import assert from "node:assert/strict";
+import { balanceSchemeOf, queryBalance, supportedBalanceSchemes } from "../lib/balance.js";
+
+// Scheme mapping: known providers map to their scheme, others have none.
+assert.equal(balanceSchemeOf("deepseek-official"), "deepseek");
+assert.equal(balanceSchemeOf("deepseek"), "deepseek");
+assert.equal(balanceSchemeOf("openrouter"), "openrouter");
+assert.equal(balanceSchemeOf("moonshotai"), "moonshot");
+assert.equal(balanceSchemeOf("moonshotai-cn"), "moonshot");
+assert.equal(balanceSchemeOf("zai"), "zai");
+assert.equal(balanceSchemeOf("zai-coding-cn"), "zai");
+assert.equal(balanceSchemeOf("opencode"), null);
+assert.equal(balanceSchemeOf("opencode-go"), null);
+assert.equal(balanceSchemeOf("ark"), null);
+assert.equal(balanceSchemeOf("openai"), null);
+assert.equal(balanceSchemeOf("anthropic"), null);
+console.log("scheme mapping ok");
+
+// Endpoint derivation from a configured base URL.
+async function stubFetchOnce(payload, status = 200) {
+	const calls = [];
+	globalThis.fetch = async (url, init) => {
+		calls.push({ url: String(url), init });
+		return { ok: status >= 200 && status < 300, status, json: async () => payload };
+	};
+	return calls;
+}
+
+{
+	const calls = await stubFetchOnce({ is_available: true, balance_infos: [{ currency: "CNY", total_balance: "36.44", granted_balance: "0.00", topped_up_balance: "36.44" }] });
+	const balance = await queryBalance("deepseek", "https://api.deepseek.com/v1", "sk-test");
+	assert.equal(calls[0].url, "https://api.deepseek.com/user/balance");
+	assert.equal(calls[0].init.headers.authorization, "Bearer sk-test");
+	assert.deepEqual(balance, { isAvailable: true, currency: "CNY", total: "36.44", granted: "0.00", toppedUp: "36.44" });
+	console.log("deepseek scheme ok:", calls[0].url);
+}
+
+{
+	const calls = await stubFetchOnce({ credits: 12.34, total_usage: 56.78 });
+	const balance = await queryBalance("openrouter", "https://openrouter.ai/api/v1", "sk-test");
+	assert.equal(calls[0].url, "https://openrouter.ai/api/v1/credits");
+	assert.deepEqual(balance, { isAvailable: true, currency: "USD", total: 12.34, granted: void 0, toppedUp: void 0 });
+	console.log("openrouter scheme ok:", calls[0].url);
+}
+
+{
+	const calls = await stubFetchOnce({ data: { available_balance: 5.5, cash_balance: 3.0, voucher_balance: 2.5, currency: "CNY" } });
+	const balance = await queryBalance("moonshot", "https://api.moonshot.cn", "sk-test");
+	assert.equal(calls[0].url, "https://api.moonshot.cn/v1/users/me/balance");
+	assert.deepEqual(balance, { isAvailable: true, currency: "CNY", total: 5.5, granted: 2.5, toppedUp: 3.0 });
+	console.log("moonshot scheme ok:", calls[0].url);
+}
+
+{
+	const calls = await stubFetchOnce({ data: { total_balance: 9.9, available_balance: 8.8, currency: "CNY" } });
+	const balance = await queryBalance("zai", "https://api.z.ai/api/paas/v4", "sk-test");
+	assert.equal(calls[0].url, "https://api.z.ai/api/paas/v4/balance");
+	assert.deepEqual(balance, { isAvailable: true, currency: "CNY", total: 9.9, granted: void 0, toppedUp: 8.8 });
+	console.log("zai scheme ok:", calls[0].url);
+}
+
+// Upstream HTTP errors surface as throws.
+{
+	const calls = await stubFetchOnce({}, 429);
+	await assert.rejects(() => queryBalance("deepseek", "https://api.deepseek.com", "sk-test"), /HTTP 429/);
+	assert.equal(calls.length, 1);
+	console.log("upstream error propagation ok");
+}
+
+delete globalThis.fetch;
+assert.deepEqual(supportedBalanceSchemes().sort(), ["deepseek", "moonshot", "openrouter", "zai"]);
+console.log("BALANCE TESTS PASSED");

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -61,6 +61,11 @@ async function testRouteFence(root) {
 	const head = makeResponse();
 	await handler({ method: "HEAD", headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, head);
 	assert.equal(head.status, 405, "the endpoints are GET-only");
+
+	const subscriptions = makeResponse();
+	await routes.get(plugin.SUBSCRIPTIONS_PATH)({ method: "GET", url: plugin.SUBSCRIPTIONS_PATH, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, subscriptions);
+	assert.equal(subscriptions.status, 200);
+	assert.deepEqual(JSON.parse(subscriptions.body).subscriptions.map((provider) => provider.status), ["not-configured", "not-configured"]);
 }
 
 async function testPersistedToLive(root) {

--- a/scripts/test-subscriptions.mjs
+++ b/scripts/test-subscriptions.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { collectSubscriptions, subscriptionCredentialRefs } from "../lib/subscriptions.js";
+
+function credentials(values) {
+	return {
+		resolve: async (ref) => Object.hasOwn(values, ref) ? { value: values[ref] } : void 0
+	};
+}
+
+const now = Date.parse("2026-08-14T00:00:00Z");
+const noLocalAuth = {
+	homedir: () => "/test-home",
+	readFile: async () => { throw new Error("missing"); }
+};
+
+{
+	const providers = await collectSubscriptions(credentials({}), {}, { ...noLocalAuth, now: () => now });
+	assert.deepEqual(providers.map((provider) => [provider.id, provider.status]), [
+		["opencode-go", "not-configured"],
+		["zai", "not-configured"]
+	]);
+	assert.deepEqual(providers[0].missingCredentials, [subscriptionCredentialRefs.openCodeApiKey]);
+	console.log("not-configured states ok");
+}
+
+{
+	const calls = [];
+	const secret = "sk-opencode-test";
+	const providers = await collectSubscriptions(credentials({ OPENCODE_GO_API_KEY: secret }), {}, {
+		...noLocalAuth,
+		now: () => now,
+		fetch: async (url, init) => {
+			calls.push({ url: String(url), init });
+			if (String(url).includes("api.z.ai")) return { ok: false, status: 401, json: async () => ({}) };
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({ usage: {
+					rolling: { status: "ok", percent: 9, resetsAt: "2026-08-14T07:20:04.810Z" },
+					weekly: { status: "ok", percent: 12, resetsAt: "2026-08-17T00:00:00.810Z" },
+					monthly: { status: "ok", percent: 6, resetsAt: "2026-09-09T00:41:03.810Z" }
+				} })
+			};
+		}
+	});
+	const go = providers[0];
+	assert.equal(go.status, "ok");
+	assert.deepEqual(go.windows.map((window) => [window.kind, window.usedPercent]), [["session", 9], ["weekly", 12], ["monthly", 6]]);
+	assert.equal(calls[0].url, "https://opencode.ai/zen/go/v1/usage");
+	assert.equal(calls[0].init.headers.authorization, `Bearer ${secret}`);
+	assert.equal(JSON.stringify(go).includes(secret), false, "API key must not cross the module interface");
+	console.log("OpenCode Go Bearer endpoint normalization ok");
+}
+
+{
+	const calls = [];
+	const secret = "super-secret-cookie";
+	const providers = await collectSubscriptions(credentials({
+		OPENCODE_GO_AUTH_COOKIE: secret,
+		OPENCODE_GO_WORKSPACE_ID: "https://opencode.ai/workspace/wrk_TEST/go"
+	}), {}, {
+		...noLocalAuth,
+		now: () => now,
+		fetch: async (url, init) => {
+			calls.push({ url: String(url), init });
+			return {
+				ok: true,
+				status: 200,
+				text: async () => JSON.stringify({
+					rollingUsage: { usagePercent: 12, resetInSec: 3600 },
+					weeklyUsage: { usagePercent: 34, resetInSec: 86400 },
+					monthlyUsage: { usagePercent: 56, resetInSec: 2592000 }
+				})
+			};
+		}
+	});
+	const go = providers[0];
+	assert.equal(go.status, "ok");
+	assert.deepEqual(go.windows.map((window) => [window.kind, window.usedPercent]), [["session", 12], ["weekly", 34], ["monthly", 56]]);
+	assert.equal(calls[0].url, "https://opencode.ai/workspace/wrk_TEST/go");
+	assert.equal(calls[0].init.headers.cookie, `auth=${secret}`);
+	assert.equal(JSON.stringify(go).includes(secret), false, "cookie must not cross the module interface");
+	console.log("OpenCode Go dashboard normalization ok");
+}
+
+{
+	const calls = [];
+	const providers = await collectSubscriptions(credentials({}), {}, {
+		homedir: () => "/users/demo",
+		readFile: async (path) => {
+			assert.equal(String(path).replaceAll("\\", "/"), "/users/demo/.local/share/opencode/auth.json");
+			return JSON.stringify({ "opencode-go": { type: "api", key: "local-opencode-key" } });
+		},
+		now: () => now,
+		fetch: async (url, init) => {
+			calls.push(String(url));
+			assert.equal(init.headers.authorization, "Bearer local-opencode-key");
+			return { ok: true, status: 200, json: async () => ({ usage: { rolling: { percent: 1 }, weekly: { percent: 2 }, monthly: { percent: 3 } } }) };
+		}
+	});
+	assert.equal(providers[0].status, "ok");
+	assert.deepEqual(calls, ["https://opencode.ai/zen/go/v1/usage"]);
+	console.log("OpenCode auth.json fallback ok");
+}
+
+{
+	const calls = [];
+	const secret = "zai-secret-key";
+	const providers = await collectSubscriptions(credentials({ ZAI_API_KEY: secret }), {}, {
+		...noLocalAuth,
+		now: () => now,
+		fetch: async (url, init) => {
+			calls.push({ url: String(url), init });
+			if (String(url).endsWith("/quota/limit")) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ({ data: { limits: [
+						{ type: "TOKENS_LIMIT", unit: 3, number: 5, usage: 1000, currentValue: 120, remaining: 850 },
+						{ type: "CREDIT_LIMIT", unit: 6, number: 1, percentage: 25 },
+						{ type: "TIME_LIMIT", remaining: 9, percentage: 40 }
+					] } })
+				};
+			}
+			return { ok: true, status: 200, json: async () => ({ data: [{ product_name: "GLM Coding Pro", next_renew_time: "2026-09-01T00:00:00Z" }] }) };
+		}
+	});
+	const zai = providers[1];
+	assert.equal(zai.status, "ok");
+	assert.equal(zai.plan, "GLM Coding Pro");
+	assert.deepEqual(zai.windows.map((window) => [window.kind, Math.round(window.usedPercent)]), [["session", 15], ["weekly", 25], ["billing", 40]]);
+	assert.deepEqual(calls.map((call) => call.url), [
+		"https://api.z.ai/api/monitor/usage/quota/limit",
+		"https://api.z.ai/api/biz/subscription/list"
+	]);
+	assert.ok(calls.every((call) => call.init.headers.authorization === `Bearer ${secret}`));
+	assert.equal(JSON.stringify(zai).includes(secret), false, "API key must not cross the module interface");
+	console.log("Z.ai quota normalization ok");
+}
+
+{
+	const providers = await collectSubscriptions(credentials({ ZAI_API_KEY: "x", ZAI_API_REGION: "cn" }), {}, {
+		...noLocalAuth,
+		now: () => now,
+		fetch: async (url) => {
+			assert.match(String(url), /^https:\/\/open\.bigmodel\.cn\//);
+			return { ok: false, status: 401, json: async () => ({}) };
+		}
+	});
+	assert.equal(providers[1].region, "bigmodel-cn");
+	assert.equal(providers[1].status, "unauthorized");
+	console.log("Z.ai region and auth error mapping ok");
+}
+
+console.log("SUBSCRIPTION TESTS PASSED");


### PR DESCRIPTION
## What changed

- attribute token usage by provider and model and add provider-aware balance schemes
- add normalized subscription adapters for OpenCode Go and Z.ai
- prefer the OpenCode Go Bearer usage endpoint, reuse local `auth.json`, and retain the dashboard cookie/workspace flow as a compatibility fallback
- unify monetary balances and quota windows in one provider account-card frame
- render only the currently selected provider, with DeepSeek balance and OpenCode Go/Z.ai subscription presentations
- document one-command and agent-friendly installation, credential boundaries, privacy, and the undocumented OpenCode endpoint
- release the package as 0.1.2

## Why

Balances and subscription quotas represent different account models, but they should share a consistent provider selection and visual frame. The selected provider now determines whether the card body shows currency values or percentage windows without stacking unrelated provider cards.

## Validation

- `npm run check`
- `npm test`
- `npm pack --dry-run`
- `git diff --check`
- Playwright interaction and visual QA at 500px and 360px viewports, confirming one account card and no horizontal overflow

## Compatibility note

OpenCode Go's Bearer usage endpoint is not publicly documented and may change. The adapter is defensive and retains the authenticated workspace dashboard parser as a fallback. No API key, auth file content, cookie, or page body crosses the server/browser boundary.
