### PR TITLE
fix: support installation through DSH plugin bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,28 @@ Token usage heatmap, provider/model breakdowns, account balances, and subscripti
 
 ## 安装 / Installation
 
-### 一条命令安装
+需要 DeepSeek Harness 的 `web` profile（面向 `@deepseek-ai/dsh >= 0.1.0-rc.6`）。
 
-需要 DeepSeek Harness 的 `web` profile（面向 `@deepseek-ai/dsh >= 0.1.0-rc.6`），以及随 Node.js 提供的 `npx`。
+### 推荐：DSH 插件命令
+
+通过 DSH 自带的插件命令安装并注册 bundle：
+
+```bash
+dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"
+```
+
+该命令会把插件安装到 `web` profile，并从包内声明的 `cordis.patch.yml` 挂载服务端插件。已经运行的 `dsh web` 需要重启，浏览器随后硬刷新。
+
+升级或卸载：
+
+```bash
+dsh plugin --profile web update dsh-usage-stats
+dsh plugin --profile web remove dsh-usage-stats
+```
+
+### 兼容安装器
+
+无法使用 `dsh plugin` 时，也可以使用随 Node.js 提供的 `npx` 安装器：
 
 在 PowerShell、命令提示符或 macOS/Linux 终端运行同一条命令：
 
