### PR TITLE
fix: portal usage panel to document.body for theme-token isolation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -16,6 +16,7 @@ window.__ModuleLoader__.load({
 
 		let react = require("react");
 		let react_jsx_runtime = require("react/jsx-runtime");
+		let react_dom = require("react-dom");
 		let primitives = require("@deepseek-ai/dsh-client-ui-primitives");
 
 		//#region css
@@ -588,7 +589,11 @@ window.__ModuleLoader__.load({
 			return react_jsx_runtime.jsxs("div", {
 				className: wide ? S.layer : `${S.layer} ${S.rail}`,
 				children: [
-					open && react_jsx_runtime.jsxs("section", {
+					// Portal the panel to document.body: sidebar-scoped theme tokens
+					// (e.g. glass skins that set light label colors for a dark sidebar)
+					// would otherwise leak into the panel and clash with its
+					// overlay surface from the global scope (#17).
+					open && react_dom.createPortal(react_jsx_runtime.jsxs("section", {
 						className: S.panel,
 						"data-usage-stats-panel": true,
 						"aria-label": translate("panel.title"),
@@ -779,7 +784,7 @@ window.__ModuleLoader__.load({
 								]
 							})
 						]
-					}),
+					}), document.body),
 					react_jsx_runtime.jsx("div", {
 						className: S.footerButtons,
 						children: react_jsx_runtime.jsxs("button", {

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -36,6 +36,9 @@ if (captured.id !== "dsh-usage-stats") throw new Error(`unexpected id ${captured
 const exports_ = captured.factory((spec) => {
 	if (spec === "react") return react;
 	if (spec === "react/jsx-runtime") return jsxRuntime;
+	// react-dom/server cannot render portals; the panel portals to document.body
+	// only for theme-token scoping, so the smoke harness inlines it instead.
+	if (spec === "react-dom") return { createPortal: (node) => node };
 	if (spec === "@deepseek-ai/dsh-client-ui-primitives") return primitives;
 	throw new Error(`unexpected require: ${spec}`);
 });


### PR DESCRIPTION
## 问题 / Problem

Issue #17：安装 dsh-deep-whale（maid-atelier 女仆皮肤）后面板显示异常。实测（见下方验证）发现这是两层问题：

1. **背景透明** —— #15 已修（皮肤把 `--dsw-alias-bg-base` 设为 `transparent`）。
2. **文字对比度崩溃** —— #15 修好背景后暴露的第二个问题：皮肤在**侧边栏作用域**把 label 令牌重写为浅色（`label-primary: #f8f3e8`，适配深色侧栏），而我们的面板虽然 `position: fixed` 视觉上是浮层，DOM 却仍挂在侧边栏子树里，继承了这套浅色文字令牌；同时 `bg-overlay` 解析到全局作用域的浅色值（`#f8fafff5`）——浅色文字落在浅色背景上。

## 修复 / Fix

面板改用 `createPortal(..., document.body)` 渲染（与宿主自身 popover 的实现模式一致），DOM 脱离侧边栏子树后，CSS 自定义属性从**全局作用域**解析，肤色预设的配对关系恢复正确：

- 亮色主题：深海军蓝文字 `#172347` on 浅色 overlay `#f8fafff5` ✅
- 暗色主题：浅色文字 `#e7ecf7` on 深色 overlay `#0d193bf7` ✅
- 默认主题：令牌全局一致，行为不变 ✅

## 验证 / Verification

在本地 dsh web（0.1.0-rc.6）实装 maid-atelier 皮肤实测：

- 修复前：面板 `rgba(248,250,255,0.96)` 浅底 + `rgb(248,243,232)` 浅字，内容不可读
- 修复后：面板挂载点为 `document.body`，标题计算色 `rgb(23,35,71)` 深蓝，余额、统计、热图全部清晰可读

`react-dom` 是宿主共享模块表（`{react, react/jsx-runtime, react-dom, react-dom/client, cordis, ui-primitives...}`）中已暴露的依赖，无新增外部依赖。smoke 测试以 identity `createPortal` 桩替代（`react-dom/server` 不支持 portal 渲染）。

## 测试 / Testing

- 全部本地套件通过（bundle / smoke-client / server / balance / subscriptions / accounts / installer）

Closes #17