### PR TITLE
fix: harden MiniMax token-plan parsing against real-world payload drift

### DIFF
--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -885,7 +885,7 @@ export async function queryAccount(spec, credentials, deps = {}) {
 			baseURL: spec.monitor.usageBaseURL
 		}, safeDeps);
 		const windows = Array.isArray(provider.windows) ? provider.windows : [];
-		return { ...baseSnapshot(spec, provider.status, now), plan: provider.plan, windows, alert: subscriptionAlert(windows), ...(provider.missingCredentials === void 0 ? {} : { missingCredentials: provider.missingCredentials }) };
+		return { ...baseSnapshot(spec, provider.status, now), plan: provider.plan, windows, alert: subscriptionAlert(windows), ...(provider.missingCredentials === void 0 ? {} : { missingCredentials: provider.missingCredentials }), ...(provider.reason === void 0 ? {} : { reason: provider.reason }) };
 	} catch (error) {
 		return unavailableSnapshot(spec, statusOf(error), now);
 	}

--- a/lib/subscriptions.js
+++ b/lib/subscriptions.js
@@ -457,33 +457,73 @@ function resetFromDuration(value, now) {
 	return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
+const MINIMAX_CHAT_MODEL_PATTERN = /^(minimax-m|coding-plan)/i;
+
+function minimaxChatEntry(remains) {
+	const named = remains.find((entry) => String(entry?.model_name ?? entry?.modelName ?? "").toLowerCase() === "general");
+	if (named !== void 0) return named;
+	// Newer payload versions name the chat entry after the model itself
+	// (e.g. "MiniMax-M3") instead of the "general" resource group.
+	return remains.find((entry) => MINIMAX_CHAT_MODEL_PATTERN.test(String(entry?.model_name ?? entry?.modelName ?? "")));
+}
+
+function minimaxWindowRemaining(remainingPercent, totalCount, usageCount, status) {
+	const remaining = clampPercent(remainingPercent);
+	if (remaining !== null) return remaining;
+	// Older payload versions carry real counters instead of percentages;
+	// current ones zero the counters, so only trust totals above zero.
+	const total = numberOrNull(totalCount);
+	const usage = numberOrNull(usageCount);
+	if (total !== null && total > 0 && usage !== null) return clampPercent((1 - usage / total) * 100);
+	// MiniMax window status: 1 = normal limited, 2 = exhausted, 3 = unlimited.
+	// A missing percentage must not hide the window entirely.
+	if (status === 2) return 0;
+	if (status === 3) return 100;
+	return null;
+}
+
 function parseMiniMax(body, now) {
 	const statusCode = numberOrNull(body?.base_resp?.status_code ?? body?.baseResp?.statusCode);
-	if (statusCode !== null && statusCode !== 0) return [];
+	if (statusCode !== null && statusCode !== 0) {
+		const message = body?.base_resp?.status_msg ?? body?.baseResp?.statusMsg;
+		const suffix = typeof message === "string" && message.trim() !== "" ? `: ${message.trim()}` : "";
+		return { windows: [], reason: `base_resp status_code ${statusCode}${suffix}` };
+	}
 	const remains = Array.isArray(body?.model_remains) ? body.model_remains : Array.isArray(body?.data?.model_remains) ? body.data.model_remains : [];
-	const general = remains.find((entry) => String(entry?.model_name ?? entry?.modelName ?? "").toLowerCase() === "general");
-	if (general === void 0) return [];
-	const intervalRemaining = clampPercent(general.current_interval_remaining_percent ?? general.currentIntervalRemainingPercent);
-	const weeklyRemaining = clampPercent(general.current_weekly_remaining_percent ?? general.currentWeeklyRemainingPercent);
-	const weeklyStatus = numberOrNull(general.current_weekly_status ?? general.currentWeeklyStatus);
+	if (remains.length === 0) return { windows: [], reason: "response has no model_remains entries" };
+	const general = minimaxChatEntry(remains);
+	if (general === void 0) return { windows: [], reason: "model_remains has no general/chat-model entry" };
+	const intervalRemaining = minimaxWindowRemaining(
+		general.current_interval_remaining_percent ?? general.currentIntervalRemainingPercent,
+		general.current_interval_total_count ?? general.currentIntervalTotalCount,
+		general.current_interval_usage_count ?? general.currentIntervalUsageCount,
+		numberOrNull(general.current_interval_status ?? general.currentIntervalStatus)
+	);
+	const weeklyRemaining = minimaxWindowRemaining(
+		general.current_weekly_remaining_percent ?? general.currentWeeklyRemainingPercent,
+		general.current_weekly_total_count ?? general.currentWeeklyTotalCount,
+		general.current_weekly_usage_count ?? general.currentWeeklyUsageCount,
+		numberOrNull(general.current_weekly_status ?? general.currentWeeklyStatus)
+	);
 	const sessionReset = toIso(general.current_interval_end_time ?? general.currentIntervalEndTime ?? general.current_interval_reset_time)
 		?? resetFromDuration(general.remains_time ?? general.remainsTime, now);
 	const weeklyReset = toIso(general.current_weekly_end_time ?? general.currentWeeklyEndTime ?? general.current_weekly_reset_time)
 		?? resetFromDuration(general.weekly_remains_time ?? general.weeklyRemainsTime, now);
-	return [
+	const windows = [
 		intervalRemaining === null ? null : {
 			kind: "session",
 			usedPercent: round1(100 - intervalRemaining),
 			remainingPercent: round1(intervalRemaining),
 			...(sessionReset === null ? {} : { resetsAt: sessionReset })
 		},
-		weeklyStatus !== 1 || weeklyRemaining === null ? null : {
+		weeklyRemaining === null ? null : {
 			kind: "weekly",
 			usedPercent: round1(100 - weeklyRemaining),
 			remainingPercent: round1(weeklyRemaining),
 			...(weeklyReset === null ? {} : { resetsAt: weeklyReset })
 		}
 	].filter(Boolean);
+	return { windows, reason: windows.length === 0 ? "chat-model entry has no usable quota fields" : null };
 }
 
 async function collectMiniMax(credentials, deps) {
@@ -495,8 +535,11 @@ async function collectMiniMax(credentials, deps) {
 	const region = minimaxRegionOf(deps.region ?? configuredRegion, deps.baseURL);
 	if (apiKey === "") return { id: "minimax", displayName: "MiniMax Coding Plan", mode: "subscription", status: "not-configured", plan: "MiniMax Coding Plan", region, missingCredentials: [apiKeyRef], windows: [] };
 	const configuredUrl = nonEmptyUrl(deps.baseURL, MINIMAX_USAGE_PATH);
+	// The token-plan endpoint is served on both the www and api hosts; try the
+	// api host before falling back to the legacy coding-plan path.
 	const urls = configuredUrl === null ? [
 		`${MINIMAX_TOKEN_PLAN_HOSTS[region]}${MINIMAX_TOKEN_PLAN_PATH}`,
+		`${MINIMAX_LEGACY_HOSTS[region]}${MINIMAX_TOKEN_PLAN_PATH}`,
 		`${MINIMAX_LEGACY_HOSTS[region]}${MINIMAX_USAGE_PATH}`
 	] : [configuredUrl];
 	try {
@@ -508,12 +551,26 @@ async function collectMiniMax(credentials, deps) {
 				}, deps, "json");
 				break;
 			} catch (error) {
-				if (index === 0 && urls.length > 1 && (error?.httpStatus === 404 || error?.httpStatus === 405)) continue;
+				// Route not found or a non-JSON (e.g. HTML) reply means this host
+				// does not serve the endpoint; auth and rate-limit failures are
+				// real answers and must not fall through to another host.
+				const tryNext = error?.httpStatus === 404 || error?.httpStatus === 405 || error?.providerStatus === "invalid-response";
+				if (index < urls.length - 1 && tryNext) continue;
 				throw error;
 			}
 		}
-		const windows = parseMiniMax(body, deps.now());
-		return { id: "minimax", displayName: "MiniMax Coding Plan", mode: "subscription", status: windows.length > 0 ? "ok" : "invalid-response", plan: "MiniMax Coding Plan", region, windows };
+		const { windows, reason } = parseMiniMax(body, deps.now());
+		return {
+			id: "minimax",
+			displayName: "MiniMax Coding Plan",
+			mode: "subscription",
+			status: windows.length > 0 ? "ok" : "invalid-response",
+			plan: "MiniMax Coding Plan",
+			region,
+			windows,
+			// Non-sensitive diagnostic so reports can say WHY parsing failed.
+			...(windows.length > 0 || reason === null ? {} : { reason })
+		};
 	} catch (error) {
 		return { id: "minimax", displayName: "MiniMax Coding Plan", mode: "subscription", status: normalizedStatus(error), plan: "MiniMax Coding Plan", region, windows: [] };
 	}

--- a/scripts/test-subscriptions.mjs
+++ b/scripts/test-subscriptions.mjs
@@ -233,11 +233,35 @@ const noLocalAuth = {
 		}
 	});
 	assert.equal(minimax.status, "ok");
