### PR TITLE
chore: prepare v0.2.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-usage-stats",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-usage-stats",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-usage-stats",
   "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Prepare `v0.2.1` as a compatibility and reliability release.

Release scope since `v0.2.0`:
- #10 — proxy fake-IP DNS compatibility
- #15 — glass-skin overlay background compatibility
- #16 — MiniMax Token Plan parser hardening (refs #14; reporter verification still pending)
- #11 — distinguish blocked account queries from unsupported providers
- #19 — portal the usage panel to `document.body` for theme-token scope isolation (closes #17)

This PR only bumps the package version from `0.2.0` to `0.2.1` in `package.json` and `package-lock.json`. PR #3 is intentionally deferred to `v0.2.2`.

## Release checks

- Confirm diff is version-only
- Run full CI on this head
- After merge, require green `main` CI before tagging
- Publish annotated tag `v0.2.1` and a GitHub Release
- Keep #14 open pending reporter verification