### PR TITLE
fix: stack host footer-actions container vertically while mounted

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -415,6 +415,7 @@ window.__ModuleLoader__.load({
 			const mountedRef = react.useRef(true);
 			const usageLoaderRef = react.useRef(null);
 			const accountLoaderRef = react.useRef(null);
+			const layerRef = react.useRef(null);
 			if (usageLoaderRef.current === null) usageLoaderRef.current = createLoader();
 			if (accountLoaderRef.current === null) accountLoaderRef.current = createLoader();
 			const providerChoices = react.useMemo(() => buildProviderChoices(providers), [providers]);
@@ -481,6 +482,29 @@ window.__ModuleLoader__.load({
 				mountedRef.current = true;
 				return () => {
 					mountedRef.current = false;
+				};
+			}, []);
+
+			// The host footer-actions container lays sidebar.footer.action list
+			// registrations out in a ROW, so two full-width entries squeeze onto
+			// one line and the later one (us) is pushed out of view (#21). Switch
+			// the container to column stacking while mounted and restore its
+			// previous inline value on unmount. Walking up (instead of targeting
+			// the host's hashed class) keeps this working across dsh versions,
+			// and a container that is already columnar is left untouched.
+			react.useEffect(() => {
+				let host = layerRef.current?.parentElement ?? null;
+				for (let depth = 0; host !== null && depth < 3; depth += 1) {
+					if (window.getComputedStyle(host).display.includes("flex")) break;
+					host = host.parentElement;
+				}
+				if (host === null) return void 0;
+				const hostStyle = window.getComputedStyle(host);
+				if (!hostStyle.display.includes("flex") || hostStyle.flexDirection === "column") return void 0;
+				const previous = host.style.flexDirection;
+				host.style.flexDirection = "column";
+				return () => {
+					host.style.flexDirection = previous;
 				};
 			}, []);
 
@@ -587,6 +611,7 @@ window.__ModuleLoader__.load({
 			});
 
 			return react_jsx_runtime.jsxs("div", {
+				ref: layerRef,
 				className: wide ? S.layer : `${S.layer} ${S.rail}`,
 				children: [
 					// Portal the panel to document.body: sidebar-scoped theme tokens

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -28,6 +28,7 @@ globalThis.document = { querySelector: () => null, createElement: () => ({ datas
 const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "lib", "client.js"), "utf8");
 if (!source.includes("/api/usage-stats/account")) throw new Error("client must use the unified account endpoint");
 if (source.includes('fetchJson("/api/usage-stats/subscriptions")')) throw new Error("client must not bulk-fetch every subscription provider");
+if (!source.includes('host.style.flexDirection = "column"')) throw new Error("client must stack the host footer-actions container vertically (#21)");
 new Function(source)(); // executes the window.__ModuleLoader__.load call
 
 if (captured === null) throw new Error("loader did not capture the bundle");


### PR DESCRIPTION
## 问题 / Problem

Issue #21：宿主 `sidebar.footer.action` 容器（`footerActions`）是**行向 flex**，内置 Cordis 面板按钮和本插件 badge 都是 `width:100% + flex:none` 的全宽条目，两个全宽子元素挤进同一行，排在后面的 usage-stats badge 被整体推出侧栏可视区，不可见也不可点；rail 模式下两个 36px 圆形图标塞进 56px 轨道同样被裁。

## 修复 / Fix

挂载时从我们的 layer 根元素**向上遍历**找到最近的 flex 容器，把它的内联 `flex-direction` 设为 `column`，卸载时还原原值：

- **不依赖宿主哈希类名**（`.hHd-Xa_footerActions`），dsh 升级后类名变化也不受影响——与 issue 建议的方案一致
- 容器已是列向时直接跳过，不打扰宿主或其他插件
- 遍历上限 3 层，找不到 flex 容器时安全退出

## 验证 / Verification

- 本地 dsh 0.1.0-rc.6 实测：effect 精确定位到宿主 `footerActions` 容器，`flex-direction` 成功切为 `column`；多个注册项将竖向堆叠
- 新增源码级回归断言（smoke-client）：防止该机制被意外移除
- 全部本地套件通过（bundle / smoke-client / server / balance / subscriptions / accounts / installer）

## 备注

PR #3 中针对同一问题的哈希类名 CSS 补丁（`fe48e35`）在本 PR 合并后可以删除——这条路径更稳。

Closes #21