### PR TITLE
fix: refold live sessions when DSH restores a compressed log

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -254,7 +254,10 @@ function withLock(run) {
 /**
  * Collect per-day usage across live and persisted sessions, incrementally.
  *
- * Live sessions: fold only the in-memory events added since the last fold.
+ * Live sessions: fold only the in-memory events added since the last fold;
+ * an in-memory log that SHRANK below the folded cursor was rebuilt (DSH
+ * restores compressed summaries after a restart), so the session is refolded
+ * from scratch instead of freezing its stats (#23).
  * Persisted sessions: skipped when the backend's opaque revision is
  * unchanged (`sessionPersistence.listSnapshots`, falling back to always
  * reading the delta); when the revision changes, the new events are verified
@@ -280,6 +283,18 @@ export async function collectUsage(ctx) {
 					state.consumed = 0;
 				}
 				const count = session.events.length;
+				if (count < (state.consumed ?? 0)) {
+					// The in-memory log shrank below the folded cursor — DSH
+					// restores sessions from disk as compressed summaries after
+					// a restart, so a positional cursor from the pre-restart
+					// full log would silently freeze this session's stats
+					// forever (#23). The cursor is meaningless against the
+					// rebuilt log: refold it from scratch.
+					state.days = new Map();
+					state.lastSample = null;
+					state.currentModel = null;
+					state.consumed = 0;
+				}
 				if ((state.consumed ?? 0) < count) {
 					applyUsageDelta(state, session.events.slice(state.consumed ?? 0));
 					state.consumed = count;

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -248,6 +248,10 @@ export function renderUsage(byDay, updatedAt) {
 					tokens: totalTokens(buckets),
 					cacheHitRate: cacheHitRate(buckets)
 				}))
+				// All-zero buckets come from warmup requests that report
+				// {input:0, output:0}; rendering them produces empty "0 tokens"
+				// model rows (#23).
+				.filter((entry) => entry.tokens > 0)
 				.sort((a, b) => b.tokens - a.tokens);
 			return {
 				date,

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -190,6 +190,48 @@ async function testRevisionRewrite(root) {
 	assert.equal(reads, 3, "rewrite detection must retry from seq 0");
 }
 
+async function testLiveLogShrink(root) {
+	const plugin = await freshModule("shrink", join(root, "shrink"));
+	const id = "shrink-session";
+	const persistence = { listSnapshots: async () => [], list: async () => [] };
+	// Pre-restart: the full live log is folded positionally.
+	let events = [usageEvent(1, 5), usageEvent(2, 7), usageEvent(3, 11)];
+	const sessions = { list: () => [{ id, events }] };
+	const ctx = makeContext({ sessions, persistence });
+	assert.equal((await plugin.collectUsage(ctx)).total.tokens, 23);
+	// DSH restart restores the session as a SHORTER compressed summary while
+	// the folded cursor still points past the summary's end (#23): the session
+	// must refold from the summary instead of freezing its stats forever.
+	events = [usageEvent(1, 5), usageEvent(3, 11)];
+	assert.equal((await plugin.collectUsage(ctx)).total.tokens, 16, "a shrunk live log must refold instead of freezing");
+	events = [...events, usageEvent(4, 13)];
+	assert.equal((await plugin.collectUsage(ctx)).total.tokens, 29, "new events after a restored summary must keep counting");
+}
+
+async function testZeroUsageRowsFiltered(root) {
+	const plugin = await freshModule("zero-rows", join(root, "zero-rows"));
+	// Warmup requests report an all-zero usage sample; the model bucket they
+	// create must not render as an empty "0 tokens" row (#23).
+	const zero = {
+		seq: 1,
+		time: Date.UTC(2026, 7, 13),
+		type: "assistant/message",
+		data: {
+			turn: "turn-1",
+			step: 0,
+			usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+			message: { source: { model: "modlens-opencode/deepseek-v4-flash-free" } }
+		}
+	};
+	const sessions = { list: () => [{ id: "zero-session", events: [zero, usageEvent(2, 9)] }] };
+	const ctx = makeContext({ sessions, persistence: { listSnapshots: async () => [], list: async () => [] } });
+	const usage = await plugin.collectUsage(ctx);
+	assert.equal(usage.total.tokens, 9);
+	const day = usage.days.find((entry) => entry.date === "2026-08-13");
+	assert.equal(day.models.length, 1, "all-zero model buckets must not render as rows");
+	assert.equal(day.models[0].model, "unknown/deepseek-chat");
+}
+
 const root = await mkdtemp(join(tmpdir(), "dsh-usage-stats-"));
 try {
 	await testRouteFence(root);
@@ -198,6 +240,8 @@ try {
 	await testBackgroundRefresh(root);
 	await testPersistedToLive(root);
 	await testRevisionRewrite(root);
+	await testLiveLogShrink(root);
+	await testZeroUsageRowsFiltered(root);
 	console.log("SERVER REGRESSION TESTS PASSED");
 } finally {
 	delete process.env.DSH_HOME;


### PR DESCRIPTION
## 根因

`collectUsage` 的 live 分支用**数组长度**当增量游标（`consumed < events.length → slice(consumed)`）。DSH 重启后会把内存中的 session 事件日志重建成**压缩摘要**，数组长度可能远小于重启前已折叠的游标（#23 报告者实测：7215 条 vs 缓存游标 120287），于是 `count < consumed` 恒不成立，该会话的统计永久冻结。

## 修复

1. **`lib/index.js`**：live 分支在计算 `count` 后检测回退——`count < state.consumed` 说明内存日志被重建、位置游标已失效，此时清空该会话的折叠状态并从头 refold，而不是继续冻结。
2. **`lib/usage.js`**：`renderUsage` 过滤全 0 的模型桶。预热请求会上报 `{inputTokens:0, outputTokens:0}`，产生只有 0 tokens 的空模型行（#23 的次要问题）。

## 测试

- 新增 `testLiveLogShrink`：3 条事件折叠后收缩到 2 条，total 从 23 正确变为 16（而非冻结），后续新增事件继续累计到 29。
- 新增 `testZeroUsageRowsFiltered`：全 0 样本的模型桶不出现在渲染结果中。
- 本地 7 个测试脚本全部通过。

Closes #23