### PR TITLE
fix: materialize self-contained monitors for late-loaded providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Z.ai 全球区使用 `api.z.ai`，中国区使用 `open.bigmodel.cn`。MiniMax �
 
 ### New API、Sub2API 与自定义 monitor
 
-在现有 `name: dsh-usage-stats` Cordis entry 下合并 `config`，不要追加第二个插件 entry。monitor 键必须是 Harness 中真实存在的 provider id；未知 provider、adapter 或非法映射会在路由和 timer 注册前阻止插件启动。
+在现有 `name: dsh-usage-stats` Cordis entry 下合并 `config`，不要追加第二个插件 entry。monitor 键必须是 Harness 中真实存在的 provider id；未知 provider、adapter 或非法映射会在路由和 timer 注册前阻止插件启动。例外：monitor 同时显式提供 `usageBaseURL` 与 `credentialRef` 时视为自包含，会在 provider 注册可见前临时物化为 provider（适用于 Harness 设置页里后加载的 provider），此时不要求该 provider 已出现在注册表中。
 
 <details>
 <summary><strong>展开 monitor 配置示例</strong></summary>

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -924,6 +924,24 @@ export function createAccountService({ credentials, getProviders, config = { mon
 			if (!providers.some((provider) => provider.id === "zai" || provider.id === "zai-coding-cn")) providers.push({ id: "zai", displayName: "Z.ai", apiKeyEnv: "ZAI_API_KEY", baseURL: "https://api.z.ai" });
 		}
 		const known = new Set(providers.map((provider) => provider.id));
+		// Settings-backed providers can become visible after this plugin's
+		// initial validation. A monitor with an explicit endpoint and credential
+		// reference is self-contained, so materialize it as a provider instead of
+		// failing startup on a transient provider-registry race.
+		for (const [providerId, monitor] of Object.entries(config.monitors ?? {})) {
+			if (known.has(providerId)) continue;
+			const baseURL = nonEmptyString(monitor.usageBaseURL);
+			const apiKeyEnv = nonEmptyString(monitor.credentialRef);
+			if (baseURL !== null && apiKeyEnv !== null) {
+				providers.push({
+					id: providerId,
+					displayName: nonEmptyString(monitor.displayName) ?? providerId,
+					apiKeyEnv,
+					baseURL
+				});
+				known.add(providerId);
+			}
+		}
 		const unknown = Object.keys(config.monitors ?? {}).filter((providerId) => !known.has(providerId));
 		if (unknown.length > 0) throw new Error(`account monitor references unknown provider: ${unknown.join(", ")}`);
 		return providers.map((provider) => resolveAccountSpec(provider, config));

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -671,4 +671,32 @@ console.log("IPv4/IPv6 private-address classification ok");
 	console.log("unknown monitor provider rejection ok");
 }
 
+{
+	const service = createAccountService({
+		credentials: credentials({ LATE_PROVIDER_API_KEY: "sk-late-provider" }),
+		getProviders: async () => [],
+		config: validateAccountConfig({ monitors: {
+			"late-provider": {
+				adapter: "sub2api",
+				usageBaseURL: "https://late-provider.example.com",
+				credentialRef: "LATE_PROVIDER_API_KEY"
+			}
+		} }),
+		deps: {
+			includeLegacyProviders: false,
+			fetch: async (url, init) => {
+				assert.equal(String(url), "https://late-provider.example.com/v1/usage");
+				assert.equal(init.headers.authorization, "Bearer sk-late-provider");
+				return jsonResponse({ mode: "unrestricted", isValid: true, remaining: 12.5, unit: "USD", balance: 12.5 });
+			}
+		}
+	});
+	const view = (await service.providerViews()).find((entry) => entry.id === "late-provider");
+	assert.equal(view?.adapter, "sub2api");
+	const account = await service.get("late-provider");
+	assert.equal(account.status, "ok");
+	assert.equal(account.balance.remaining, 12.5);
+	console.log("explicit dynamic provider monitor fallback ok");
+}
+
 console.log("ACCOUNT TESTS PASSED");


### PR DESCRIPTION
## Summary

Split out from #24 per the maintainer's review feedback to keep the mature part moving independently:

- A monitor with an explicit `usageBaseURL` + `credentialRef` is self-contained: when a settings-backed provider becomes visible only after this plugin's initial validation, materialize it as a provider instead of failing startup on a transient provider-registry race.
- The narrower rule is documented in the README; monitors without an explicit self-contained endpoint still keep the existing "unknown provider blocks startup" behavior (regression-tested).
- Rebased on the latest `main` (includes #27 and #3).

## Tests

`node scripts/test-accounts.mjs` passes locally, including the new `explicit dynamic provider monitor fallback ok` case.

The Command Code adapter (the other half of #24) is not part of this PR and will be re-submitted separately.