@@ -37,6 +56,8 @@ npx --yes github:Ychris12138/dsh-usage-stats
 ```
 
 安装器会自动完成两件事：把运行文件复制到 `~/.dsh/profiles/node_modules/dsh-usage-stats`，并在 `profiles/web/cordis.patch.yml` 中幂等启用插件。重复运行同一命令即可更新，不会重复添加配置。
+
+`dsh plugin` 与 `npx` 是两条独立安装路径，请选择其中一种；不要在保留手工 Cordis patch 条目的同时再注册 bundle，否则会重复挂载插件。
 
 如设置了 `DSH_HOME`，安装器会使用该目录而不是 `~/.dsh`。可先预览或只检查现有安装：
 
@@ -140,11 +161,12 @@ Constraints:
 
 Procedure:
 1. Confirm node, npx, and dsh are available.
-2. Run: npx --yes github:Ychris12138/dsh-usage-stats
-3. Require the installer to report a verified package and exactly one Cordis patch entry.
-4. Report the resolved install and patch paths.
-5. Run the installer again with --check and require a zero exit code.
-6. If dsh web is already running, tell me a restart is needed and stop.
+2. Prefer: dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"
+3. If the dsh plugin command is unavailable, fall back to: npx --yes github:Ychris12138/dsh-usage-stats
+4. Do not combine the bundle installation with an existing manual dsh-usage-stats Cordis patch entry.
+5. For the npx fallback, require the installer to report a verified package and exactly one Cordis patch entry, then run it again with --check.
+6. Report which installation path was used and its resolved profile paths.
+7. If dsh web is already running, tell me a restart is needed and stop.
 
 Optional subscription setup (do not handle secrets yourself):
 - Tell me that OpenCode Go can reuse its local auth.json automatically, or I can add OPENCODE_GO_API_KEY to the Harness credentials file myself.

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,0 +1,5 @@
+# Mount the usage-stats server plugin when this package is registered as a
+# DeepSeek Harness profile bundle.
+- insert:
+    - id: usage-stats
+      name: dsh-usage-stats

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "lib/",
+    "cordis.patch.yml",
     "docs/images/usage-panel.png",
     "scripts/install.mjs",
     "README.md",
@@ -35,6 +36,9 @@
     "./package.json": "./package.json"
   },
   "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    },
     "client": {
       "platform": "web",
       "inject": [
@@ -45,8 +49,9 @@
     }
   },
   "scripts": {
-    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
-    "test": "npm run test:client && npm run test:server && npm run test:balance && npm run test:subscriptions && npm run test:install",
+    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-bundle.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
+    "test": "npm run test:bundle && npm run test:client && npm run test:server && npm run test:balance && npm run test:subscriptions && npm run test:install",
+    "test:bundle": "node scripts/test-bundle.mjs",
     "test:client": "node scripts/smoke-client.mjs",
     "test:install": "node scripts/test-install.mjs",
     "test:server": "node scripts/test-server.mjs",

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -82,7 +82,7 @@ if (args.has("--check")) {
 }
 
 await mkdir(target, { recursive: true });
-for (const entry of ["lib", "package.json", "README.md", "LICENSE", "SECURITY.md"]) {
+for (const entry of ["lib", "cordis.patch.yml", "package.json", "README.md", "LICENSE", "SECURITY.md"]) {
 	await cp(join(sourceRoot, entry), join(target, entry), { recursive: true, force: true });
 }
 await mkdir(join(target, "scripts"), { recursive: true });

--- a/scripts/test-bundle.mjs
+++ b/scripts/test-bundle.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { access, readFile } from "node:fs/promises";
+import { dirname, join, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+const patchDeclaration = manifest.dsh?.bundle?.patch;
+
+assert.equal(patchDeclaration, "./cordis.patch.yml", "package must declare its DSH bundle patch");
+assert.ok(manifest.files?.includes("cordis.patch.yml"), "npm package must include the declared bundle patch");
+
+const patchPath = join(root, normalize(patchDeclaration));
+await access(patchPath);
+const patch = await readFile(patchPath, "utf8");
+assert.equal(
+	[...patch.matchAll(/^\s+name:\s*dsh-usage-stats\s*$/gm)].length,
+	1,
+	"bundle patch must mount dsh-usage-stats exactly once"
+);
+
+console.log("DSH BUNDLE MANIFEST TESTS PASSED");

--- a/scripts/test-install.mjs
+++ b/scripts/test-install.mjs
@@ -25,6 +25,11 @@ try {
 	assert.equal([...patch.matchAll(/^\s+name:\s*dsh-usage-stats\s*$/gm)].length, 1, "installer must be idempotent");
 	const installed = JSON.parse(await readFile(join(home, "profiles", "node_modules", "dsh-usage-stats", "package.json"), "utf8"));
 	assert.equal(installed.name, "dsh-usage-stats");
+	assert.equal(installed.dsh?.bundle?.patch, "./cordis.patch.yml");
+	assert.match(
+		await readFile(join(home, "profiles", "node_modules", "dsh-usage-stats", "cordis.patch.yml"), "utf8"),
+		/^\s+name:\s*dsh-usage-stats\s*$/m
+	);
 	assert.equal(await readFile(join(home, "profiles", "node_modules", "dsh-usage-stats", "lib", "index.js"), "utf8").then((text) => text.length > 1000), true);
 	console.log("INSTALLER REGRESSION TESTS PASSED");
 } finally {


### PR DESCRIPTION
## Summary

- declare the package as a DSH bundle and ship its Cordis patch
- keep the legacy npx installer aligned with the bundle artifact
- add regression coverage for the manifest, packaged patch, and installer copy
- document the official `dsh plugin` flow and warn against mixing it with a manual patch

## Problem

Running:

```sh
dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"
```

adds `dsh-usage-stats` to the profile bundle stack, but the installed package does not declare `dsh.bundle`. The next profile boot fails with:

```text
Error: dsh: profile bundle "dsh-usage-stats" declares no dsh.bundle in its package.json
```

A service supervised with automatic restart then remains in a crash loop.

## Verification

- `npm run check`
- `npm test`
- `npm pack --dry-run` confirms `cordis.patch.yml` is shipped
- clean-profile smoke test with `@deepseek-ai/dsh` 0.1.0-rc.6:
  - installed using `dsh plugin --profile web add link:<checkout>`
  - confirmed the profile registered the bundle
  - started `dsh web`
  - verified the Web root and all four usage-stats API endpoints return HTTP 200
