### PR TITLE
fix: distinguish blocked account queries from unsupported providers

### DIFF
--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -27,6 +27,7 @@ const ACCOUNT_STATUSES = new Set([
 	"rate-limited",
 	"unavailable",
 	"invalid-response",
+	"blocked",
 	"unsupported"
 ]);
 const ADAPTERS = new Set([
@@ -442,7 +443,7 @@ export function selectResolvedAddress(url, rawAddresses, allowPrivateNetwork = f
 
 async function resolvePublicAddress(url, spec, deps) {
 	const hostname = url.hostname.replace(/^\[|\]$/g, "");
-	if (privateHostname(hostname) && spec.monitor.allowPrivateNetwork !== true) throw statusError("unsupported", "account monitor private-network access requires allowPrivateNetwork");
+	if (privateHostname(hostname) && spec.monitor.allowPrivateNetwork !== true) throw statusError("blocked", "account monitor private-network access requires allowPrivateNetwork");
 	if (isIP(hostname) !== 0) return { address: hostname, family: isIP(hostname) };
 	let addresses;
 	try {
@@ -458,7 +459,7 @@ async function resolvePublicAddress(url, spec, deps) {
 		spec.monitor.allowPrivateNetwork === true
 	);
 	if (selected === null) {
-		throw statusError("unsupported", "account monitor hostname resolves only to blocked network addresses");
+		throw statusError("blocked", "account monitor hostname resolves only to blocked network addresses");
 	}
 	return { address: selected.address, family: selected.family ?? isIP(selected.address) };
 }
@@ -474,11 +475,11 @@ function crossOriginSensitive(spec) {
 async function assertTargetPolicy(rawUrl, spec, deps) {
 	const url = new URL(rawUrl);
 	if (url.username !== "" || url.password !== "") throw statusError("unsupported", "account monitor URL must not contain credentials");
-	if (url.protocol !== "https:" && spec.monitor.allowInsecure !== true) throw statusError("unsupported", "account monitor requires HTTPS");
+	if (url.protocol !== "https:" && spec.monitor.allowInsecure !== true) throw statusError("blocked", "account monitor requires HTTPS");
 	if (url.protocol !== "https:" && url.protocol !== "http:") throw statusError("unsupported", "account monitor protocol is unsupported");
 	if (crossOriginSensitive(spec) && nonEmptyString(spec.providerBaseURL) !== null) {
 		const providerOrigin = new URL(spec.providerBaseURL).origin;
-		if (url.origin !== providerOrigin && spec.monitor.allowCrossOrigin !== true) throw statusError("unsupported", "account monitor cross-origin access requires allowCrossOrigin");
+		if (url.origin !== providerOrigin && spec.monitor.allowCrossOrigin !== true) throw statusError("blocked", "account monitor cross-origin access requires allowCrossOrigin");
 	}
 	const resolved = await resolvePublicAddress(url, spec, deps);
 	return { url, ...resolved };
@@ -534,9 +535,9 @@ async function pinnedFetch(rawUrl, init, spec, deps) {
 function customURL(spec) {
 	const base = new URL(spec.baseURL);
 	const providerBase = nonEmptyString(spec.providerBaseURL) === null ? null : new URL(spec.providerBaseURL);
-	if (base.protocol !== "https:" && spec.monitor.allowInsecure !== true) throw statusError("unsupported", "custom monitor requires HTTPS");
-	if (privateHostname(base.hostname) && spec.monitor.allowPrivateNetwork !== true) throw statusError("unsupported", "custom monitor private-network access requires allowPrivateNetwork");
-	if (providerBase !== null && base.origin !== providerBase.origin && spec.monitor.allowCrossOrigin !== true) throw statusError("unsupported", "custom monitor cross-origin access requires allowCrossOrigin");
+	if (base.protocol !== "https:" && spec.monitor.allowInsecure !== true) throw statusError("blocked", "custom monitor requires HTTPS");
+	if (privateHostname(base.hostname) && spec.monitor.allowPrivateNetwork !== true) throw statusError("blocked", "custom monitor private-network access requires allowPrivateNetwork");
+	if (providerBase !== null && base.origin !== providerBase.origin && spec.monitor.allowCrossOrigin !== true) throw statusError("blocked", "custom monitor cross-origin access requires allowCrossOrigin");
 	const url = new URL(spec.monitor.request.path, base);
 	if (url.origin !== base.origin) throw statusError("unsupported", "custom monitor request must stay on its configured origin");
 	return url.href;

--- a/lib/client.js
+++ b/lib/client.js
@@ -823,6 +823,7 @@ window.__ModuleLoader__.load({
 		/** Balance-mode body rendered inside the shared provider account frame. */
 		function BalanceContent({ balance, state, message, translate, onRetry }) {
 			if (state === "loading" || balance === null && state === "ok") return react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: translate("balance.loading") });
+			if (state === "blocked") return react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: translate("account.blocked") });
 			if (state === "unsupported") return react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: translate("balance.unsupported") });
 			if (state === "no-credential") return react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: translate("balance.noCredential", { ref: message ?? "" }) });
 			if (state === "error") return react_jsx_runtime.jsxs("div", {
@@ -887,6 +888,7 @@ window.__ModuleLoader__.load({
 			if (status === "unauthorized") return translate("subscription.status.unauthorized");
 			if (status === "rate-limited") return translate("subscription.status.rateLimited");
 			if (status === "invalid-response") return translate("account.status.invalidResponse");
+			if (status === "blocked") return translate("account.status.blocked");
 			if (status === "unsupported") return translate("account.status.unsupported");
 			return translate("subscription.status.unavailable");
 		}
@@ -919,8 +921,9 @@ window.__ModuleLoader__.load({
 				: status === "unauthorized" ? translate("subscription.unauthorized")
 					: status === "rate-limited" ? translate("subscription.rateLimited")
 						: status === "invalid-response" ? translate("account.invalidResponse")
-							: status === "unsupported" ? translate("balance.unsupported")
-								: translate("subscription.unavailable");
+							: status === "blocked" ? translate("account.blocked")
+								: status === "unsupported" ? translate("balance.unsupported")
+									: translate("subscription.unavailable");
 			return (status === "ok" || provider.stale === true) && windows.length > 0 ? react_jsx_runtime.jsx("div", {
 						className: S.quotaList,
 						children: windows.map((window) => {
@@ -960,14 +963,16 @@ window.__ModuleLoader__.load({
 			const subscriptionMode = mode === "subscription";
 			const status = accountLoading && account === null ? "loading" : account?.status ?? "unavailable";
 			const statusText = status === "loading" ? translate("account.status.loading")
-				: status === "unsupported" ? translate("account.status.unsupported")
-					: subscriptionStatusLabel(status, translate);
+				: status === "blocked" ? translate("account.status.blocked")
+					: status === "unsupported" ? translate("account.status.unsupported")
+						: subscriptionStatusLabel(status, translate);
 			const subtitle = account?.plan ?? (subscriptionMode ? translate("subscription.planUnknown") : translate("account.balanceMode"));
 			const balanceState = accountLoading && account === null ? "loading"
 				: accountError !== null ? "error"
 					: status === "not-configured" ? "no-credential"
-						: status === "unsupported" ? "unsupported"
-							: account?.balance !== null && account?.balance !== void 0 ? "ok" : "error";
+						: status === "blocked" ? "blocked"
+							: status === "unsupported" ? "unsupported"
+								: account?.balance !== null && account?.balance !== void 0 ? "ok" : "error";
 			const balanceMessage = accountError ?? account?.missingCredentials?.[0] ?? status;
 			return react_jsx_runtime.jsxs("article", {
 				className: S.accountCard,
@@ -1162,9 +1167,11 @@ window.__ModuleLoader__.load({
 			"account.balanceMode": "API 余额",
 			"account.loading": "正在加载供应商…",
 			"account.status.loading": "查询中",
+			"account.status.blocked": "已阻止",
 			"account.status.unsupported": "不支持余额",
 			"account.status.invalidResponse": "响应异常",
 			"account.invalidResponse": "供应商返回了无法识别的额度数据。",
+			"account.blocked": "账户查询被本地安全策略阻止，请检查 HTTPS、同源和私网访问设置。",
 			"balance.title": "账户余额",
 			"balance.provider": "供应商",
 			"balance.noSchemeTag": "无余额接口",
@@ -1243,9 +1250,11 @@ window.__ModuleLoader__.load({
 			"account.balanceMode": "API balance",
 			"account.loading": "Loading providers…",
 			"account.status.loading": "Loading",
+			"account.status.blocked": "Blocked",
 			"account.status.unsupported": "Balance unsupported",
 			"account.status.invalidResponse": "Invalid response",
 			"account.invalidResponse": "The provider returned unrecognized quota data.",
+			"account.blocked": "The account query was blocked by the local security policy. Check HTTPS, same-origin, and private-network settings.",
 			"balance.title": "Account balance",
 			"balance.provider": "Provider",
 			"balance.noSchemeTag": "no balance API",

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -197,6 +197,31 @@ const invalidMarkup = renderToStaticMarkup(react.createElement(ProviderAccountCa
 }));
 if (!invalidMarkup.includes("account.status.invalidResponse") || !invalidMarkup.includes("account.invalidResponse")) throw new Error("invalid account responses need a distinct status and explanation");
 
+// Local security-policy rejections must render a distinct blocked state, not
+// the "provider has no balance interface" unsupported message.
+const blockedMarkup = renderToStaticMarkup(react.createElement(ProviderAccountCard, {
+	provider: { id: "relay-a", displayName: "Relay A", accountMode: "balance" },
+	account: { id: "relay-a", displayName: "Relay A", mode: "balance", status: "blocked", balance: null },
+	accountLoading: false,
+	accountError: null,
+	translate: translateAccount,
+	onRetry: () => {}
+}));
+const blockedSubMarkup = renderToStaticMarkup(react.createElement(ProviderAccountCard, {
+	provider: { id: "opencode-go", displayName: "OpenCode Go", accountMode: "subscription" },
+	account: { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: "blocked", windows: [] },
+	accountLoading: false,
+	accountError: null,
+	translate: translateAccount,
+	onRetry: () => {}
+}));
+if (!blockedMarkup.includes("account.status.blocked") || !blockedMarkup.includes("account.blocked")) throw new Error("blocked balance queries need a distinct status and neutral explanation");
+if (!blockedSubMarkup.includes("account.status.blocked") || !blockedSubMarkup.includes("account.blocked")) throw new Error("blocked subscription queries need a distinct status and neutral explanation");
+if (blockedMarkup.includes("balance.unsupported")) throw new Error("blocked must not reuse the unsupported explanation");
+if (blockedMarkup.includes("balance.blocked") || blockedSubMarkup.includes("balance.blocked")) throw new Error("blocked must not reuse the balance-specific explanation");
+if (!source.includes('"account.status.blocked"') || !source.includes('"account.blocked"')) throw new Error("blocked status keys missing from client locales");
+if (source.includes('"balance.blocked"')) throw new Error("balance-specific blocked copy must not be reintroduced");
+
 const choices = buildProviderChoices([
 	{ id: "deepseek-official", displayName: "DeepSeek", adapter: "deepseek-balance", accountMode: "balance", configured: true },
 	{ id: "zai-coding-cn", displayName: "Z.ai CN", adapter: "zai-token-plan", accountMode: "subscription", configured: true },

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -405,7 +405,7 @@ console.log("IPv4/IPv6 private-address classification ok");
 		}
 	} }));
 	const account = await queryAccount(spec, credentials({}), { now: () => now, fetch: async () => { throw new Error("must not fetch"); } });
-	assert.equal(account.status, "unsupported");
+	assert.equal(account.status, "blocked", "cross-origin policy rejection must surface as blocked");
 	console.log("declarative cross-origin default deny ok");
 }
 
@@ -422,7 +422,7 @@ console.log("IPv4/IPv6 private-address classification ok");
 		}
 	} }));
 	const account = await queryAccount(spec, credentials({}), { now: () => now, fetch: async () => { throw new Error("must not fetch"); } });
-	assert.equal(account.status, "unsupported", "private network access needs its own opt-in");
+	assert.equal(account.status, "blocked", "private-network policy rejection must surface as blocked, not unsupported");
 	console.log("declarative private-network default deny ok");
 }
 
@@ -479,7 +479,7 @@ console.log("IPv4/IPv6 private-address classification ok");
 		now: () => now,
 		lookup: async () => [{ address: "127.0.0.1", family: 4 }]
 	});
-	assert.equal(account.status, "unsupported", "DNS answers pointing at private networks must be rejected before connecting");
+	assert.equal(account.status, "blocked", "DNS answers pointing at private networks must surface as blocked, not unsupported");
 	console.log("DNS-to-private-network rejection ok");
 }
 
@@ -533,7 +533,7 @@ console.log("IPv4/IPv6 private-address classification ok");
 		now: () => now,
 		lookup: async () => { throw new Error("literal targets must be blocked before DNS lookup"); }
 	});
-	assert.equal(account.status, "unsupported", "literal 198.18/15 targets must remain blocked without allowPrivateNetwork");
+	assert.equal(account.status, "blocked", "literal 198.18/15 targets must surface as blocked without allowPrivateNetwork");
 	console.log("literal benchmarking-range target rejection ok");
 }
 
@@ -562,6 +562,43 @@ console.log("IPv4/IPv6 private-address classification ok");
 		await new Promise((resolve) => server.close(resolve));
 	}
 	console.log("allowPrivateNetwork opt-in preserves private network access ok");
+}
+
+{
+	// No adapter: the provider genuinely has no balance/subscription interface.
+	const bare = resolveAccountSpec(relay, validateAccountConfig());
+	assert.equal(bare.adapter, null);
+	const account = await queryAccount(bare, credentials({}), { now: () => now, fetch: async () => { throw new Error("must not fetch"); } });
+	assert.equal(account.status, "unsupported", "a provider without any adapter must stay unsupported");
+	console.log("missing adapter stays unsupported ok");
+}
+
+{
+	// HTTP 404/405: the upstream itself has no such account API.
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "general" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async () => jsonResponse({}, 404)
+	});
+	assert.equal(account.status, "unsupported", "HTTP 404 must stay unsupported, not blocked");
+	console.log("upstream 404 stays unsupported ok");
+}
+
+{
+	// HTTPS policy: local security policy rejects the plain-HTTP target before
+	// any DNS resolution or connection attempt.
+	const insecureProvider = { ...relay, baseURL: "http://relay.example.com/v1" };
+	const spec = resolveAccountSpec(insecureProvider, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "general" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		lookup: async () => { throw new Error("must not resolve before the HTTPS policy check"); }
+	});
+	assert.equal(account.status, "blocked", "non-HTTPS targets must surface as blocked without allowInsecure");
+	console.log("non-HTTPS policy rejection ok");
 }
 
 {


### PR DESCRIPTION
## Summary

Account statuses currently collapse two very different situations into one
wire value:

- the provider or upstream genuinely has no account API (no adapter, HTTP
  `404`/`405`);
- the local security policy refused to run the query (non-HTTPS target,
  cross-origin, private-network/DNS policy).

Both surface as `unsupported`, and the browser then unconditionally renders
"该供应商没有公开的余额查询接口" ("this provider has no public balance
interface") — which is wrong for policy rejections such as a private-network
target or a plain-HTTP endpoint.

This PR splits them into two wire statuses:

```text
unsupported
→ Provider/API 不支持这个功能 (the provider has no such account API)

blocked
→ 功能可能存在，但本地安全策略拒绝执行 (the feature may exist, but the
  local security policy refused to run it)
```

The branch is rebased onto the latest `main`, including #10, #15, and #16.

## What changed

- add a new `blocked` account status
- preserve #10's `selectResolvedAddress()` fake-IP/DNS selection behavior
  while mapping actual local-policy rejection paths to `blocked`
- local policy rejections now report `blocked` instead of `unsupported`:
  - `account monitor requires HTTPS` / `custom monitor requires HTTPS`
  - cross-origin access (`requires allowCrossOrigin`)
  - private-network / DNS policy (`requires allowPrivateNetwork`, hostname
    resolving only to blocked network addresses)
- keep `unsupported` for provider-side absence: no adapter, HTTP `404`/`405`,
  unsupported protocols, and URLs embedding credentials
- render a distinct blocked state in the client (balance and subscription
  cards) with neutral account-level copy (`account.blocked`) instead of
  reusing `balance.blocked` or the unsupported explanation
- preserve subsequent upstream changes from #15 (overlay background token
  with base fallback) and #16 (MiniMax token-plan hardening /
  `provider.reason` propagation)

## Security boundary

No policy behavior changes: the same targets remain blocked, only the
reported status differs. `blocked` never bypasses a check and never enables
an opt-in.

## Tests

Added and updated regressions:

- missing adapter → `unsupported`
- upstream HTTP `404` → `unsupported`
- non-HTTPS target → `blocked`
- cross-origin policy → `blocked`
- private-network / DNS policy → `blocked`
- literal 198.18/15 target → `blocked`
- HTTPS hostname + 198.18/15 fake-IP → selected; public beats fake-IP;
  HTTP + fake-IP → not selected; `allowPrivateNetwork` opt-in preserved
- client smoke: blocked balance and subscription cards render the blocked
  status and neutral `account.blocked` explanation, and must not reuse
  `balance.blocked` or the unsupported copy

Validation (local, Node 26):

- `npm ci`
- `npm run check`
- `npm test`
- `npm pack --dry-run`
- `git diff --check`
