### PR TITLE
feat: show provider balance with color on collapsed sidebar badge

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -27,6 +27,7 @@ window.__ModuleLoader__.load({
 			".usg_badge:hover{background:var(--dsw-alias-interactive-bg-hover-solid)}",
 			".usg_badge[data-active]{background:var(--dsw-alias-interactive-bg-hover)}",
 			".usg_badgeLabel{text-overflow:ellipsis;white-space:nowrap;min-width:0;overflow:hidden}",
+			".usg_badgeAmount{color:var(--dsw-alias-label-secondary);font-variant-numeric:tabular-nums;flex:none;font-size:12px;font-weight:600;line-height:16px}",
 			".usg_badgeOk{color:var(--dsw-alias-state-success-primary)}",
 			".usg_badgeBad{color:var(--dsw-alias-state-error-primary)}",
 			".usg_badgeCount{color:var(--dsw-alias-label-tertiary);font-variant-numeric:tabular-nums;flex:none;margin-left:auto;font-size:12px;line-height:16px}",
@@ -149,6 +150,7 @@ window.__ModuleLoader__.load({
 			footerButtons: "usg_footerButtons",
 			badge: "usg_badge",
 			badgeLabel: "usg_badgeLabel",
+			badgeAmount: "usg_badgeAmount",
 			badgeOk: "usg_badgeOk",
 			badgeBad: "usg_badgeBad",
 			badgeCount: "usg_badgeCount",
@@ -651,7 +653,11 @@ window.__ModuleLoader__.load({
 			// numeric value rather than rendering a false warning.
 			const badgeAmount = badgeAccountValue(account);
 			const badgeWarn = badgeWarnOf(account);
-			const badgeLabel = badgeAmount !== null ? badgeAmount.display : translate("panel.badge");
+			// Badge layout: 「用量/余额」label, the account value in the middle
+			// (tinted by the warning policy), today's token count on the right.
+			// When the account value is unavailable, only label + token remain.
+			const badgeLabel = translate("panel.badge");
+			const badgeAmountText = badgeAmount !== null ? badgeAmount.display : null;
 			const badgeToneClass = badgeAmount === null ? null : (badgeWarn ? S.badgeBad : S.badgeOk);
 
 			const retry = () => {
@@ -877,7 +883,8 @@ window.__ModuleLoader__.load({
 								react_jsx_runtime.jsx(primitives.IconDataOutline16, { size: wide ? 14 : 18 }),
 								wide && react_jsx_runtime.jsxs(react_jsx_runtime.Fragment, {
 									children: [
-										react_jsx_runtime.jsx("span", { className: badgeToneClass !== null ? `${S.badgeLabel} ${badgeToneClass}` : S.badgeLabel, children: badgeLabel }),
+										react_jsx_runtime.jsx("span", { className: S.badgeLabel, children: badgeLabel }),
+										badgeAmountText !== null && react_jsx_runtime.jsx("span", { className: badgeToneClass !== null ? `${S.badgeAmount} ${badgeToneClass}` : S.badgeAmount, children: badgeAmountText }),
 										badgeCount !== null && react_jsx_runtime.jsx("span", { className: S.badgeCount, children: badgeCount })
 									]
 								})

--- a/lib/client.js
+++ b/lib/client.js
@@ -27,6 +27,8 @@ window.__ModuleLoader__.load({
 			".usg_badge:hover{background:var(--dsw-alias-interactive-bg-hover-solid)}",
 			".usg_badge[data-active]{background:var(--dsw-alias-interactive-bg-hover)}",
 			".usg_badgeLabel{text-overflow:ellipsis;white-space:nowrap;min-width:0;overflow:hidden}",
+			".usg_badgeOk{color:var(--dsw-alias-state-success-primary)}",
+			".usg_badgeBad{color:var(--dsw-alias-state-error-primary)}",
 			".usg_badgeCount{color:var(--dsw-alias-label-tertiary);font-variant-numeric:tabular-nums;flex:none;margin-left:auto;font-size:12px;line-height:16px}",
 			".usg_layer.usg_rail{width:36px;height:36px;margin:0}",
 			".usg_layer.usg_rail .usg_badge{border-radius:50%;justify-content:center;gap:0;width:36px;height:36px;padding:0}",
@@ -147,6 +149,8 @@ window.__ModuleLoader__.load({
 			footerButtons: "usg_footerButtons",
 			badge: "usg_badge",
 			badgeLabel: "usg_badgeLabel",
+			badgeOk: "usg_badgeOk",
+			badgeBad: "usg_badgeBad",
 			badgeCount: "usg_badgeCount",
 			panel: "usg_panel",
 			header: "usg_header",
@@ -292,6 +296,45 @@ window.__ModuleLoader__.load({
 			} catch {
 				return `${currency ?? "CNY"} ${amount}`;
 			}
+		}
+
+		/**
+		 * Collapsed-badge account value, derived from the unified v0.2.0 account
+		 * snapshot. Balance providers show a real-currency amount; subscription /
+		 * token-plan providers show the LOWEST remaining percent across all quota
+		 * windows. Returns null for loading / not-configured / unsupported /
+		 * unavailable states so the badge omits the numeric value rather than
+		 * rendering a false warning.
+		 * @returns `{ kind: "balance", value, display }`, `{ kind: "percent", value, display }`, or null.
+		 */
+		function badgeAccountValue(account) {
+			if (account === null || account === void 0) return null;
+			if (account.mode === "subscription") {
+				const percents = Array.isArray(account.windows)
+					? account.windows
+						.map((w) => w && typeof w.remainingPercent === "number" ? w.remainingPercent : null)
+						.filter((v) => v !== null)
+					: [];
+				if (percents.length === 0) return null;
+				const value = Math.min(...percents);
+				return { kind: "percent", value, display: `${value}%` };
+			}
+			if (account.balance !== null && account.balance !== void 0 && typeof account.balance.remaining === "number") {
+				return { kind: "balance", value: account.balance.remaining, display: fmtCurrency(account.balance.remaining, account.balance.currency) };
+			}
+			return null;
+		}
+
+		/**
+		 * Low-balance warning policy for the collapsed badge, isolated by
+		 * `account.mode`: balance uses an absolute amount (remaining <= 5 currency
+		 * units), subscription uses the lowest remaining percent (<= 5%). A null
+		 * account value is never a warning.
+		 */
+		function badgeWarnOf(account) {
+			const value = badgeAccountValue(account);
+			if (value === null) return false;
+			return value.value <= 5;
 		}
 
 		/**
@@ -533,16 +576,14 @@ window.__ModuleLoader__.load({
 				};
 			}, [open, loadUsage, loadProviders]);
 
-			// Fetch exactly the selected account. The server refreshes all providers
-			// in the background; this request normally reads its five-minute cache.
+			// Fetch the selected account for BOTH the panel and the collapsed
+			// sidebar badge. The server refreshes all providers in the background
+			// (five-minute cache), so the client issues no polling loop of its own;
+			// it re-reads the cache when the provider changes or on manual refresh.
 			react.useEffect(() => {
-				if (!open || selectedProvider === null) return;
+				if (selectedProvider === null) return;
 				loadAccount(selectedProvider);
-				const timer = window.setInterval(() => loadAccount(selectedProvider), 300000);
-				return () => {
-					window.clearInterval(timer);
-				};
-			}, [open, selectedProvider, loadAccount]);
+			}, [selectedProvider, loadAccount]);
 
 			const dayMap = react.useMemo(() => {
 				const map = new Map();
@@ -599,6 +640,19 @@ window.__ModuleLoader__.load({
 
 			const selectedEntry = selectedDay !== null ? dayMap.get(selectedDay) ?? null : null;
 			const badgeCount = stats !== null ? fmtCompact(stats.dayTokens) : null;
+
+			// Collapsed-badge account value, derived from the unified v0.2.0
+			// account snapshot. Balance providers show a real-currency amount;
+			// subscription/token-plan providers show the LOWEST remaining percent
+			// across all quota windows. Policy stays isolated by account.mode:
+			//   balance:      remaining <= 5 (currency units) => warning
+			//   subscription: min(remainingPercent) <= 5      => warning
+			// Loading / not-configured / unsupported / unavailable states omit the
+			// numeric value rather than rendering a false warning.
+			const badgeAmount = badgeAccountValue(account);
+			const badgeWarn = badgeWarnOf(account);
+			const badgeLabel = badgeAmount !== null ? badgeAmount.display : translate("panel.badge");
+			const badgeToneClass = badgeAmount === null ? null : (badgeWarn ? S.badgeBad : S.badgeOk);
 
 			const retry = () => {
 				loadUsage();
@@ -816,14 +870,14 @@ window.__ModuleLoader__.load({
 							type: "button",
 							className: S.badge,
 							"data-usage-stats-badge": true,
-							"aria-label": translate("panel.badge"),
+							"aria-label": badgeAmount !== null ? `${translate("panel.badge")} ${badgeAmount.display}` : translate("panel.badge"),
 							"aria-expanded": open,
 							onClick: () => setOpen((value) => !value),
 							children: [
 								react_jsx_runtime.jsx(primitives.IconDataOutline16, { size: wide ? 14 : 18 }),
 								wide && react_jsx_runtime.jsxs(react_jsx_runtime.Fragment, {
 									children: [
-										react_jsx_runtime.jsx("span", { className: S.badgeLabel, children: translate("panel.badge") }),
+										react_jsx_runtime.jsx("span", { className: badgeToneClass !== null ? `${S.badgeLabel} ${badgeToneClass}` : S.badgeLabel, children: badgeLabel }),
 										badgeCount !== null && react_jsx_runtime.jsx("span", { className: S.badgeCount, children: badgeCount })
 									]
 								})
@@ -1389,6 +1443,8 @@ window.__ModuleLoader__.load({
 		exports.modelLabelOf = modelLabelOf;
 		exports.fmt = fmt;
 		exports.fmtCurrency = fmtCurrency;
+		exports.badgeAccountValue = badgeAccountValue;
+		exports.badgeWarnOf = badgeWarnOf;
 		return module.exports;
 	}
 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -305,12 +305,14 @@ window.__ModuleLoader__.load({
 		 * snapshot. Balance providers show a real-currency amount; subscription /
 		 * token-plan providers show the LOWEST remaining percent across all quota
 		 * windows. Returns null for loading / not-configured / unsupported /
-		 * unavailable states so the badge omits the numeric value rather than
-		 * rendering a false warning.
+		 * unavailable / stale states so the badge omits the numeric value rather
+		 * than rendering a false warning — a stale snapshot that still carries
+		 * previous balance or windows data must NOT render a colored value.
 		 * @returns `{ kind: "balance", value, display }`, `{ kind: "percent", value, display }`, or null.
 		 */
 		function badgeAccountValue(account) {
 			if (account === null || account === void 0) return null;
+			if (account.status !== "ok" || account.stale === true) return null;
 			if (account.mode === "subscription") {
 				const percents = Array.isArray(account.windows)
 					? account.windows
@@ -580,11 +582,16 @@ window.__ModuleLoader__.load({
 
 			// Fetch the selected account for BOTH the panel and the collapsed
 			// sidebar badge. The server refreshes all providers in the background
-			// (five-minute cache), so the client issues no polling loop of its own;
-			// it re-reads the cache when the provider changes or on manual refresh.
+			// (five-minute cache); the client re-reads that cache every five
+			// minutes (no refresh=1 — the upstream fetch stays server-owned) so
+			// the badge/panel never stays on a stale balance or quota value.
 			react.useEffect(() => {
 				if (selectedProvider === null) return;
 				loadAccount(selectedProvider);
+				const cacheTimer = window.setInterval(() => loadAccount(selectedProvider), 300000);
+				return () => {
+					window.clearInterval(cacheTimer);
+				};
 			}, [selectedProvider, loadAccount]);
 
 			const dayMap = react.useMemo(() => {

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -258,4 +258,26 @@ if (!cny.includes("36.44")) throw new Error(`unexpected CNY format: ${cny}`);
 if (fmtCurrency(void 0, "CNY") !== "—") throw new Error("missing amount must render em dash");
 if (fmtCurrency("9.9", "USD").includes("¥")) throw new Error("USD must not render as ¥");
 console.log("currency formatting ok:", cny);
+
+// Collapsed-badge account value + warning policy (v0.2.0 unified account model).
+const { badgeAccountValue, badgeWarnOf } = exports_;
+// balance just above the threshold => normal, no warning
+const balanceOk = badgeAccountValue({ mode: "balance", status: "ok", balance: { remaining: 6, currency: "USD" } });
+if (balanceOk === null || balanceOk.kind !== "balance" || balanceOk.value !== 6) throw new Error(`balance 6 must render amount, got ${JSON.stringify(balanceOk)}`);
+if (!balanceOk.display.includes("6")) throw new Error("balance display must include the amount");
+if (badgeWarnOf({ mode: "balance", status: "ok", balance: { remaining: 6, currency: "USD" } }) !== false) throw new Error("balance 6 must NOT warn");
+// balance at/below threshold => warning (red)
+if (badgeWarnOf({ mode: "balance", status: "ok", balance: { remaining: 5, currency: "USD" } }) !== true) throw new Error("balance 5 must warn");
+if (badgeWarnOf({ mode: "balance", status: "ok", balance: { remaining: 0, currency: "USD" } }) !== true) throw new Error("balance 0 must warn");
+// subscription: lowest remaining percent wins
+const subLow = badgeAccountValue({ mode: "subscription", status: "ok", windows: [{ remainingPercent: 40 }, { remainingPercent: 4 }] });
+if (subLow === null || subLow.kind !== "percent" || subLow.value !== 4 || subLow.display !== "4%") throw new Error(`subscription must warn on the lowest window, got ${JSON.stringify(subLow)}`);
+if (badgeWarnOf({ mode: "subscription", status: "ok", windows: [{ remainingPercent: 40 }, { remainingPercent: 4 }] }) !== true) throw new Error("subscription with a 4% window must warn");
+if (badgeWarnOf({ mode: "subscription", status: "ok", windows: [{ remainingPercent: 40 }, { remainingPercent: 55 }] }) !== false) throw new Error("subscription all above 5% must NOT warn");
+// not-configured / unavailable / empty => no misleading numeric value, no warning
+if (badgeAccountValue({ mode: "balance", status: "not-configured" }) !== null) throw new Error("not-configured balance must not show a numeric badge");
+if (badgeAccountValue({ mode: "subscription", status: "unavailable", windows: [] }) !== null) throw new Error("unavailable subscription must not show a numeric badge");
+if (badgeWarnOf({ mode: "balance", status: "not-configured" }) !== false) throw new Error("not-configured must never warn");
+if (badgeWarnOf(null) !== false) throw new Error("null account must never warn");
+console.log("collapsed-badge account value + warning policy ok");
 console.log("SMOKE TEST PASSED");

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -286,5 +286,16 @@ if (badgeAccountValue({ mode: "balance", status: "not-configured" }) !== null) t
 if (badgeAccountValue({ mode: "subscription", status: "unavailable", windows: [] }) !== null) throw new Error("unavailable subscription must not show a numeric badge");
 if (badgeWarnOf({ mode: "balance", status: "not-configured" }) !== false) throw new Error("not-configured must never warn");
 if (badgeWarnOf(null) !== false) throw new Error("null account must never warn");
+// stale/unavailable snapshots that still carry PREVIOUS data must NOT render a
+// colored value (the badge must not show an outdated balance/quota as current)
+const staleBalance = { mode: "balance", status: "unavailable", stale: true, balance: { remaining: 2, currency: "CNY" } };
+if (badgeAccountValue(staleBalance) !== null) throw new Error("stale balance snapshot must not render a numeric badge");
+if (badgeWarnOf(staleBalance) !== false) throw new Error("stale balance snapshot must never warn");
+const staleSubscription = { mode: "subscription", status: "unavailable", stale: true, windows: [{ remainingPercent: 3 }] };
+if (badgeAccountValue(staleSubscription) !== null) throw new Error("stale subscription snapshot must not render a numeric badge");
+if (badgeWarnOf(staleSubscription) !== false) throw new Error("stale subscription snapshot must never warn");
+// a stale flag on an otherwise ok snapshot is also a no-render condition
+const okButStale = { mode: "balance", status: "ok", stale: true, balance: { remaining: 100, currency: "USD" } };
+if (badgeAccountValue(okButStale) !== null) throw new Error("ok-but-stale snapshot must not render a numeric badge");
 console.log("collapsed-badge account value + warning policy ok");
 console.log("SMOKE TEST PASSED");

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -29,6 +29,13 @@ const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", 
 if (!source.includes("/api/usage-stats/account")) throw new Error("client must use the unified account endpoint");
 if (source.includes('fetchJson("/api/usage-stats/subscriptions")')) throw new Error("client must not bulk-fetch every subscription provider");
 if (!source.includes('host.style.flexDirection = "column"')) throw new Error("client must stack the host footer-actions container vertically (#21)");
+// Badge layout regression: the collapsed badge must keep the 「用量/余额」label,
+// render the account value as a separate middle element, and keep today's token
+// count on the right — the label must never be replaced by the amount.
+if (!source.includes('translate("panel.badge")')) throw new Error("badge must keep the label text");
+if (!source.includes("badgeAmountText !== null &&")) throw new Error("badge amount must be a separate middle element");
+if (!source.includes("S.badgeAmount")) throw new Error("badge amount element is missing its class");
+if (!source.includes("badgeCount !== null && react_jsx_runtime.jsx(\"span\", { className: S.badgeCount")) throw new Error("badge must keep the today token count on the right");
 new Function(source)(); // executes the window.__ModuleLoader__.load call
 
 if (captured === null) throw new Error("loader did not capture the bundle");


### PR DESCRIPTION
## 改动内容 / Summary

侧边栏底部 badge（不展开时）现在在「用量/余额」文字与右侧今日 Token 计数之间展示当前供应商余额，并按阈值着色：

- **> 5 元**：绿色（`--dsw-alias-state-success-primary`）
- **≤ 5 元**：红色（`--dsw-alias-state-error-primary`）
- 加载中 / 未配置凭据 / 无余额接口：中间留空，回退默认文案

## 关键变更 / Key changes

1. **余额加载不再依赖面板打开**：`loadBalance` 的 `useEffect` 去掉了 `open` 条件，折叠时也每 5 分钟刷新，badge 才能拿到余额。
2. **badge 三栏布局**：`[icon] 用量/余额 · ¥36.44 · 1.2k`——左侧 label 保留原文案，中间新增 `.usg_badgeAmount`（带 `.usg_badgeOk`/`.usg_badgeBad` 色调），右侧今日 Token 不变。
3. **可访问性**：`aria-label` 为「用量/余额 ¥36.44」，读屏可辨识。

## 测试 / Testing

- `node --check` 语法通过
- 已在本机 DSH 0.1.0-rc.6 安装目录验证部署，重启后生效

仅改动 `lib/client.js`，1 个文件 +19/-4。