### PR TITLE
fix: support explicit late-loaded monitors and Command Code subscriptions

### DIFF
--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -39,6 +39,7 @@ const ADAPTERS = new Set([
 	"new-api",
 	"sub2api",
 	"opencode-go",
+	"command-code",
 	"zai-token-plan",
 	"kimi-token-plan",
 	"minimax-token-plan",
@@ -182,7 +183,7 @@ function defaultAdapter(provider) {
 
 function adapterMode(adapter, monitor) {
 	if (adapter === "declarative") return monitor.mode;
-	if (["opencode-go", "zai-token-plan", "kimi-token-plan", "minimax-token-plan"].includes(adapter)) return "subscription";
+	if (["opencode-go", "command-code", "zai-token-plan", "kimi-token-plan", "minimax-token-plan"].includes(adapter)) return "subscription";
 	return "balance";
 }
 
@@ -877,6 +878,7 @@ export async function queryAccount(spec, credentials, deps = {}) {
 		const subscriptionId = spec.adapter === "zai-token-plan" ? "zai"
 			: spec.adapter === "kimi-token-plan" ? "kimi"
 				: spec.adapter === "minimax-token-plan" ? "minimax"
+					: spec.adapter === "command-code" ? "command-code"
 					: "opencode-go";
 		const provider = await collectSubscription(subscriptionId, credentials, {
 			apiKeyRef: spec.apiKeyRef,
@@ -924,6 +926,24 @@ export function createAccountService({ credentials, getProviders, config = { mon
 			if (!providers.some((provider) => provider.id === "zai" || provider.id === "zai-coding-cn")) providers.push({ id: "zai", displayName: "Z.ai", apiKeyEnv: "ZAI_API_KEY", baseURL: "https://api.z.ai" });
 		}
 		const known = new Set(providers.map((provider) => provider.id));
+		// Settings-backed providers can become visible after this plugin's
+		// initial validation. A monitor with an explicit endpoint and credential
+		// reference is self-contained, so materialize it as a provider instead of
+		// failing startup on a transient provider-registry race.
+		for (const [providerId, monitor] of Object.entries(config.monitors ?? {})) {
+			if (known.has(providerId)) continue;
+			const baseURL = nonEmptyString(monitor.usageBaseURL);
+			const apiKeyEnv = nonEmptyString(monitor.credentialRef);
+			if (baseURL !== null && apiKeyEnv !== null) {
+				providers.push({
+					id: providerId,
+					displayName: nonEmptyString(monitor.displayName) ?? providerId,
+					apiKeyEnv,
+					baseURL
+				});
+				known.add(providerId);
+			}
+		}
 		const unknown = Object.keys(config.monitors ?? {}).filter((providerId) => !known.has(providerId));
 		if (unknown.length > 0) throw new Error(`account monitor references unknown provider: ${unknown.join(", ")}`);
 		return providers.map((provider) => resolveAccountSpec(provider, config));

--- a/lib/subscriptions.js
+++ b/lib/subscriptions.js
@@ -21,6 +21,7 @@ import { join } from "node:path";
 
 const OPENCODE_GO_URL = "https://opencode.ai";
 const OPENCODE_GO_USAGE_URL = `${OPENCODE_GO_URL}/zen/go/v1/usage`;
+const COMMAND_CODE_URL = "https://api.commandcode.ai";
 const ZAI_HOSTS = {
 	global: "https://api.z.ai",
 	"bigmodel-cn": "https://open.bigmodel.cn"
@@ -48,8 +49,13 @@ const REFS = {
 	zaiRegion: "ZAI_API_REGION",
 	kimiApiKey: "KIMI_API_KEY",
 	minimaxApiKey: "MINIMAX_API_KEY",
-	minimaxRegion: "MINIMAX_API_REGION"
+	minimaxRegion: "MINIMAX_API_REGION",
+	commandCodeApiKey: "COMMAND_CODE_API_KEY"
 };
+
+function nonEmptyString(value) {
+	return typeof value === "string" && value.trim() !== "" ? value.trim() : null;
+}
 
 function numberOrNull(value) {
 	if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -576,6 +582,100 @@ async function collectMiniMax(credentials, deps) {
 	}
 }
 
+function commandCodeWindow(value, kind) {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+	const cap = numberOrNull(value.cap ?? value.limit ?? value.total ?? value.quota);
+	const used = numberOrNull(value.used ?? value.consumed ?? value.usage);
+	if (cap === null || cap <= 0 || used === null) return null;
+	const usedPercent = round1(Math.max(0, Math.min(100, used / cap * 100)));
+	const resetsAt = toIso(value.resetAt ?? value.resetsAt ?? value.reset);
+	return {
+		kind,
+		usedPercent,
+		remainingPercent: round1(100 - usedPercent),
+		...(resetsAt === null ? {} : { resetsAt })
+	};
+}
+
+function commandCodePlanName(value) {
+	if (typeof value !== "string" || value.trim() === "") return void 0;
+	const key = value.trim().toLowerCase().replace(/[\\s_-]+/g, "-");
+	const names = {
+		"individual-go": "Go",
+		"individual-goat": "GOAT",
+		"individual-pro": "Pro",
+		"individual-max": "Max",
+		"individual-ultra": "Ultra",
+		"individual-provider": "Provider",
+		"teams-pro": "Team Pro"
+	};
+	return names[key] ?? value;
+}
+
+async function collectCommandCode(credentials, deps) {
+	const apiKeyRef = deps.apiKeyRef ?? REFS.commandCodeApiKey;
+	const apiKey = await resolveCredential(credentials, apiKeyRef);
+	if (apiKey === "") return {
+		id: "command-code",
+		displayName: "Command Code",
+		mode: "subscription",
+		status: "not-configured",
+		plan: void 0,
+		missingCredentials: [apiKeyRef],
+		windows: []
+	};
+	const base = (() => {
+		try { return new URL(deps.baseURL ?? COMMAND_CODE_URL).origin; }
+		catch { return COMMAND_CODE_URL; }
+	})();
+	const headers = {
+		authorization: `Bearer ${apiKey}`,
+		accept: "application/json",
+		"x-command-code-version": "0.29.0",
+		"x-cli-environment": "production"
+	};
+	try {
+		const whoami = await request(`${base}/alpha/whoami`, { headers }, deps, "json");
+		const orgId = nonEmptyString(whoami?.org?.id);
+		const suffix = orgId === null ? "" : `?orgId=${encodeURIComponent(orgId)}`;
+		const [credits, summary, subscription] = await Promise.all([
+			request(`${base}/alpha/billing/credits${suffix}`, { headers }, deps, "json"),
+			request(`${base}/alpha/usage/summary${suffix}`, { headers }, deps, "json"),
+			request(`${base}/alpha/billing/subscriptions${suffix}`, { headers }, deps, "json").catch(() => null)
+		]);
+		const totalCredits = ["monthlyCredits", "purchasedCredits", "freeCredits"]
+			.reduce((sum, key) => sum + Math.max(0, numberOrNull(credits?.credits?.[key]) ?? 0), 0);
+		const spent = Math.max(0, numberOrNull(summary?.totalCost) ?? 0);
+		const windows = [];
+		if (totalCredits > 0) {
+			const total = spent + totalCredits;
+			const usedPercent = round1(Math.max(0, Math.min(100, spent / total * 100)));
+			windows.push({ kind: "credits", usedPercent, remainingPercent: round1(100 - usedPercent) });
+		}
+		const limits = credits?.windowLimits;
+		if (limits !== null && typeof limits === "object" && !Array.isArray(limits)) {
+			for (const [key, kind] of [["fiveHour", "session"], ["weekly", "weekly"]]) {
+				const window = commandCodeWindow(limits[key], kind);
+				if (window !== null) windows.push(window);
+			}
+		}
+		const planId = subscription?.planId ?? subscription?.data?.planId ?? whoami?.planId;
+		const hasValidAccountPayload = credits?.credits !== null && typeof credits?.credits === "object"
+			&& summary !== null && typeof summary === "object";
+		return {
+			id: "command-code",
+			displayName: "Command Code",
+			mode: "subscription",
+			status: hasValidAccountPayload ? "ok" : "invalid-response",
+			plan: commandCodePlanName(planId) ?? (hasValidAccountPayload ? "No active plan" : void 0),
+			windows,
+			...(windows.length > 0 || hasValidAccountPayload ? {} : { reason: "no-usage-windows" })
+		};
+	} catch (error) {
+		return { id: "command-code", displayName: "Command Code", mode: "subscription", status: normalizedStatus(error), plan: void 0, windows: [] };
+	}
+}
+
 /** Query one subscription/token-plan adapter. */
 export async function collectSubscription(providerId, credentials, options = {}, deps = {}) {
 	const shared = {
@@ -589,6 +689,7 @@ export async function collectSubscription(providerId, credentials, options = {},
 		region: options.region
 	};
 	if (providerId === "opencode-go") return collectOpenCodeGo(credentials, shared);
+	if (providerId === "command-code" || providerId === "commandcode") return collectCommandCode(credentials, shared);
 	if (providerId === "zai") return collectZai(credentials, {
 		...shared,
 		zaiApiKeyRef: options.apiKeyRef,

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -671,4 +671,32 @@ console.log("IPv4/IPv6 private-address classification ok");
 	console.log("unknown monitor provider rejection ok");
 }
 
+{
+	const service = createAccountService({
+		credentials: credentials({ LATE_PROVIDER_API_KEY: "sk-late-provider" }),
+		getProviders: async () => [],
+		config: validateAccountConfig({ monitors: {
+			"late-provider": {
+				adapter: "sub2api",
+				usageBaseURL: "https://late-provider.example.com",
+				credentialRef: "LATE_PROVIDER_API_KEY"
+			}
+		} }),
+		deps: {
+			includeLegacyProviders: false,
+			fetch: async (url, init) => {
+				assert.equal(String(url), "https://late-provider.example.com/v1/usage");
+				assert.equal(init.headers.authorization, "Bearer sk-late-provider");
+				return jsonResponse({ mode: "unrestricted", isValid: true, remaining: 12.5, unit: "USD", balance: 12.5 });
+			}
+		}
+	});
+	const view = (await service.providerViews()).find((entry) => entry.id === "late-provider");
+	assert.equal(view?.adapter, "sub2api");
+	const account = await service.get("late-provider");
+	assert.equal(account.status, "ok");
+	assert.equal(account.balance.remaining, 12.5);
+	console.log("explicit dynamic provider monitor fallback ok");
+}
+
 console.log("ACCOUNT TESTS PASSED");

--- a/scripts/test-subscriptions.mjs
+++ b/scripts/test-subscriptions.mjs
@@ -85,6 +85,55 @@ const noLocalAuth = {
 
 {
 	const calls = [];
+	const secret = "command-code-secret";
+	const commandCode = await collectSubscription("command-code", credentials({ COMMAND_CODE_API_KEY: secret }), {}, {
+		...noLocalAuth,
+		now: () => now,
+		fetch: async (url, init) => {
+			calls.push({ url: String(url), init });
+			if (String(url).endsWith("/alpha/whoami")) return { ok: true, status: 200, json: async () => ({ org: { id: "org_test" } }) };
+			if (String(url).includes("/alpha/billing/subscriptions")) return { ok: true, status: 200, json: async () => ({ planId: "individual-pro" }) };
+			if (String(url).includes("/alpha/billing/credits")) return { ok: true, status: 200, json: async () => ({ credits: { monthlyCredits: 10, purchasedCredits: 2, freeCredits: 1 }, windowLimits: { fiveHour: { used: 2, cap: 10, resetAt: "2026-08-14T05:00:00Z" }, weekly: { used: 3, cap: 20 } } }) };
+			return { ok: true, status: 200, json: async () => ({ totalCost: 4 }) };
+		}
+	});
+	assert.equal(commandCode.status, "ok");
+	assert.equal(commandCode.plan, "Pro");
+	assert.deepEqual(commandCode.windows.map((window) => [window.kind, window.usedPercent, window.remainingPercent]), [
+		["credits", 23.5, 76.5],
+		["session", 20, 80],
+		["weekly", 15, 85]
+	]);
+	assert.deepEqual(calls.map((call) => call.url), [
+		"https://api.commandcode.ai/alpha/whoami",
+		"https://api.commandcode.ai/alpha/billing/credits?orgId=org_test",
+		"https://api.commandcode.ai/alpha/usage/summary?orgId=org_test",
+		"https://api.commandcode.ai/alpha/billing/subscriptions?orgId=org_test"
+	]);
+	assert.ok(calls.every((call) => call.init.headers.authorization === `Bearer ${secret}`));
+	assert.equal(JSON.stringify(commandCode).includes(secret), false);
+	console.log("Command Code subscription normalization ok");
+}
+
+{
+	const commandCode = await collectSubscription("command-code", credentials({ COMMAND_CODE_API_KEY: "command-code-secret" }), {}, {
+		...noLocalAuth,
+		now: () => now,
+		fetch: async (url) => {
+			if (String(url).endsWith("/alpha/whoami")) return { ok: true, status: 200, json: async () => ({ org: null }) };
+			if (String(url).includes("/alpha/billing/credits")) return { ok: true, status: 200, json: async () => ({ credits: { monthlyCredits: 0, purchasedCredits: 0, freeCredits: 0 }, windowLimits: { limited: false, fiveHour: null, weekly: null } }) };
+			if (String(url).includes("/alpha/usage/summary")) return { ok: true, status: 200, json: async () => ({ totalCost: 0 }) };
+			return { ok: true, status: 200, json: async () => ({ success: true, data: null }) };
+		}
+	});
+	assert.equal(commandCode.status, "ok");
+	assert.equal(commandCode.plan, "No active plan");
+	assert.deepEqual(commandCode.windows, []);
+	console.log("Command Code zero-credit account normalization ok");
+}
+
+{
+	const calls = [];
 	const providers = await collectSubscriptions(credentials({}), {}, {
 		homedir: () => "/users/demo",
 		readFile: async (path) => {


### PR DESCRIPTION
## Summary
- allow explicitly configured monitor endpoints to survive late-loaded provider settings
- preserve rejection for unknown monitors without an explicit HTTPS endpoint and credential reference
- add a generic delayed-provider regression test
- add the documented Command Code subscription adapter for credits, 5-hour, and weekly windows

The provider-monitor fallback is generic and does not depend on any private/custom provider name.