### PR TITLE
chore: prepare v0.2.4 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-usage-stats",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-usage-stats",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-usage-stats",
   "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prepare `v0.2.4` as a focused stability and interaction patch.

## Scope

- #35 / #34 — preserve all DNS answers that pass the existing account-monitor network policy and safely fall back across those pinned candidates when one address family is unreachable. IPv4-only, IPv6-only, WSL2/no-IPv6-route, private-network and fake-IP safety behavior are regression-tested. All validated addresses failing now degrades to a normalized `unavailable` snapshot instead of escaping the monitor.
- #36 — dismiss the portaled usage panel when the user clicks outside it or presses Escape, while clicks inside the panel/sidebar badge remain safe. The existing close button is retained in this patch release.
- #36 — surface only bounded, credential-filtered account diagnostic reasons; localize `dns-resolution-failed` and `all-addresses-unreachable` so failures are easier to report without leaking secrets.

## Release checks

- version-only diff in `package.json` / `package-lock.json`: `0.2.3` → `0.2.4`;
- require full CI green on this exact head before merge;
- after merge, require final `main` CI green before tagging/releasing;
- no #18/#20 current-session feature work or new provider adapters in this patch release.