+	assert.deepEqual(minimax.windows.map((window) => [window.kind, window.remainingPercent]), [["session", 90]]);
 	assert.deepEqual(calls, [
 		"https://www.minimax.io/v1/token_plan/remains",
+		"https://api.minimax.io/v1/token_plan/remains"
+	]);
+	console.log("MiniMax official endpoint and api-host fallback ok");
+}
+
+{
+	const calls = [];
+	const minimax = await collectSubscription("minimax", credentials({ MINIMAX_API_KEY: "x" }), {}, {
+		now: () => now,
+		fetch: async (url) => {
+			calls.push(String(url));
+			if (calls.length < 3) return { ok: false, status: 404, json: async () => ({}) };
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({ model_remains: [{ model_name: "general", current_interval_remaining_percent: 88 }] })
+			};
+		}
+	});
+	assert.equal(minimax.status, "ok");
+	assert.deepEqual(calls, [
+		"https://www.minimax.io/v1/token_plan/remains",
+		"https://api.minimax.io/v1/token_plan/remains",
 		"https://api.minimax.io/v1/api/openplatform/coding_plan/remains"
 	]);
-	console.log("MiniMax official endpoint and legacy fallback ok");
+	console.log("MiniMax legacy coding-plan fallback ok");
 }
 
 {
@@ -246,12 +270,114 @@ const noLocalAuth = {
 		fetch: async () => ({
 			ok: true,
 			status: 200,
-			json: async () => ({ model_remains: [{ model_name: "text-01", current_interval_remaining_percent: 99 }] })
+			json: async () => ({ model_remains: [{ model_name: "video", current_interval_remaining_percent: 99 }] })
 		})
 	});
 	assert.equal(minimax.status, "invalid-response");
 	assert.deepEqual(minimax.windows, []);
