### PR TITLE
chore: prepare v0.2.2 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-usage-stats",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-usage-stats",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-usage-stats",
   "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prepare v0.2.2 from the current main.

## Scope
- #25 / #21 — stack multiple sidebar footer actions vertically without relying on hashed host CSS classes.
- #27 / #23 — recover token aggregation after DSH restarts with compressed live-session logs; hide all-zero model rows.
- #3 — show account balance or the lowest remaining subscription quota directly in the collapsed sidebar badge, with stale-data suppression and low-balance warnings.

PR #24 is intentionally excluded and deferred to v0.2.3.

This release PR only bumps package metadata from 0.2.1 to 0.2.2.