### PR TITLE
fix(accounts): allow proxy fake-ip DNS answers through the address pin

### DIFF
--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -369,12 +369,36 @@ export function isPrivateAddress(address) {
 	return !globalUnicast || ietfSpecial || sixToFour || documentation;
 }
 
+/**
+ * True for 198.18.0.0/15 — the IANA benchmarking range (RFC 2544) that proxy
+ * tools (Clash, Surge, ...) reuse as the fake-ip pool in fake-ip DNS mode.
+ * Real public hosts never resolve here; the answer is a proxy-managed alias
+ * that the proxy's TUN routes back to the originally requested hostname, so a
+ * pinned connection to it is not an SSRF signal. Every other non-public range
+ * stays hard-blocked by {@link isPrivateAddress} unless the monitor opts in.
+ */
+export function isFakeIpAddress(address) {
+	const value = String(address ?? "").trim().replace(/^\[|\]$/g, "");
+	if (isIP(value) === 4) {
+		const [a, b] = value.split(".").map(Number);
+		return a === 198 && (b === 18 || b === 19);
+	}
+	if (isIP(value) !== 6) return false;
+	const bytes = ipv6Bytes(value);
+	if (bytes === null) return false;
+	if (bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === 0xff && bytes[11] === 0xff) {
+		const [a, b] = bytes.slice(12);
+		return a === 198 && (b === 18 || b === 19);
+	}
+	return false;
+}
+
 function privateHostname(hostname) {
 	const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
 	return host === "localhost" || host.endsWith(".localhost") || isPrivateAddress(host);
 }
 
-async function resolvePublicAddress(url, spec, deps) {
+export async function resolvePublicAddress(url, spec, deps) {
 	const hostname = url.hostname.replace(/^\[|\]$/g, "");
 	if (privateHostname(hostname) && spec.monitor.allowPrivateNetwork !== true) throw statusError("unsupported", "account monitor private-network access requires allowPrivateNetwork");
 	if (isIP(hostname) !== 0) return { address: hostname, family: isIP(hostname) };
@@ -386,7 +410,8 @@ async function resolvePublicAddress(url, spec, deps) {
 	}
 	if (!Array.isArray(addresses)) addresses = [addresses];
 	if (addresses.length === 0) throw statusError("unavailable", "account monitor hostname resolved to no addresses");
-	if (spec.monitor.allowPrivateNetwork !== true && addresses.some((entry) => isPrivateAddress(entry?.address))) {
+	if (spec.monitor.allowPrivateNetwork !== true
+		&& addresses.some((entry) => isPrivateAddress(entry?.address) && !isFakeIpAddress(entry?.address))) {
 		throw statusError("unsupported", "account monitor hostname resolves to a private network");
 	}
 	const selected = addresses[0];

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import {
 	createAccountService,
+	isFakeIpAddress,
 	isPrivateAddress,
 	queryAccount,
 	resolveAccountSpec,
+	resolvePublicAddress,
 	validateAccountConfig
 } from "../lib/accounts.js";
 
@@ -53,6 +55,13 @@ assert.equal(isPrivateAddress("2001:2::1"), true);
 assert.equal(isPrivateAddress("2002:7f00:1::"), true);
 assert.equal(isPrivateAddress("2606:4700:4700::1111"), false);
 console.log("IPv4/IPv6 private-address classification ok");
+
+assert.equal(isFakeIpAddress("198.18.0.1"), true);
+assert.equal(isFakeIpAddress("198.19.255.255"), true);
+assert.equal(isFakeIpAddress("198.17.0.1"), false);
+assert.equal(isFakeIpAddress("192.168.1.1"), false);
+assert.equal(isFakeIpAddress("::ffff:198.18.1.68"), true);
+console.log("proxy fake-ip range classification ok");
 
 {
 	const spec = resolveAccountSpec(passion, validateAccountConfig());
@@ -477,6 +486,36 @@ console.log("IPv4/IPv6 private-address classification ok");
 	});
 	assert.equal(account.status, "unsupported", "DNS answers pointing at private networks must be rejected before connecting");
 	console.log("DNS-to-private-network rejection ok");
+}
+
+{
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "general" }
+	} }));
+	// Fake-ip DNS is a proxy artifact (Clash/Surge fake-ip mode): the answer
+	// is routed locally back to the requested hostname, so the pinned
+	// connection is allowed instead of being mistaken for an SSRF signal.
+	const target = await resolvePublicAddress(new URL(spec.baseURL), spec, {
+		lookup: async () => [{ address: "198.18.1.68", family: 4 }]
+	});
+	assert.equal(target.address, "198.18.1.68", "proxy fake-ip answers must be pinned, not rejected");
+	console.log("proxy fake-ip DNS answers are pinned, not rejected");
+}
+
+{
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "general" }
+	} }));
+	// Genuine private answers keep the hard block even when the DNS runs
+	// through a proxy that also emits fake-ip ranges.
+	await assert.rejects(
+		resolvePublicAddress(new URL(spec.baseURL), spec, {
+			lookup: async () => [{ address: "10.0.0.5", family: 4 }]
+		}),
+		/private network/,
+		"genuine private answers must stay rejected"
+	);
+	console.log("genuine private answers stay rejected");
 }
 
 {


### PR DESCRIPTION
## Problem

Proxy tools in fake-ip DNS mode (Clash, Surge, ...) answer **every** hostname with an address from 198.18.0.0/15 (the IANA benchmarking range, RFC 2544). The address pin in esolvePublicAddress classified those answers as private networks and aborted the query with status unsupported - so balance/account queries (e.g. DeepSeek /user/balance) show Balance unsupported for users running behind such a proxy, even though the endpoint is reachable.

Fake-ip answers are proxy-managed aliases: the proxy's TUN routes the pinned connection back to the **originally requested hostname**, so connecting to them is not an SSRF signal.

## Fix

- Add isFakeIpAddress() classifying the 198.18.0.0/15 fake-ip pool (IPv4 and IPv4-mapped IPv6).
- Carve fake-ip answers out of the private-network hard block: only genuine private answers (RFC1918, loopback, link-local, CGNAT, ...) keep the existing rejection unless the monitor opts in via llowPrivateNetwork.
- Export esolvePublicAddress for testing and add classification + policy tests.

## Verification

- 
ode scripts/test-accounts.mjs - all pass, including the two new cases (proxy fake-ip DNS answers are pinned, not rejected, genuine private answers stay rejected).
- 	est-balance, 	est-subscriptions, 	est-server, 	est-bundle, 	est-install pass; 
pm run check passes.
- On a machine whose DNS resolves pi.deepseek.com to 198.18.1.68 (Clash fake-ip), the DeepSeek account now reports ok with the real balance instead of unsupported.