-	console.log("MiniMax ignores non-general model quotas ok");
+	assert.equal(minimax.reason, "model_remains has no general/chat-model entry");
+	console.log("MiniMax ignores non-chat model quotas ok");
+}
+
+{
+	// Newer payload versions name the chat entry after the model itself
+	// (e.g. "MiniMax-M3") instead of the "general" resource group (#14).
+	const minimax = await collectSubscription("minimax", credentials({ MINIMAX_API_KEY: "x" }), {}, {
+		now: () => now,
+		fetch: async () => ({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				base_resp: { status_code: 0, status_msg: "success" },
+				model_remains: [
+					{ model_name: "video", current_interval_remaining_percent: 66, current_weekly_remaining_percent: 95 },
+					{
+						model_name: "MiniMax-M3",
+						current_interval_remaining_percent: 80,
+						remains_time: 3600000,
+						current_weekly_remaining_percent: 45,
+						weekly_remains_time: 604800000
+					}
+				]
+			})
+		})
+	});
+	assert.equal(minimax.status, "ok");
+	assert.deepEqual(minimax.windows.map((window) => [window.kind, window.remainingPercent]), [
+		["session", 80],
+		["weekly", 45]
+	]);
+	console.log("MiniMax model-named chat entry ok");
+}
+
+{
+	// Window status semantics: 1 = normal, 2 = exhausted, 3 = unlimited.
+	// Exhausted/unlimited windows must still render instead of disappearing (#14).
+	const fetchFor = (entry) => async () => ({ ok: true, status: 200, json: async () => ({ model_remains: [{ model_name: "general", ...entry }] }) });
+	const exhausted = await collectSubscription("minimax", credentials({ MINIMAX_API_KEY: "x" }), {}, {
+		now: () => now,
+		fetch: fetchFor({ current_interval_remaining_percent: 12, current_weekly_status: 2 })
+	});
+	assert.deepEqual(exhausted.windows.map((window) => [window.kind, window.remainingPercent]), [
+		["session", 12],
+		["weekly", 0]
+	]);
+	const unlimited = await collectSubscription("minimax", credentials({ MINIMAX_API_KEY: "x" }), {}, {
+		now: () => now,
+		fetch: fetchFor({ current_interval_status: 3, current_weekly_status: 1, current_weekly_remaining_percent: 64 })
+	});
+	assert.deepEqual(unlimited.windows.map((window) => [window.kind, window.remainingPercent]), [
+		["session", 100],
+		["weekly", 64]
+	]);
+	const legacyCounters = await collectSubscription("minimax", credentials({ MINIMAX_API_KEY: "x" }), {}, {
+		now: () => now,
+		fetch: fetchFor({ current_interval_total_count: 1500, current_interval_usage_count: 300, current_weekly_remaining_percent: 70 })
+	});
+	assert.deepEqual(legacyCounters.windows.map((window) => [window.kind, window.remainingPercent]), [
+		["session", 80],
+		["weekly", 70]
+	]);
+	console.log("MiniMax window status and counter fallbacks ok");
+}
+
+{
+	// Upstream business errors surface as invalid-response with a safe reason.
+	const minimax = await collectSubscription("minimax", credentials({ MINIMAX_API_KEY: "x" }), {}, {
+		now: () => now,
+		fetch: async () => ({
+			ok: true,
+			status: 200,
+			json: async () => ({ base_resp: { status_code: 2057, status_msg: "not a coding plan key" } })
+		})
+	});
+	assert.equal(minimax.status, "invalid-response");
+	assert.deepEqual(minimax.windows, []);
+	assert.equal(minimax.reason, "base_resp status_code 2057: not a coding plan key");
+	console.log("MiniMax base_resp error reason ok");
+}
+
+{
+	// A non-JSON (HTML) reply from the www host falls through to the api host.
+	const calls = [];
+	const minimax = await collectSubscription("minimax", credentials({ MINIMAX_API_KEY: "x" }), {}, {
+		now: () => now,
+		fetch: async (url) => {
+			calls.push(String(url));
+			if (calls.length === 1) return { ok: true, status: 200, json: async () => { throw new SyntaxError("Unexpected token <"); } };
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({ model_remains: [{ model_name: "general", current_interval_remaining_percent: 77, current_weekly_remaining_percent: 55 }] })
+			};
+		}
+	});
+	assert.equal(minimax.status, "ok");
+	assert.deepEqual(calls, [
+		"https://www.minimax.io/v1/token_plan/remains",
+		"https://api.minimax.io/v1/token_plan/remains"
+	]);
+	console.log("MiniMax non-JSON host fallback ok");
 }
 
 {


### PR DESCRIPTION
## 问题 / Problem

Issue #14：MiniMax 安装后无法显示 5 小时额度和 Weekly 额度。

对照社区已验证的真实响应（MiniMax Token Plan 接口未公开 schema），发现当前 parser 有三个脆弱假设，任一命中都会让用户看到空窗口（`invalid-response`）：

1. **条目选择只认 `model_name === "general"`**：新版响应把聊天条目命名为模型名（如 `MiniMax-M3`），`parseMiniMax` 直接返回空。
2. **Weekly 窗口要求 `current_weekly_status === 1`**：实际语义是 `1`=正常限量、`2`=已耗尽、`3`=无限制。耗尽/无限制/旧版载荷下周窗口整个消失，而不是显示 0%/100%。
3. **端点只有 www 主机**：野外证实 `api.minimax.io` / `api.minimaxi.com` 同样提供 `/v1/token_plan/remains`；www 主机若返回 HTML 也会直接中止，不会尝试备用端点。

## 修复 / Fix

- 条目选择：`general` → `MiniMax-M*` / `coding-plan*` 聊天条目兜底
- 窗口存在性跟随剩余百分比；百分比缺失时依次回退：真实计数（`total_count`/`usage_count`）→ 状态语义（耗尽 0% / 无限制 100%）
- 端点回退链：`www/token_plan` → `api/token_plan` → `api/coding_plan`（legacy）；404/405/非 JSON 继续尝试下一端点，401/403/429 立即失败不穿透
- `invalid-response` 快照附带不含敏感信息的 `reason`（如 `base_resp status_code 2057: ...`），经 `accounts.js` 透传到客户端快照，方便下次报障定位

## 测试 / Testing

新增 6 组回归用例，全套件通过：

- `MiniMax-M3` 命名条目解析出 session + weekly
- status 2（耗尽）→ weekly 0%，status 3（无限制）→ session 100%
- 旧版计数字段回退（1500/300 → 80%）
- `base_resp` 业务错误 → `invalid-response` + `reason`
- www 主机返回 HTML → 穿透到 api 主机
- 三级端点回退顺序断言

**注意**：没有报告者的真实响应，无法 100% 确认覆盖其具体载荷；合并后需要请 #14 报告者验证。`reason` 字段也为后续排查提供了抓手。

Refs #14