### PR TITLE
chore: prepare v0.2.3 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-usage-stats",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-usage-stats",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"
@@ -39,7 +39,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5gLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "resolved": "https://registry.npmmirror.com/react-dom/-/react-18.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5gLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -51,7 +51,7 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-18.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-usage-stats",
   "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prepare `v0.2.3` from the current validated `main`.

## Scope
- #29 — allow explicitly configured self-contained account monitors (`usageBaseURL` + `credentialRef`) to survive late provider-registration timing without weakening the existing unknown-provider/security checks.
- #32 / #30 — keep the portaled usage panel above sidebar workbench plugins by moving it to the normal DSH overlay layer; adds a dedicated layering regression test.

## Suggested release notes

### Compatibility and reliability
- **Late-loaded provider monitors** — self-contained monitors with an explicit endpoint and credential reference can now initialize even when Harness exposes their provider settings after the plugin's initial validation. Existing unknown-provider rejection and request safety policies remain intact.
- **Sidebar workbench compatibility** — the usage panel now stays above bottom/right sidebar workbenches such as DSH-better-sidebar while remaining below DSH modal/menu overlay layers. Fixes #30.

## Release checks
- version-only diff in `package.json` / `package-lock.json`: `0.2.2` → `0.2.3`
- require full CI green on this head before merge
- after merge, tag/release from the exact final `main` commit

No new provider adapter or feature work is included in this patch release.