### PR TITLE
feat: add real Sub2API panel balance via sub2api-auth adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ npx --yes github:Ychris12138/dsh-usage-stats --no-enable
 | MiniMax Coding Plan | 订阅 | `MINIMAX_API_KEY` | `/v1/token_plan/remains` |
 | New API | 余额 | provider 推理 Token | `/api/usage/token/` |
 | Sub2API / Passion | 自动判别 | provider `apiKeyEnv` | `/v1/usage` |
-| Sub2API 面板（真实） | 余额 | 面板账号 或 JWT | `/api/v1/auth/me` |
+| Sub2API 面板（真实） | 余额 | provider 推理 Token | `/user/balance`（复用 apiKey） |
 | General / Declarative | 余额或订阅 | 配置中的 credential ref | 受限 GET + JSON |
 
 没有公开账户接口的供应商仍会正常统计 Token；账户卡片会明确显示“不支持”，不会猜测余额。
@@ -175,35 +175,24 @@ Sub2API 风格 `/v1/usage`：
               criticalBelow: 1
 ```
 
-> 注意：`sub2api` 适配器对应一部分 Sub2API 部署暴露的 `/v1/usage` 协议。真实 Sub2API 面板（Wei-Shaw/sub2api 系）不提供该公开接口，改用 `sub2api-auth` 适配器读取面板自己的账号余额（见下）。
+> 注意：`sub2api` 适配器对应一部分 Sub2API 部署暴露的 `/v1/usage` 协议。真实 Sub2API 面板（Wei-Shaw/sub2api 系）不提供该公开接口，改用 `sub2api-auth` 适配器读取面板自己的余额（见下）。
 
-**真实 Sub2API 面板余额（`sub2api-auth`）**：Sub2API 面板把上游订阅统一暴露成 API，但上游供应商通常没有公开余额接口。面板自己会维护一个美元余额（非订阅制账号），位于 `GET /api/v1/auth/me`，需要面板的 dashboard 会话。`sub2api-auth` 用两种方式之一取到短效访问令牌：
+**真实 Sub2API 面板余额（`sub2api-auth`）**：Sub2API 面板把上游订阅统一暴露成 API，但上游供应商通常没有公开余额接口。`sub2api-auth` 用 provider 自己的推理 API Key 查询面板余额，同 CC Switch 的 General 模板：`GET {baseUrl}/user/balance`，`Authorization: Bearer {apiKey}`，读取 `body.balance`。**无需单独的面板凭据** —— provider 在 DSH 模型页里配置的那个 API Key 会被直接复用：
 
 ```yaml
         monitors:
           relay-b:
             adapter: sub2api-auth
-            # 方式一：面板账号登录（推荐），用户名/密码经 credential ref 注入
-            usernameRef: SUB2API_EMAIL
-            passwordRef: SUB2API_PASSWORD
-```
-```yaml
-          relay-b:
-            adapter: sub2api-auth
-            # 方式二：复用已有的访问令牌（无需保存面板密码）
-            accessTokenRef: SUB2API_ACCESS_TOKEN
 ```
 
-dashboard 令牌是短效的；`sub2api-auth` 只在进程内存中维护当前令牌，401 时用面板密码重新登录，**不会把令牌或密码写入磁盘缓存、浏览器响应或日志**。关闭插件进程后内存令牌即失效，下次按需重新认证。
+（可选）若 `/user/balance` 返回 UTF-8 金额对应 `body.unit`，会显示该币种；否则默认 USD。今日已用额度尽量从 `GET /api/v1/usage/stats?period=today` 的 `total_actual_cost` 补充，查询不到也不影响余额展示。
+
+**自动识别真实 Sub2API 面板（`sub2api-auth`）**：只要把 Sub2API 面板作为普通 provider 配置进 DSH（带入它的 API Key），插件会探测该 provider 的 `GET /api/v1/settings/public`。若指纹命中真实 Sub2API 面板（返回 `data.affiliate_enabled: boolean`），就自动按 `sub2api-auth` 用该 provider 的 API Key 读取余额，**无需为该 provider 单独写 `adapter`，也无需额外凭据**。显式 `adapter` 始终优先于自动识别；没有配置 API Key 的 provider 绝不会被探测。
 
 ```yaml
-# ~/.dsh/.credentials.yaml
-SUB2API_EMAIL: you-account@panel.example
-SUB2API_PASSWORD: your-panel-password
-SUB2API_ACCESS_TOKEN: <可选，面板登录后得到的短效 JWT>
+# 只要这些（不需要单独的 SUB2API_* 凭据）
+# DSH 模型页里为 Sub2API 面板配置 provider，baseURL 指向面板，API Key 填可用的密钥
 ```
-
-**自动识别真实 Sub2API 面板（`sub2api-auth`）**：只要在任何 Harness provider 里配置了 Sub2API 面板，并在 `~/.dsh/.credentials.yaml` 提供上面的 `SUB2API_EMAIL` + `SUB2API_PASSWORD`（或 `SUB2API_ACCESS_TOKEN`），插件会启动时探测该 provider 的 `GET /api/v1/settings/public`。若指纹命中真实 Sub2API 面板（返回 `data.affiliate_enabled: boolean`），则自动按 `sub2api-auth` 读取该面板的账号余额，无需为该 provider 单独写 `adapter`。显式 `adapter` 始终优先于自动识别；未配置面板凭据时绝不会发起探测请求。
 
 Passion（provider id 为 `passion` 或域名为 `*.passionapi.com`）会自动识别。钱包响应显示余额；`quota_limited` 或包含 `subscription` 的响应自动切换为额度窗口。
 
@@ -294,7 +283,7 @@ npx --yes github:Ychris12138/dsh-usage-stats --check
 ## 隐私与安全 / Privacy & security
 
 - API Key、OpenCode `auth.json`、Cookie 与管理 PAT 不会进入浏览器响应、插件缓存或日志。
-- Sub2API 面板短效 JWT（`sub2api-auth`）只保存在进程内存，401 时用面板密码重新登录；令牌与面板密码同样不进浏览器响应、磁盘缓存或日志。
+- Sub2API `sub2api-auth` 复用 provider 自己的推理 API Key（模型页已配置的那个），不会再引入或落盘额外的面板凭据。
 - 自定义 monitor 默认要求 HTTPS、同源相对路径、手动 redirect 和 JSON 响应，body 上限为 1 MiB。
 - 发凭据前会筛选域名的 IPv4/IPv6 解析结果并固定一个允许的连接地址，优先使用公网地址；HTTPS 域名解析到 `198.18.0.0/15` 时可作为 Clash/Mihomo 等代理的 synthetic fake-IP 使用。字面量 `198.18/15`、其他私网/特殊地址仍默认拒绝，防止 DNS rebinding 绕过私网限制。
 - `usageBaseURL` 禁止内嵌 username/password；`Authorization`、`X-API-Key`、`API-Key` 等 header 必须由 credential ref 注入。

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ SUB2API_PASSWORD: your-panel-password
 SUB2API_ACCESS_TOKEN: <可选，面板登录后得到的短效 JWT>
 ```
 
+**自动识别真实 Sub2API 面板（`sub2api-auth`）**：只要在任何 Harness provider 里配置了 Sub2API 面板，并在 `~/.dsh/.credentials.yaml` 提供上面的 `SUB2API_EMAIL` + `SUB2API_PASSWORD`（或 `SUB2API_ACCESS_TOKEN`），插件会启动时探测该 provider 的 `GET /api/v1/settings/public`。若指纹命中真实 Sub2API 面板（返回 `data.affiliate_enabled: boolean`），则自动按 `sub2api-auth` 读取该面板的账号余额，无需为该 provider 单独写 `adapter`。显式 `adapter` 始终优先于自动识别；未配置面板凭据时绝不会发起探测请求。
+
 Passion（provider id 为 `passion` 或域名为 `*.passionapi.com`）会自动识别。钱包响应显示余额；`quota_limited` 或包含 `subscription` 的响应自动切换为额度窗口。
 
 声明式自定义查询只支持受限 GET + JSON Pointer，不执行 JavaScript：

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ npx --yes github:Ychris12138/dsh-usage-stats --no-enable
 | MiniMax Coding Plan | 订阅 | `MINIMAX_API_KEY` | `/v1/token_plan/remains` |
 | New API | 余额 | provider 推理 Token | `/api/usage/token/` |
 | Sub2API / Passion | 自动判别 | provider `apiKeyEnv` | `/v1/usage` |
+| Sub2API 面板（真实） | 余额 | 面板账号 或 JWT | `/api/v1/auth/me` |
 | General / Declarative | 余额或订阅 | 配置中的 credential ref | 受限 GET + JSON |
 
 没有公开账户接口的供应商仍会正常统计 Token；账户卡片会明确显示“不支持”，不会猜测余额。
@@ -174,6 +175,34 @@ Sub2API 风格 `/v1/usage`：
               criticalBelow: 1
 ```
 
+> 注意：`sub2api` 适配器对应一部分 Sub2API 部署暴露的 `/v1/usage` 协议。真实 Sub2API 面板（Wei-Shaw/sub2api 系）不提供该公开接口，改用 `sub2api-auth` 适配器读取面板自己的账号余额（见下）。
+
+**真实 Sub2API 面板余额（`sub2api-auth`）**：Sub2API 面板把上游订阅统一暴露成 API，但上游供应商通常没有公开余额接口。面板自己会维护一个美元余额（非订阅制账号），位于 `GET /api/v1/auth/me`，需要面板的 dashboard 会话。`sub2api-auth` 用两种方式之一取到短效访问令牌：
+
+```yaml
+        monitors:
+          relay-b:
+            adapter: sub2api-auth
+            # 方式一：面板账号登录（推荐），用户名/密码经 credential ref 注入
+            usernameRef: SUB2API_EMAIL
+            passwordRef: SUB2API_PASSWORD
+```
+```yaml
+          relay-b:
+            adapter: sub2api-auth
+            # 方式二：复用已有的访问令牌（无需保存面板密码）
+            accessTokenRef: SUB2API_ACCESS_TOKEN
+```
+
+dashboard 令牌是短效的；`sub2api-auth` 只在进程内存中维护当前令牌，401 时用面板密码重新登录，**不会把令牌或密码写入磁盘缓存、浏览器响应或日志**。关闭插件进程后内存令牌即失效，下次按需重新认证。
+
+```yaml
+# ~/.dsh/.credentials.yaml
+SUB2API_EMAIL: you-account@panel.example
+SUB2API_PASSWORD: your-panel-password
+SUB2API_ACCESS_TOKEN: <可选，面板登录后得到的短效 JWT>
+```
+
 Passion（provider id 为 `passion` 或域名为 `*.passionapi.com`）会自动识别。钱包响应显示余额；`quota_limited` 或包含 `subscription` 的响应自动切换为额度窗口。
 
 声明式自定义查询只支持受限 GET + JSON Pointer，不执行 JavaScript：
@@ -198,7 +227,7 @@ Passion（provider id 为 `passion` 或域名为 `*.passionapi.com`）会自动�
 
 </details>
 
-支持的 adapter：`deepseek-balance`、`openrouter-balance`、`moonshot-balance`、`zai-balance`、`new-api`、`sub2api`、`general`、`opencode-go`、`zai-token-plan`、`kimi-token-plan`、`minimax-token-plan`、`declarative`。
+支持的 adapter：`deepseek-balance`、`openrouter-balance`、`moonshot-balance`、`zai-balance`、`new-api`、`sub2api`、`sub2api-auth`、`general`、`opencode-go`、`zai-token-plan`、`kimi-token-plan`、`minimax-token-plan`、`declarative`。
 
 `warning.warnBelow` 与 `warning.criticalBelow` 是余额绝对值阈值。具有总额度的余额和 Token Plan 会自动产生 `normal / warning / critical` 剩余比例状态（默认 30% / 10%）。
 
@@ -263,6 +292,7 @@ npx --yes github:Ychris12138/dsh-usage-stats --check
 ## 隐私与安全 / Privacy & security
 
 - API Key、OpenCode `auth.json`、Cookie 与管理 PAT 不会进入浏览器响应、插件缓存或日志。
+- Sub2API 面板短效 JWT（`sub2api-auth`）只保存在进程内存，401 时用面板密码重新登录；令牌与面板密码同样不进浏览器响应、磁盘缓存或日志。
 - 自定义 monitor 默认要求 HTTPS、同源相对路径、手动 redirect 和 JSON 响应，body 上限为 1 MiB。
 - 发凭据前会筛选域名的 IPv4/IPv6 解析结果并固定一个允许的连接地址，优先使用公网地址；HTTPS 域名解析到 `198.18.0.0/15` 时可作为 Clash/Mihomo 等代理的 synthetic fake-IP 使用。字面量 `198.18/15`、其他私网/特殊地址仍默认拒绝，防止 DNS rebinding 绕过私网限制。
 - `usageBaseURL` 禁止内嵌 username/password；`Authorization`、`X-API-Key`、`API-Key` 等 header 必须由 credential ref 注入。

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -20,6 +20,12 @@ const DEFAULT_TIMEOUT_MS = 15000;
 const DEFAULT_REFRESH_MS = 300000;
 const MAX_RESPONSE_BYTES = 1024 * 1024;
 const OPENROUTER_MANAGEMENT_REF = "OPENROUTER_MANAGEMENT_KEY";
+const SUB2API_LOGIN_PATH = "/api/v1/auth/login";
+const SUB2API_AUTH_ME_PATH = "/api/v1/auth/me";
+/** Sub2API dashboard JWTs are short-lived; re-authenticate when a request is rejected. */
+const SUB2API_ACCESS_TOKEN_REF = "accessTokenRef";
+const SUB2API_USERNAME_REF = "usernameRef";
+const SUB2API_PASSWORD_REF = "passwordRef";
 const ACCOUNT_STATUSES = new Set([
 	"ok",
 	"not-configured",
@@ -38,6 +44,7 @@ const ADAPTERS = new Set([
 	"general",
 	"new-api",
 	"sub2api",
+	"sub2api-auth",
 	"opencode-go",
 	"zai-token-plan",
 	"kimi-token-plan",
@@ -210,6 +217,20 @@ function validatePointer(pointer, label) {
 	if (typeof value !== "string" || value !== "" && !value.startsWith("/")) throw new Error(`${label} must be a JSON Pointer`);
 }
 
+function validateSub2ApiAuth(monitor, label) {
+	const refs = [SUB2API_ACCESS_TOKEN_REF, SUB2API_USERNAME_REF, SUB2API_PASSWORD_REF];
+	for (const ref of refs) {
+		if (monitor[ref] !== void 0 && nonEmptyString(monitor[ref]) === null) {
+			throw new Error(`${label}.${ref} must be a credential reference name`);
+		}
+	}
+	// A dashboard session needs either a pre-issued token or the account login.
+	if (monitor[SUB2API_ACCESS_TOKEN_REF] === void 0
+		&& (monitor[SUB2API_USERNAME_REF] === void 0 || monitor[SUB2API_PASSWORD_REF] === void 0)) {
+		throw new Error(`${label}.sub2api-auth requires accessTokenRef or both usernameRef and passwordRef`);
+	}
+}
+
 function validateWarning(value, label) {
 	if (value === void 0) return;
 	if (value === null || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
@@ -260,6 +281,7 @@ export function validateAccountConfig(raw = {}) {
 		}
 		validateWarning(value.warning, `${label}.warning`);
 		if (adapter === "declarative") validateDeclarative(value, label);
+		if (adapter === "sub2api-auth") validateSub2ApiAuth(value, label);
 		normalized[providerId] = { ...value, providerId, adapter };
 	}
 	return { monitors: normalized };
@@ -277,7 +299,12 @@ export function resolveAccountSpec(provider, config = { monitors: {} }) {
 		displayName: provider.displayName ?? provider.id,
 		adapter,
 		mode,
-		apiKeyRef,
+		// The apiKeyRef doubles as the "configured" indicator in provider views;
+		// sub2api-auth authenticates with a dashboard account, so surface its
+		// access-token (or username) ref instead of the inference key env.
+		apiKeyRef: adapter === "sub2api-auth"
+			? monitor[SUB2API_ACCESS_TOKEN_REF] ?? monitor[SUB2API_USERNAME_REF] ?? apiKeyRef
+			: apiKeyRef,
 		baseURL: monitor.usageBaseURL ?? provider.baseURL,
 		providerBaseURL: provider.baseURL,
 		monitor,
@@ -479,6 +506,7 @@ function crossOriginSensitive(spec) {
 	return spec.monitor.usageBaseURL !== void 0
 		|| spec.adapter === "general"
 		|| spec.adapter === "new-api"
+		|| spec.adapter === "sub2api-auth"
 		|| spec.adapter === "declarative"
 		|| schemeOfAdapter(spec.adapter ?? "") !== null;
 }
@@ -849,6 +877,149 @@ async function querySub2Api(spec, credential, deps, now) {
 	};
 }
 
+/**
+ * Parse the Sub2API dashboard `{ code, message, data }` envelope.
+ *
+ * Sub2API reports business failures with HTTP 200 and a non-zero `code`, and
+ * envelopes can be missing entirely on some endpoints, so callers decide how
+ * strictly to validate the `data` payload. `code === 0` means success.
+ */
+function sub2apiEnvelope(body) {
+	if (body === null || typeof body !== "object" || Array.isArray(body)) throw statusError("invalid-response", "Sub2API response must be an object");
+	const code = body.code;
+	const message = typeof body.message === "string" ? body.message : "";
+	if (code !== 0) {
+		const err = statusError("invalid-response", message !== "" ? `Sub2API: ${message}` : "Sub2API returned a business error");
+		if (/invalid|unauthor|password|credential|login|expired|refresh/i.test(message)) err.providerStatus = "unauthorized";
+		throw err;
+	}
+	return body;
+}
+
+/** The per-process Sub2API dashboard sessions, retained across background refreshes. */
+function sub2apiSessions(deps) {
+	if (deps.sessions === void 0 || deps.sessions === null) deps.sessions = new Map();
+	return deps.sessions;
+}
+
+/** Log into a Sub2API dashboard and return the short-lived access token. */
+async function sub2apiLogin(spec, username, password, deps) {
+	const body = await requestJson(new URL(SUB2API_LOGIN_PATH, spec.baseURL).href, {
+		method: "POST",
+		headers: { "content-type": "application/json", accept: "application/json" },
+		body: JSON.stringify({ email: username, password })
+	}, deps);
+	const envelope = sub2apiEnvelope(body);
+	const token = nonEmptyString(envelope.data?.access_token);
+	if (token === null) throw statusError("unauthorized", "Sub2API login did not return an access token");
+	return token;
+}
+
+/**
+ * Resolve the dashboard access token for a `sub2api-auth` monitor.
+ *
+ * A pre-issued `accessTokenRef` wins when non-empty (it can be rotated by the
+ * user without storing the panel password). Otherwise the account `usernameRef`
+ * + `passwordRef` are used to log in. The token is held only in the process
+ * memory session map and is never written to the usage cache, browser response,
+ * or logs. Login-on-demand keeps short-lived JWTs valid without persisting a
+ * refresh token to disk.
+ */
+async function sub2apiToken(spec, credentials, deps, forceLogin = false) {
+	const sessions = sub2apiSessions(deps);
+	const key = spec.configKey;
+	const cached = sessions.get(key);
+	if (cached !== void 0 && !forceLogin) return cached.accessToken;
+
+	const staticToken = await resolveCredential(credentials, spec.monitor[SUB2API_ACCESS_TOKEN_REF]);
+	if (staticToken !== "" && !forceLogin) {
+		sessions.set(key, { accessToken: staticToken });
+		return staticToken;
+	}
+
+	if (forceLogin) sessions.delete(key);
+	const username = await resolveCredential(credentials, spec.monitor[SUB2API_USERNAME_REF]);
+	const password = await resolveCredential(credentials, spec.monitor[SUB2API_PASSWORD_REF]);
+	if (username === "" || password === "") {
+		if (cached !== void 0) sessions.delete(key);
+		return "";
+	}
+	const token = await sub2apiLogin(spec, username, password, deps);
+	sessions.set(key, { accessToken: token });
+	return token;
+}
+
+/** Query the verified dashboard for the user's own balance (USD) and today's usage. */
+async function querySub2ApiAuth(spec, credentials, deps, now) {
+	const authRefs = [SUB2API_ACCESS_TOKEN_REF, SUB2API_USERNAME_REF, SUB2API_PASSWORD_REF];
+	if (spec.monitor[SUB2API_ACCESS_TOKEN_REF] === void 0
+		&& (spec.monitor[SUB2API_USERNAME_REF] === void 0 || spec.monitor[SUB2API_PASSWORD_REF] === void 0)) {
+		return unavailableSnapshot(spec, "not-configured", now, {
+			missingCredentials: authRefs.filter((ref) => spec.monitor[ref] === void 0)
+		});
+	}
+
+	let token = await sub2apiToken(spec, credentials, deps, false);
+	if (token === "") return unavailableSnapshot(spec, "not-configured", now, { missingCredentials: authRefs });
+
+	const queryMe = async (accessToken) => requestJson(new URL(SUB2API_AUTH_ME_PATH, spec.baseURL).href, {
+		headers: { authorization: `Bearer ${accessToken}`, accept: "application/json" }
+	}, deps);
+
+	let envelope;
+	try {
+		envelope = sub2apiEnvelope(await queryMe(token));
+	} catch (error) {
+		const rejected = error?.httpStatus === 401 || error?.providerStatus === "unauthorized";
+		if (!rejected) throw error;
+		// A stale dashboard JWT is the common case; re-authenticate once with the
+		// panel account and retry before reporting unauthorized. This never
+		// downgrades to the provider's inference/static key as a fallback.
+		const reauth = await sub2apiToken(spec, credentials, deps, true);
+		if (reauth === "") return unavailableSnapshot(spec, "unauthorized", now);
+		try {
+			envelope = sub2apiEnvelope(await queryMe(reauth));
+		} catch (retryError) {
+			if (retryError?.httpStatus !== 401 && retryError?.providerStatus !== "unauthorized") throw retryError;
+			return unavailableSnapshot(spec, "unauthorized", now);
+		}
+	}
+
+	const data = envelope.data;
+	if (data === null || typeof data !== "object" || Array.isArray(data)) throw statusError("invalid-response", "Sub2API auth/me is missing account data");
+	const remaining = numberOrNull(data.balance);
+	if (remaining === null) throw statusError("invalid-response", "Sub2API auth/me is missing a numeric balance");
+
+	// Today's usage is optional; when unavailable the account still shows balance.
+	let used = null;
+	try {
+		const usage = sub2apiEnvelope(await requestJson(new URL("/api/v1/usage/stats?period=today", spec.baseURL).href, {
+			headers: { authorization: `Bearer ${token}`, accept: "application/json" }
+		}, deps));
+		if (usage?.data !== null && typeof usage?.data === "object") {
+			used = numberOrNull(usage.data.total_actual_cost);
+		}
+	} catch {
+		// Usage is supplementary; a failure here must not hide the balance.
+	}
+
+	const displayName = nonEmptyString(data.username)
+		?? (nonEmptyString(data.email) !== null ? nonEmptyString(data.email) : void 0);
+	const balance = {
+		remaining,
+		...(used === null ? {} : { used }),
+		currency: "USD",
+		unlimited: false,
+		expiresAt: null
+	};
+	return {
+		...baseSnapshot(spec, "ok", now),
+		...(displayName === void 0 ? {} : { plan: displayName }),
+		balance,
+		alert: balanceAlert(balance, spec.monitor.warning)
+	};
+}
+
 function customBalance(spec, body, now) {
 	const extract = spec.monitor.extract;
 	const root = jsonPointer(body, extract.root ?? "");
@@ -909,6 +1080,9 @@ export async function queryAccount(spec, credentials, deps = {}) {
 	try {
 		const safeDeps = deps.fetch === void 0 ? { ...deps, fetch: (url, init) => pinnedFetch(url, init, spec, deps) } : deps;
 		if (spec.adapter === "declarative") return await queryDeclarative(spec, credentials, safeDeps, now);
+		// sub2api-auth authenticates with the dashboard account, not the provider's
+		// inference apiKeyEnv, so it must run before the generic apiKeyRef gate.
+		if (spec.adapter === "sub2api-auth") return await querySub2ApiAuth(spec, credentials, safeDeps, now);
 		const credential = await resolveCredential(credentials, spec.apiKeyRef);
 		if (spec.adapter !== "opencode-go" && credential === "") return unavailableSnapshot(spec, "not-configured", now, { missingCredentials: spec.apiKeyRef === void 0 ? [] : [spec.apiKeyRef] });
 		if (schemeOfAdapter(spec.adapter) !== null) return await queryBuiltInBalance(spec, credential, safeDeps, now);

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -838,10 +838,8 @@ function sub2ApiSubscription(spec, body, now) {
 	};
 }
 
-async function querySub2Api(spec, credential, deps, now) {
-	const body = await requestJson(new URL("/v1/usage", spec.baseURL).href, {
-		headers: { authorization: `Bearer ${credential}`, accept: "application/json" }
-	}, deps);
+/** Parse a Sub2API /v1/usage body into a normalized account snapshot (balance or subscription windows). */
+function parseSub2ApiUsage(spec, body, now) {
 	if (body === null || typeof body !== "object" || Array.isArray(body)) throw statusError("invalid-response", "Sub2API response must be an object");
 	if (body.isValid === false || body.is_active === false) throw statusError("unauthorized", "Sub2API key is invalid");
 	const hasSubscription = body.subscription !== null && typeof body.subscription === "object" && !Array.isArray(body.subscription);
@@ -861,6 +859,13 @@ async function querySub2Api(spec, credential, deps, now) {
 		balance,
 		alert: balanceAlert(balance, spec.monitor.warning)
 	};
+}
+
+async function querySub2Api(spec, credential, deps, now) {
+	const body = await requestJson(new URL("/v1/usage", spec.baseURL).href, {
+		headers: { authorization: `Bearer ${credential}`, accept: "application/json" }
+	}, deps);
+	return parseSub2ApiUsage(spec, body, now);
 }
 
 /**
@@ -935,60 +940,78 @@ function sub2apiAuthSpec(spec) {
 }
 
 /**
- * Query a Sub2API panel's USD balance with the provider's own inference API key.
+ * Query a Sub2API panel's balance with the provider's own inference API key.
  *
- * Mirrors CC Switch's General usage template: `GET {baseUrl}/user/balance`
- * with `Authorization: Bearer {apiKey}` and reads `response.balance` as the
- * remaining amount. No separate dashboard credential is required — the model-
- * configured apiKeyEnv is reused. Today's actual cost is an optional supplement.
+ * No separate dashboard credential is required — the model-configured apiKeyEnv
+ * is reused. Two key-accessible endpoints are tried in order:
+ *   1. `GET {baseUrl}/user/balance` (CC Switch General shape, reads
+ *      `response.balance`); some panels expose this and some do not.
+ *   2. `GET {baseUrl}/v1/usage` (the legacy Sub2API/passion shape parsed by
+ *      `parseSub2ApiUsage`), which real panels commonly expose.
+ * Panels whose SPA serves HTML for unknown routes (returning non-JSON for
+ * `/user/balance`) fall through to `/v1/usage` instead of failing.
  */
 async function querySub2ApiAuth(spec, credentials, deps, now) {
 	const credential = await resolveCredential(credentials, spec.apiKeyRef);
 	if (credential === "") return unavailableSnapshot(spec, "not-configured", now, { missingCredentials: [spec.apiKeyRef === void 0 ? "<apiKey>" : spec.apiKeyRef] });
 
-	const body = await requestJson(new URL(SUB2API_BALANCE_PATH, spec.baseURL).href, {
-		headers: { authorization: `Bearer ${credential}`, accept: "application/json" }
-	}, deps);
-	const remaining = numberOrNull(body?.balance)
-		?? numberOrNull(body?.data?.balance)
-		?? numberOrNull(body?.remaining)
-		?? numberOrNull(body?.data?.remaining);
-	if (remaining === null) {
-		// Secret-free diagnostic: report which top-level keys the panel returned
-		// so the shape mismatch is visible instead of a bare "invalid-response".
-		const keys = typeof body === "object" && body !== null && !Array.isArray(body)
-			? Object.keys(body).slice(0, 8).join(",")
-			: typeof body === "object" && body !== null
-				? "[array]"
-				: "<" + typeof body + ">";
-		throw statusError("invalid-response", "Sub2API balance response is missing a numeric balance", void 0, `sub2api-balance-keys:${keys}`);
-	}
-
-	// Today's actual cost is optional; when unavailable the account still shows balance.
-	let used = null;
+	// Try the CC Switch General /user/balance first; any transport/parse failure
+	// (e.g. an SPA HTML response) just moves on to /v1/usage.
+	let balanceBody = null;
 	try {
-		const usage = await requestJson(new URL(SUB2API_USAGE_STATS_PATH, spec.baseURL).href, {
+		balanceBody = await requestJson(new URL(SUB2API_BALANCE_PATH, spec.baseURL).href, {
 			headers: { authorization: `Bearer ${credential}`, accept: "application/json" }
 		}, deps);
-		const cost = numberOrNull(usage?.data?.total_actual_cost);
-		if (cost !== null) used = cost;
 	} catch {
-		// Usage is supplementary; a failure here must not hide the balance.
+		balanceBody = null;
+	}
+	const remaining = balanceBody === null ? null : (numberOrNull(balanceBody?.balance)
+		?? numberOrNull(balanceBody?.data?.balance)
+		?? numberOrNull(balanceBody?.remaining)
+		?? numberOrNull(balanceBody?.data?.remaining));
+	if (remaining !== null) {
+		// Today's actual cost is optional; when unavailable the account still shows balance.
+		let used = null;
+		try {
+			const usage = await requestJson(new URL(SUB2API_USAGE_STATS_PATH, spec.baseURL).href, {
+				headers: { authorization: `Bearer ${credential}`, accept: "application/json" }
+			}, deps);
+			const cost = numberOrNull(usage?.data?.total_actual_cost);
+			if (cost !== null) used = cost;
+		} catch {
+			// Usage is supplementary; a failure here must not hide the balance.
+		}
+		const balance = {
+			remaining,
+			...(used === null ? {} : { used }),
+			currency: nonEmptyString(balanceBody?.unit) ?? "USD",
+			unlimited: false,
+			expiresAt: null
+		};
+		return {
+			...baseSnapshot(spec, "ok", now),
+			...(nonEmptyString(balanceBody?.planName) === null ? {} : { plan: balanceBody.planName }),
+			balance,
+			alert: balanceAlert(balance, spec.monitor.warning)
+		};
 	}
 
-	const balance = {
-		remaining,
-		...(used === null ? {} : { used }),
-		currency: nonEmptyString(body?.unit) ?? "USD",
-		unlimited: false,
-		expiresAt: null
-	};
-	return {
-		...baseSnapshot(spec, "ok", now),
-		...(nonEmptyString(body?.planName) === null ? {} : { plan: body.planName }),
-		balance,
-		alert: balanceAlert(balance, spec.monitor.warning)
-	};
+	// Fall back to the panel's own /v1/usage (same model API key).
+	try {
+		const usageBody = await requestJson(new URL("/v1/usage", spec.baseURL).href, {
+			headers: { authorization: `Bearer ${credential}`, accept: "application/json" }
+		}, deps);
+		return parseSub2ApiUsage(spec, usageBody, now);
+	} catch (error) {
+		// Secret-free diagnostic: report what /user/balance returned when it was
+		// reachable but unrecognized, so the shape mismatch is visible instead of
+		// a bare "invalid-response".
+		if (balanceBody !== null && typeof balanceBody === "object") {
+			const keys = Object.keys(balanceBody).slice(0, 8).join(",");
+			error.safeReason = `sub2api-balance-keys:${keys}`;
+		}
+		throw error;
+	}
 }
 
 function customBalance(spec, body, now) {

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -140,24 +140,24 @@ function responseStatus(status) {
 
 async function parseJsonResponse(response, maxBytes = MAX_RESPONSE_BYTES) {
 	const declared = numberOrNull(response.headers?.get?.("content-length"));
-	if (declared !== null && declared > maxBytes) throw statusError("invalid-response", "upstream response exceeds the size limit");
+	if (declared !== null && declared > maxBytes) throw statusError("invalid-response", "upstream response exceeds the size limit", void 0, "upstream-too-large");
 	const contentType = response.headers?.get?.("content-type");
 	if (typeof contentType === "string" && contentType !== "" && !/\bjson\b/i.test(contentType)) {
-		throw statusError("invalid-response", "upstream did not return JSON");
+		throw statusError("invalid-response", "upstream did not return JSON", void 0, "upstream-not-json");
 	}
 	if (typeof response.arrayBuffer === "function") {
 		const bytes = new Uint8Array(await response.arrayBuffer());
-		if (bytes.byteLength > maxBytes) throw statusError("invalid-response", "upstream response exceeds the size limit");
+		if (bytes.byteLength > maxBytes) throw statusError("invalid-response", "upstream response exceeds the size limit", void 0, "upstream-too-large");
 		try {
 			return JSON.parse(new TextDecoder().decode(bytes));
 		} catch {
-			throw statusError("invalid-response", "upstream returned invalid JSON");
+			throw statusError("invalid-response", "upstream returned invalid JSON", void 0, "upstream-invalid-json");
 		}
 	}
 	try {
 		return await response.json();
 	} catch {
-		throw statusError("invalid-response", "upstream returned invalid JSON");
+		throw statusError("invalid-response", "upstream returned invalid JSON", void 0, "upstream-invalid-json");
 	}
 }
 
@@ -949,8 +949,20 @@ async function querySub2ApiAuth(spec, credentials, deps, now) {
 	const body = await requestJson(new URL(SUB2API_BALANCE_PATH, spec.baseURL).href, {
 		headers: { authorization: `Bearer ${credential}`, accept: "application/json" }
 	}, deps);
-	const remaining = numberOrNull(body?.balance);
-	if (remaining === null) throw statusError("invalid-response", "Sub2API balance response is missing a numeric balance");
+	const remaining = numberOrNull(body?.balance)
+		?? numberOrNull(body?.data?.balance)
+		?? numberOrNull(body?.remaining)
+		?? numberOrNull(body?.data?.remaining);
+	if (remaining === null) {
+		// Secret-free diagnostic: report which top-level keys the panel returned
+		// so the shape mismatch is visible instead of a bare "invalid-response".
+		const keys = typeof body === "object" && body !== null && !Array.isArray(body)
+			? Object.keys(body).slice(0, 8).join(",")
+			: typeof body === "object" && body !== null
+				? "[array]"
+				: "<" + typeof body + ">";
+		throw statusError("invalid-response", "Sub2API balance response is missing a numeric balance", void 0, `sub2api-balance-keys:${keys}`);
+	}
 
 	// Today's actual cost is optional; when unavailable the account still shows balance.
 	let used = null;

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -22,10 +22,20 @@ const MAX_RESPONSE_BYTES = 1024 * 1024;
 const OPENROUTER_MANAGEMENT_REF = "OPENROUTER_MANAGEMENT_KEY";
 const SUB2API_LOGIN_PATH = "/api/v1/auth/login";
 const SUB2API_AUTH_ME_PATH = "/api/v1/auth/me";
+const SUB2API_USAGE_STATS_PATH = "/api/v1/usage/stats";
+const SUB2API_PUBLIC_SETTINGS_PATH = "/api/v1/settings/public";
 /** Sub2API dashboard JWTs are short-lived; re-authenticate when a request is rejected. */
 const SUB2API_ACCESS_TOKEN_REF = "accessTokenRef";
 const SUB2API_USERNAME_REF = "usernameRef";
 const SUB2API_PASSWORD_REF = "passwordRef";
+/**
+ * Default credential references for auto-detected Sub2API panels. When a relay
+ * provider has no explicit adapter but the panel credentials exist under these
+ * names, the plugin probes the panel and auto-selects `sub2api-auth`.
+ */
+const SUB2API_DEFAULT_USERNAME_REF = "SUB2API_EMAIL";
+const SUB2API_DEFAULT_PASSWORD_REF = "SUB2API_PASSWORD";
+const SUB2API_DEFAULT_ACCESS_TOKEN_REF = "SUB2API_ACCESS_TOKEN";
 const ACCOUNT_STATUSES = new Set([
 	"ok",
 	"not-configured",
@@ -902,6 +912,91 @@ function sub2apiSessions(deps) {
 	return deps.sessions;
 }
 
+/**
+ * Detection cache for auto-detected Sub2API panels, keyed by the provider's
+ * config key so we only probe once per (provider × config) even across the
+ * five-minute background refreshes.
+ */
+function sub2apiDetection(deps) {
+	if (deps.sub2apiDetection === void 0 || deps.sub2apiDetection === null) deps.sub2apiDetection = new Map();
+	return deps.sub2apiDetection;
+}
+
+/**
+ * Resolve the effective Sub2API auth credential refs for a spec. Explicit
+ * per-monitor refs win; otherwise the shared default refs (SUB2API_EMAIL /
+ * SUB2API_PASSWORD / SUB2API_ACCESS_TOKEN) are used so an auto-detected panel
+ * needs no per-provider config.
+ */
+function sub2apiAuthRefs(monitor = {}) {
+	return {
+		[SUB2API_ACCESS_TOKEN_REF]: nonEmptyString(monitor[SUB2API_ACCESS_TOKEN_REF]) ?? SUB2API_DEFAULT_ACCESS_TOKEN_REF,
+		[SUB2API_USERNAME_REF]: nonEmptyString(monitor[SUB2API_USERNAME_REF]) ?? SUB2API_DEFAULT_USERNAME_REF,
+		[SUB2API_PASSWORD_REF]: nonEmptyString(monitor[SUB2API_PASSWORD_REF]) ?? SUB2API_DEFAULT_PASSWORD_REF
+	};
+}
+
+/**
+ * True when a provider bound to `sub2api-auth` should use the shared default
+ * credential references (i.e. it was auto-detected and carries no per-provider
+ * account config).
+ */
+function usesSub2ApiDefaultRefs(monitor) {
+	return nonEmptyString(monitor[SUB2API_USERNAME_REF]) === null
+		&& nonEmptyString(monitor[SUB2API_ACCESS_TOKEN_REF]) === null;
+}
+
+/**
+ * Probe whether a relay endpoint is a real Sub2API panel.
+ *
+ * Real Sub2API panels expose the public `GET /api/v1/settings/public` route
+ * (envelope `{ code: 0, data: { affiliate_enabled: boolean } }`) which neither
+ * One/New-API nor passion-style gateways provide, so this is a cheap, read-only,
+ * capability fingerprint for auto-detection. Results are cached per config key.
+ */
+async function probeSub2ApiPanel(spec, deps) {
+	const cache = sub2apiDetection(deps);
+	const key = spec.configKey;
+	if (cache.has(key)) return cache.get(key);
+	let detected = false;
+	try {
+		const body = await requestJson(new URL(SUB2API_PUBLIC_SETTINGS_PATH, spec.baseURL).href, {
+			headers: { accept: "application/json" }
+		}, deps);
+		const envelope = sub2apiEnvelope(body);
+		const settings = envelope?.data;
+		detected = settings !== null && typeof settings === "object" && !Array.isArray(settings)
+			&& typeof settings.affiliate_enabled === "boolean";
+	} catch {
+		detected = false;
+	}
+	cache.set(key, detected);
+	return detected;
+}
+
+/**
+ * Build a sub2api-auth spec from an auto-detected panel's provider using the
+ * default credential references.
+ */
+function sub2apiAuthSpec(spec) {
+	return {
+		...spec,
+		adapter: "sub2api-auth",
+		mode: "balance",
+		apiKeyRef: SUB2API_DEFAULT_ACCESS_TOKEN_REF
+	};
+}
+
+/** True when any of the shared Sub2API panel credentials resolve to a value. */
+async function hasSub2ApiDefaultCredentials(credentials, deps) {
+	const [token, username, password] = await Promise.all([
+		resolveCredential(credentials, SUB2API_DEFAULT_ACCESS_TOKEN_REF),
+		resolveCredential(credentials, SUB2API_DEFAULT_USERNAME_REF),
+		resolveCredential(credentials, SUB2API_DEFAULT_PASSWORD_REF)
+	]);
+	return token !== "" || (username !== "" && password !== "");
+}
+
 /** Log into a Sub2API dashboard and return the short-lived access token. */
 async function sub2apiLogin(spec, username, password, deps) {
 	const body = await requestJson(new URL(SUB2API_LOGIN_PATH, spec.baseURL).href, {
@@ -931,15 +1026,16 @@ async function sub2apiToken(spec, credentials, deps, forceLogin = false) {
 	const cached = sessions.get(key);
 	if (cached !== void 0 && !forceLogin) return cached.accessToken;
 
-	const staticToken = await resolveCredential(credentials, spec.monitor[SUB2API_ACCESS_TOKEN_REF]);
+	const { [SUB2API_ACCESS_TOKEN_REF]: accessRef, [SUB2API_USERNAME_REF]: userRef, [SUB2API_PASSWORD_REF]: passRef } = sub2apiAuthRefs(spec.monitor);
+	const staticToken = await resolveCredential(credentials, accessRef);
 	if (staticToken !== "" && !forceLogin) {
 		sessions.set(key, { accessToken: staticToken });
 		return staticToken;
 	}
 
 	if (forceLogin) sessions.delete(key);
-	const username = await resolveCredential(credentials, spec.monitor[SUB2API_USERNAME_REF]);
-	const password = await resolveCredential(credentials, spec.monitor[SUB2API_PASSWORD_REF]);
+	const username = await resolveCredential(credentials, userRef);
+	const password = await resolveCredential(credentials, passRef);
 	if (username === "" || password === "") {
 		if (cached !== void 0) sessions.delete(key);
 		return "";
@@ -951,12 +1047,11 @@ async function sub2apiToken(spec, credentials, deps, forceLogin = false) {
 
 /** Query the verified dashboard for the user's own balance (USD) and today's usage. */
 async function querySub2ApiAuth(spec, credentials, deps, now) {
-	const authRefs = [SUB2API_ACCESS_TOKEN_REF, SUB2API_USERNAME_REF, SUB2API_PASSWORD_REF];
-	if (spec.monitor[SUB2API_ACCESS_TOKEN_REF] === void 0
-		&& (spec.monitor[SUB2API_USERNAME_REF] === void 0 || spec.monitor[SUB2API_PASSWORD_REF] === void 0)) {
-		return unavailableSnapshot(spec, "not-configured", now, {
-			missingCredentials: authRefs.filter((ref) => spec.monitor[ref] === void 0)
-		});
+	const refs = sub2apiAuthRefs(spec.monitor);
+	const authRefs = [refs[SUB2API_ACCESS_TOKEN_REF], refs[SUB2API_USERNAME_REF], refs[SUB2API_PASSWORD_REF]];
+	if (refs[SUB2API_ACCESS_TOKEN_REF] === void 0
+		&& (refs[SUB2API_USERNAME_REF] === void 0 || refs[SUB2API_PASSWORD_REF] === void 0)) {
+		return unavailableSnapshot(spec, "not-configured", now, { missingCredentials: authRefs });
 	}
 
 	let token = await sub2apiToken(spec, credentials, deps, false);
@@ -993,7 +1088,7 @@ async function querySub2ApiAuth(spec, credentials, deps, now) {
 	// Today's usage is optional; when unavailable the account still shows balance.
 	let used = null;
 	try {
-		const usage = sub2apiEnvelope(await requestJson(new URL("/api/v1/usage/stats?period=today", spec.baseURL).href, {
+		const usage = sub2apiEnvelope(await requestJson(new URL(`${SUB2API_USAGE_STATS_PATH}?period=today`, spec.baseURL).href, {
 			headers: { authorization: `Bearer ${token}`, accept: "application/json" }
 		}, deps));
 		if (usage?.data !== null && typeof usage?.data === "object") {
@@ -1076,9 +1171,24 @@ async function queryDeclarative(spec, credentials, deps, now) {
 /** Query one adapter and return a secret-free normalized account snapshot. */
 export async function queryAccount(spec, credentials, deps = {}) {
 	const now = (deps.now ?? Date.now)();
-	if (spec === null || spec === void 0 || spec.adapter === null || spec.mode === null) return unavailableSnapshot(spec ?? { id: "unknown", displayName: "Unknown", adapter: null, mode: "balance" }, "unsupported", now);
+	if (spec === null || spec === void 0) return unavailableSnapshot({ id: "unknown", displayName: "Unknown", adapter: null, mode: "balance" }, "unsupported", now);
 	try {
 		const safeDeps = deps.fetch === void 0 ? { ...deps, fetch: (url, init) => pinnedFetch(url, init, spec, deps) } : deps;
+		// A provider with no built-in/explicit adapter may be a real Sub2API
+		// panel. Probe its public settings endpoint only when the shared panel
+		// credentials are present, and when it fingerprints as a Sub2API panel,
+		// use the sub2api-auth adapter automatically. Explicit adapters always win.
+		if (spec.adapter === null || spec.mode === null) {
+			const hasPanelCreds = await hasSub2ApiDefaultCredentials(credentials, deps);
+			if (!hasPanelCreds) return unavailableSnapshot(spec, "unsupported", now);
+			const probeable = { ...spec, adapter: null, mode: "balance" };
+			if (await probeSub2ApiPanel(probeable, safeDeps)) {
+				const panel = sub2apiAuthSpec(probeable);
+				const authSpec = { ...panel, configKey: probeable.configKey, monitor: { ...panel.monitor } };
+				return await querySub2ApiAuth(authSpec, credentials, safeDeps, now);
+			}
+			return unavailableSnapshot(spec, "unsupported", now);
+		}
 		if (spec.adapter === "declarative") return await queryDeclarative(spec, credentials, safeDeps, now);
 		// sub2api-auth authenticates with the dashboard account, not the provider's
 		// inference apiKeyEnv, so it must run before the generic apiKeyRef gate.
@@ -1190,7 +1300,14 @@ export function createAccountService({ credentials, getProviders, config = { mon
 
 	async function refreshAll() {
 		const all = await specs();
-		return Promise.all(all.filter((spec) => spec.adapter !== null).map(refresh));
+		const panelCredentials = await hasSub2ApiDefaultCredentials(credentials, deps);
+		return Promise.all(all.filter((spec) => {
+			if (spec.adapter !== null) return true;
+			// Only probe providers that (a) have the shared Sub2API panel
+			// credentials present and (b) carry no explicit adapter, so the
+			// capability probe stays bounded and never touches unrelated relays.
+			return panelCredentials && !(spec.monitor.adapter !== void 0);
+		}).map(refresh));
 	}
 
 	async function providerViews() {
@@ -1203,7 +1320,7 @@ export function createAccountService({ credentials, getProviders, config = { mon
 				id: spec.id,
 				displayName: spec.displayName,
 				accountMode: account?.mode ?? spec.mode,
-				adapter: spec.adapter,
+				adapter: spec.adapter ?? account?.adapter ?? null,
 				configured: account === void 0 ? credentialConfigured : account.status !== "not-configured",
 				status: account?.status ?? "pending",
 				fetchedAt: account?.fetchedAt ?? null,

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -20,22 +20,15 @@ const DEFAULT_TIMEOUT_MS = 15000;
 const DEFAULT_REFRESH_MS = 300000;
 const MAX_RESPONSE_BYTES = 1024 * 1024;
 const OPENROUTER_MANAGEMENT_REF = "OPENROUTER_MANAGEMENT_KEY";
-const SUB2API_LOGIN_PATH = "/api/v1/auth/login";
-const SUB2API_AUTH_ME_PATH = "/api/v1/auth/me";
-const SUB2API_USAGE_STATS_PATH = "/api/v1/usage/stats";
-const SUB2API_PUBLIC_SETTINGS_PATH = "/api/v1/settings/public";
-/** Sub2API dashboard JWTs are short-lived; re-authenticate when a request is rejected. */
-const SUB2API_ACCESS_TOKEN_REF = "accessTokenRef";
-const SUB2API_USERNAME_REF = "usernameRef";
-const SUB2API_PASSWORD_REF = "passwordRef";
 /**
- * Default credential references for auto-detected Sub2API panels. When a relay
- * provider has no explicit adapter but the panel credentials exist under these
- * names, the plugin probes the panel and auto-selects `sub2api-auth`.
+ * Real Sub2API panels expose a read-only public settings route used to detect
+ * the panel (auto-selecting the `sub2api-auth` adapter) and a balance route the
+ * provider's own inference API key can query — the same pattern as CC Switch's
+ * General usage template (GET {baseUrl}/user/balance with a Bearer api key).
  */
-const SUB2API_DEFAULT_USERNAME_REF = "SUB2API_EMAIL";
-const SUB2API_DEFAULT_PASSWORD_REF = "SUB2API_PASSWORD";
-const SUB2API_DEFAULT_ACCESS_TOKEN_REF = "SUB2API_ACCESS_TOKEN";
+const SUB2API_BALANCE_PATH = "/user/balance";
+const SUB2API_USAGE_STATS_PATH = "/api/v1/usage/stats?period=today";
+const SUB2API_PUBLIC_SETTINGS_PATH = "/api/v1/settings/public";
 const ACCOUNT_STATUSES = new Set([
 	"ok",
 	"not-configured",
@@ -227,20 +220,6 @@ function validatePointer(pointer, label) {
 	if (typeof value !== "string" || value !== "" && !value.startsWith("/")) throw new Error(`${label} must be a JSON Pointer`);
 }
 
-function validateSub2ApiAuth(monitor, label) {
-	const refs = [SUB2API_ACCESS_TOKEN_REF, SUB2API_USERNAME_REF, SUB2API_PASSWORD_REF];
-	for (const ref of refs) {
-		if (monitor[ref] !== void 0 && nonEmptyString(monitor[ref]) === null) {
-			throw new Error(`${label}.${ref} must be a credential reference name`);
-		}
-	}
-	// A dashboard session needs either a pre-issued token or the account login.
-	if (monitor[SUB2API_ACCESS_TOKEN_REF] === void 0
-		&& (monitor[SUB2API_USERNAME_REF] === void 0 || monitor[SUB2API_PASSWORD_REF] === void 0)) {
-		throw new Error(`${label}.sub2api-auth requires accessTokenRef or both usernameRef and passwordRef`);
-	}
-}
-
 function validateWarning(value, label) {
 	if (value === void 0) return;
 	if (value === null || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
@@ -291,7 +270,6 @@ export function validateAccountConfig(raw = {}) {
 		}
 		validateWarning(value.warning, `${label}.warning`);
 		if (adapter === "declarative") validateDeclarative(value, label);
-		if (adapter === "sub2api-auth") validateSub2ApiAuth(value, label);
 		normalized[providerId] = { ...value, providerId, adapter };
 	}
 	return { monitors: normalized };
@@ -309,12 +287,10 @@ export function resolveAccountSpec(provider, config = { monitors: {} }) {
 		displayName: provider.displayName ?? provider.id,
 		adapter,
 		mode,
-		// The apiKeyRef doubles as the "configured" indicator in provider views;
-		// sub2api-auth authenticates with a dashboard account, so surface its
-		// access-token (or username) ref instead of the inference key env.
-		apiKeyRef: adapter === "sub2api-auth"
-			? monitor[SUB2API_ACCESS_TOKEN_REF] ?? monitor[SUB2API_USERNAME_REF] ?? apiKeyRef
-			: apiKeyRef,
+		// The apiKeyRef doubles as the "configured" indicator in provider views.
+		// sub2api-auth reuses the provider's own inference apiKeyEnv (CC Switch
+		// style), so the default apiKeyRef already points at it.
+		apiKeyRef,
 		baseURL: monitor.usageBaseURL ?? provider.baseURL,
 		providerBaseURL: provider.baseURL,
 		monitor,
@@ -906,12 +882,6 @@ function sub2apiEnvelope(body) {
 	return body;
 }
 
-/** The per-process Sub2API dashboard sessions, retained across background refreshes. */
-function sub2apiSessions(deps) {
-	if (deps.sessions === void 0 || deps.sessions === null) deps.sessions = new Map();
-	return deps.sessions;
-}
-
 /**
  * Detection cache for auto-detected Sub2API panels, keyed by the provider's
  * config key so we only probe once per (provider × config) even across the
@@ -920,30 +890,6 @@ function sub2apiSessions(deps) {
 function sub2apiDetection(deps) {
 	if (deps.sub2apiDetection === void 0 || deps.sub2apiDetection === null) deps.sub2apiDetection = new Map();
 	return deps.sub2apiDetection;
-}
-
-/**
- * Resolve the effective Sub2API auth credential refs for a spec. Explicit
- * per-monitor refs win; otherwise the shared default refs (SUB2API_EMAIL /
- * SUB2API_PASSWORD / SUB2API_ACCESS_TOKEN) are used so an auto-detected panel
- * needs no per-provider config.
- */
-function sub2apiAuthRefs(monitor = {}) {
-	return {
-		[SUB2API_ACCESS_TOKEN_REF]: nonEmptyString(monitor[SUB2API_ACCESS_TOKEN_REF]) ?? SUB2API_DEFAULT_ACCESS_TOKEN_REF,
-		[SUB2API_USERNAME_REF]: nonEmptyString(monitor[SUB2API_USERNAME_REF]) ?? SUB2API_DEFAULT_USERNAME_REF,
-		[SUB2API_PASSWORD_REF]: nonEmptyString(monitor[SUB2API_PASSWORD_REF]) ?? SUB2API_DEFAULT_PASSWORD_REF
-	};
-}
-
-/**
- * True when a provider bound to `sub2api-auth` should use the shared default
- * credential references (i.e. it was auto-detected and carries no per-provider
- * account config).
- */
-function usesSub2ApiDefaultRefs(monitor) {
-	return nonEmptyString(monitor[SUB2API_USERNAME_REF]) === null
-		&& nonEmptyString(monitor[SUB2API_ACCESS_TOKEN_REF]) === null;
 }
 
 /**
@@ -975,141 +921,59 @@ async function probeSub2ApiPanel(spec, deps) {
 }
 
 /**
- * Build a sub2api-auth spec from an auto-detected panel's provider using the
- * default credential references.
+ * Build a sub2api-auth spec from an auto-detected panel's provider. It reuses
+ * the provider's own inference apiKeyEnv (already configured in the model) —
+ * the same credential model as CC Switch's General usage template — so no
+ * separate panel credential is needed. The apiKeyRef stays the provider's.
  */
 function sub2apiAuthSpec(spec) {
 	return {
 		...spec,
 		adapter: "sub2api-auth",
-		mode: "balance",
-		apiKeyRef: SUB2API_DEFAULT_ACCESS_TOKEN_REF
+		mode: "balance"
 	};
 }
 
-/** True when any of the shared Sub2API panel credentials resolve to a value. */
-async function hasSub2ApiDefaultCredentials(credentials, deps) {
-	const [token, username, password] = await Promise.all([
-		resolveCredential(credentials, SUB2API_DEFAULT_ACCESS_TOKEN_REF),
-		resolveCredential(credentials, SUB2API_DEFAULT_USERNAME_REF),
-		resolveCredential(credentials, SUB2API_DEFAULT_PASSWORD_REF)
-	]);
-	return token !== "" || (username !== "" && password !== "");
-}
-
-/** Log into a Sub2API dashboard and return the short-lived access token. */
-async function sub2apiLogin(spec, username, password, deps) {
-	const body = await requestJson(new URL(SUB2API_LOGIN_PATH, spec.baseURL).href, {
-		method: "POST",
-		headers: { "content-type": "application/json", accept: "application/json" },
-		body: JSON.stringify({ email: username, password })
-	}, deps);
-	const envelope = sub2apiEnvelope(body);
-	const token = nonEmptyString(envelope.data?.access_token);
-	if (token === null) throw statusError("unauthorized", "Sub2API login did not return an access token");
-	return token;
-}
-
 /**
- * Resolve the dashboard access token for a `sub2api-auth` monitor.
+ * Query a Sub2API panel's USD balance with the provider's own inference API key.
  *
- * A pre-issued `accessTokenRef` wins when non-empty (it can be rotated by the
- * user without storing the panel password). Otherwise the account `usernameRef`
- * + `passwordRef` are used to log in. The token is held only in the process
- * memory session map and is never written to the usage cache, browser response,
- * or logs. Login-on-demand keeps short-lived JWTs valid without persisting a
- * refresh token to disk.
+ * Mirrors CC Switch's General usage template: `GET {baseUrl}/user/balance`
+ * with `Authorization: Bearer {apiKey}` and reads `response.balance` as the
+ * remaining amount. No separate dashboard credential is required — the model-
+ * configured apiKeyEnv is reused. Today's actual cost is an optional supplement.
  */
-async function sub2apiToken(spec, credentials, deps, forceLogin = false) {
-	const sessions = sub2apiSessions(deps);
-	const key = spec.configKey;
-	const cached = sessions.get(key);
-	if (cached !== void 0 && !forceLogin) return cached.accessToken;
-
-	const { [SUB2API_ACCESS_TOKEN_REF]: accessRef, [SUB2API_USERNAME_REF]: userRef, [SUB2API_PASSWORD_REF]: passRef } = sub2apiAuthRefs(spec.monitor);
-	const staticToken = await resolveCredential(credentials, accessRef);
-	if (staticToken !== "" && !forceLogin) {
-		sessions.set(key, { accessToken: staticToken });
-		return staticToken;
-	}
-
-	if (forceLogin) sessions.delete(key);
-	const username = await resolveCredential(credentials, userRef);
-	const password = await resolveCredential(credentials, passRef);
-	if (username === "" || password === "") {
-		if (cached !== void 0) sessions.delete(key);
-		return "";
-	}
-	const token = await sub2apiLogin(spec, username, password, deps);
-	sessions.set(key, { accessToken: token });
-	return token;
-}
-
-/** Query the verified dashboard for the user's own balance (USD) and today's usage. */
 async function querySub2ApiAuth(spec, credentials, deps, now) {
-	const refs = sub2apiAuthRefs(spec.monitor);
-	const authRefs = [refs[SUB2API_ACCESS_TOKEN_REF], refs[SUB2API_USERNAME_REF], refs[SUB2API_PASSWORD_REF]];
-	if (refs[SUB2API_ACCESS_TOKEN_REF] === void 0
-		&& (refs[SUB2API_USERNAME_REF] === void 0 || refs[SUB2API_PASSWORD_REF] === void 0)) {
-		return unavailableSnapshot(spec, "not-configured", now, { missingCredentials: authRefs });
-	}
+	const credential = await resolveCredential(credentials, spec.apiKeyRef);
+	if (credential === "") return unavailableSnapshot(spec, "not-configured", now, { missingCredentials: [spec.apiKeyRef === void 0 ? "<apiKey>" : spec.apiKeyRef] });
 
-	let token = await sub2apiToken(spec, credentials, deps, false);
-	if (token === "") return unavailableSnapshot(spec, "not-configured", now, { missingCredentials: authRefs });
-
-	const queryMe = async (accessToken) => requestJson(new URL(SUB2API_AUTH_ME_PATH, spec.baseURL).href, {
-		headers: { authorization: `Bearer ${accessToken}`, accept: "application/json" }
+	const body = await requestJson(new URL(SUB2API_BALANCE_PATH, spec.baseURL).href, {
+		headers: { authorization: `Bearer ${credential}`, accept: "application/json" }
 	}, deps);
+	const remaining = numberOrNull(body?.balance);
+	if (remaining === null) throw statusError("invalid-response", "Sub2API balance response is missing a numeric balance");
 
-	let envelope;
-	try {
-		envelope = sub2apiEnvelope(await queryMe(token));
-	} catch (error) {
-		const rejected = error?.httpStatus === 401 || error?.providerStatus === "unauthorized";
-		if (!rejected) throw error;
-		// A stale dashboard JWT is the common case; re-authenticate once with the
-		// panel account and retry before reporting unauthorized. This never
-		// downgrades to the provider's inference/static key as a fallback.
-		const reauth = await sub2apiToken(spec, credentials, deps, true);
-		if (reauth === "") return unavailableSnapshot(spec, "unauthorized", now);
-		try {
-			envelope = sub2apiEnvelope(await queryMe(reauth));
-		} catch (retryError) {
-			if (retryError?.httpStatus !== 401 && retryError?.providerStatus !== "unauthorized") throw retryError;
-			return unavailableSnapshot(spec, "unauthorized", now);
-		}
-	}
-
-	const data = envelope.data;
-	if (data === null || typeof data !== "object" || Array.isArray(data)) throw statusError("invalid-response", "Sub2API auth/me is missing account data");
-	const remaining = numberOrNull(data.balance);
-	if (remaining === null) throw statusError("invalid-response", "Sub2API auth/me is missing a numeric balance");
-
-	// Today's usage is optional; when unavailable the account still shows balance.
+	// Today's actual cost is optional; when unavailable the account still shows balance.
 	let used = null;
 	try {
-		const usage = sub2apiEnvelope(await requestJson(new URL(`${SUB2API_USAGE_STATS_PATH}?period=today`, spec.baseURL).href, {
-			headers: { authorization: `Bearer ${token}`, accept: "application/json" }
-		}, deps));
-		if (usage?.data !== null && typeof usage?.data === "object") {
-			used = numberOrNull(usage.data.total_actual_cost);
-		}
+		const usage = await requestJson(new URL(SUB2API_USAGE_STATS_PATH, spec.baseURL).href, {
+			headers: { authorization: `Bearer ${credential}`, accept: "application/json" }
+		}, deps);
+		const cost = numberOrNull(usage?.data?.total_actual_cost);
+		if (cost !== null) used = cost;
 	} catch {
 		// Usage is supplementary; a failure here must not hide the balance.
 	}
 
-	const displayName = nonEmptyString(data.username)
-		?? (nonEmptyString(data.email) !== null ? nonEmptyString(data.email) : void 0);
 	const balance = {
 		remaining,
 		...(used === null ? {} : { used }),
-		currency: "USD",
+		currency: nonEmptyString(body?.unit) ?? "USD",
 		unlimited: false,
 		expiresAt: null
 	};
 	return {
 		...baseSnapshot(spec, "ok", now),
-		...(displayName === void 0 ? {} : { plan: displayName }),
+		...(nonEmptyString(body?.planName) === null ? {} : { plan: body.planName }),
 		balance,
 		alert: balanceAlert(balance, spec.monitor.warning)
 	};
@@ -1174,24 +1038,21 @@ export async function queryAccount(spec, credentials, deps = {}) {
 	if (spec === null || spec === void 0) return unavailableSnapshot({ id: "unknown", displayName: "Unknown", adapter: null, mode: "balance" }, "unsupported", now);
 	try {
 		const safeDeps = deps.fetch === void 0 ? { ...deps, fetch: (url, init) => pinnedFetch(url, init, spec, deps) } : deps;
-		// A provider with no built-in/explicit adapter may be a real Sub2API
-		// panel. Probe its public settings endpoint only when the shared panel
-		// credentials are present, and when it fingerprints as a Sub2API panel,
-		// use the sub2api-auth adapter automatically. Explicit adapters always win.
+		// A relay provider with no built-in/explicit adapter may be a real
+		// Sub2API panel. Only when it also has a model-configured API key do we
+		// probe its public settings endpoint; a matching fingerprint selects the
+		// sub2api-auth adapter, which reuses that same provider API key. Explicit
+		// adapters always win, and unkeyed relays are never probed.
 		if (spec.adapter === null || spec.mode === null) {
-			const hasPanelCreds = await hasSub2ApiDefaultCredentials(credentials, deps);
-			if (!hasPanelCreds) return unavailableSnapshot(spec, "unsupported", now);
+			const providerKey = await resolveCredential(credentials, spec.apiKeyRef);
+			if (providerKey === "") return unavailableSnapshot(spec, "unsupported", now);
 			const probeable = { ...spec, adapter: null, mode: "balance" };
 			if (await probeSub2ApiPanel(probeable, safeDeps)) {
-				const panel = sub2apiAuthSpec(probeable);
-				const authSpec = { ...panel, configKey: probeable.configKey, monitor: { ...panel.monitor } };
-				return await querySub2ApiAuth(authSpec, credentials, safeDeps, now);
+				return await querySub2ApiAuth(sub2apiAuthSpec(probeable), credentials, safeDeps, now);
 			}
 			return unavailableSnapshot(spec, "unsupported", now);
 		}
 		if (spec.adapter === "declarative") return await queryDeclarative(spec, credentials, safeDeps, now);
-		// sub2api-auth authenticates with the dashboard account, not the provider's
-		// inference apiKeyEnv, so it must run before the generic apiKeyRef gate.
 		if (spec.adapter === "sub2api-auth") return await querySub2ApiAuth(spec, credentials, safeDeps, now);
 		const credential = await resolveCredential(credentials, spec.apiKeyRef);
 		if (spec.adapter !== "opencode-go" && credential === "") return unavailableSnapshot(spec, "not-configured", now, { missingCredentials: spec.apiKeyRef === void 0 ? [] : [spec.apiKeyRef] });
@@ -1300,14 +1161,16 @@ export function createAccountService({ credentials, getProviders, config = { mon
 
 	async function refreshAll() {
 		const all = await specs();
-		const panelCredentials = await hasSub2ApiDefaultCredentials(credentials, deps);
-		return Promise.all(all.filter((spec) => {
-			if (spec.adapter !== null) return true;
-			// Only probe providers that (a) have the shared Sub2API panel
-			// credentials present and (b) carry no explicit adapter, so the
-			// capability probe stays bounded and never touches unrelated relays.
-			return panelCredentials && !(spec.monitor.adapter !== void 0);
-		}).map(refresh));
+		// Auto-detection only probes null-adapter relays that have a configured
+		// API key, so the background refresh stays bounded and never touches
+		// unrelated, unkeyed providers.
+		const keyed = await Promise.all(all.map(async (spec) => ({
+			spec,
+			probe: spec.adapter === null
+				? (await resolveCredential(credentials, spec.apiKeyRef)) !== ""
+				: true
+		})));
+		return Promise.all(keyed.filter((entry) => entry.probe).map((entry) => refresh(entry.spec)));
 	}
 
 	async function providerViews() {

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -955,14 +955,20 @@ async function querySub2ApiAuth(spec, credentials, deps, now) {
 	const credential = await resolveCredential(credentials, spec.apiKeyRef);
 	if (credential === "") return unavailableSnapshot(spec, "not-configured", now, { missingCredentials: [spec.apiKeyRef === void 0 ? "<apiKey>" : spec.apiKeyRef] });
 
-	// Try the CC Switch General /user/balance first; any transport/parse failure
-	// (e.g. an SPA HTML response) just moves on to /v1/usage.
+	// Try the CC Switch General /user/balance first; only "the route does not
+	// exist or is not JSON here" failures fall through to /v1/usage. Security
+	// policy, TLS, connection, rate-limit and auth failures are real errors and
+	// must not be silently swallowed — a masked security failure would make the
+	// panel look fine while the fallback endpoint hides the problem.
 	let balanceBody = null;
 	try {
 		balanceBody = await requestJson(new URL(SUB2API_BALANCE_PATH, spec.baseURL).href, {
 			headers: { authorization: `Bearer ${credential}`, accept: "application/json" }
 		}, deps);
-	} catch {
+	} catch (error) {
+		const fallbackable = error?.providerStatus === "unsupported"
+			|| error?.providerStatus === "invalid-response";
+		if (!fallbackable) throw error;
 		balanceBody = null;
 	}
 	const remaining = balanceBody === null ? null : (numberOrNull(balanceBody?.balance)
@@ -1003,12 +1009,13 @@ async function querySub2ApiAuth(spec, credentials, deps, now) {
 		}, deps);
 		return parseSub2ApiUsage(spec, usageBody, now);
 	} catch (error) {
-		// Secret-free diagnostic: report what /user/balance returned when it was
-		// reachable but unrecognized, so the shape mismatch is visible instead of
-		// a bare "invalid-response".
+		// Fixed, bounded diagnostic: /user/balance was reachable but returned an
+		// unrecognized shape. Never include upstream-controlled content (JSON
+		// property names, values, messages) in safeReason — a hostile upstream
+		// could otherwise echo sensitive material across the server→browser
+		// boundary, since safeReasonOf() only truncates.
 		if (balanceBody !== null && typeof balanceBody === "object") {
-			const keys = Object.keys(balanceBody).slice(0, 8).join(",");
-			error.safeReason = `sub2api-balance-keys:${keys}`;
+			error.safeReason = "sub2api-balance-shape-unrecognized";
 		}
 		throw error;
 	}
@@ -1138,6 +1145,12 @@ export function createAccountService({ credentials, getProviders, config = { mon
 	const cache = new Map();
 	const inflight = new Map();
 	const refreshMs = deps.refreshMs ?? DEFAULT_REFRESH_MS;
+	// Long-lived Sub2API panel-detection cache, keyed by the provider's config
+	// key. It lives on the service so auto-detection probes once per
+	// (provider × config) even across five-minute background refreshes; a caller
+	// may still inject its own Map (e.g. tests) by passing deps.sub2apiDetection.
+	const sub2apiDetection = deps.sub2apiDetection ?? new Map();
+	const serviceDeps = { ...deps, sub2apiDetection };
 
 	async function specs() {
 		const providers = [...await getProviders()];
@@ -1176,7 +1189,7 @@ export function createAccountService({ credentials, getProviders, config = { mon
 	async function refresh(spec) {
 		const existing = inflight.get(spec.id);
 		if (existing !== void 0) return existing;
-		const promise = queryAccount(spec, credentials, deps).then((current) => {
+		const promise = queryAccount(spec, credentials, serviceDeps).then((current) => {
 			const next = withStaleData(cache.get(spec.id)?.account, current);
 			cache.set(spec.id, { configKey: spec.configKey, account: next });
 			return next;

--- a/lib/client.js
+++ b/lib/client.js
@@ -380,6 +380,12 @@ window.__ModuleLoader__.load({
 			if (value === null) return null;
 			if (value === "dns-resolution-failed") return translate("account.reason.dnsResolutionFailed");
 			if (value === "all-addresses-unreachable") return translate("account.reason.allAddressesUnreachable");
+			if (value === "upstream-not-json") return translate("account.reason.upstreamNotJson");
+			if (value === "upstream-invalid-json") return translate("account.reason.upstreamInvalidJson");
+			if (value.startsWith("sub2api-balance-keys:")) {
+				const keys = value.slice("sub2api-balance-keys:".length);
+				return `${translate("account.reason.sub2apiUnknownKeys")}: ${keys}`;
+			}
 			return value;
 		}
 
@@ -1323,6 +1329,9 @@ window.__ModuleLoader__.load({
 			"account.invalidResponse": "供应商返回了无法识别的额度数据。",
 			"account.reason.dnsResolutionFailed": "无法解析供应商域名。",
 			"account.reason.allAddressesUnreachable": "已验证的网络地址均无法连接。",
+			"account.reason.upstreamNotJson": "上游返回的不是 JSON",
+			"account.reason.upstreamInvalidJson": "上游返回了无法解析的 JSON",
+			"account.reason.sub2apiUnknownKeys": "Sub2API 余额接口返回了未识别的字段，已返回顶层键",
 			"account.blocked": "账户查询被本地安全策略阻止，请检查 HTTPS、同源和私网访问设置。",
 			"balance.title": "账户余额",
 			"balance.provider": "供应商",
@@ -1408,6 +1417,9 @@ window.__ModuleLoader__.load({
 			"account.invalidResponse": "The provider returned unrecognized quota data.",
 			"account.reason.dnsResolutionFailed": "The provider hostname could not be resolved.",
 			"account.reason.allAddressesUnreachable": "None of the validated network addresses could be reached.",
+			"account.reason.upstreamNotJson": "The upstream response was not JSON",
+			"account.reason.upstreamInvalidJson": "The upstream returned unparsable JSON",
+			"account.reason.sub2apiUnknownKeys": "Sub2API balance returned unrecognized fields; top-level keys were",
 			"account.blocked": "The account query was blocked by the local security policy. Check HTTPS, same-origin, and private-network settings.",
 			"balance.title": "Account balance",
 			"balance.provider": "Provider",

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -473,6 +473,136 @@ console.log("IPv4/IPv6 private-address classification ok");
 }
 
 {
+	// sub2api-auth: email+password login, then the dashboard balance + today usage.
+	const calls = [];
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": {
+			adapter: "sub2api-auth",
+			usernameRef: "SUB2API_EMAIL",
+			passwordRef: "SUB2API_PASSWORD"
+		}
+	} }));
+	const account = await queryAccount(spec, credentials({ SUB2API_EMAIL: "me@example.com", SUB2API_PASSWORD: "s3cret" }), {
+		now: () => now,
+		fetch: async (url, init) => {
+			calls.push({ url: String(url), method: init?.method ?? "GET", authorization: init?.headers?.authorization });
+			if (String(url).endsWith("/api/v1/auth/login")) {
+				assert.equal(init.method, "POST");
+				const body = JSON.parse(init.body);
+				assert.equal(body.email, "me@example.com");
+				assert.equal(body.password, "s3cret");
+				return jsonResponse({ code: 0, message: "ok", data: { access_token: "jwt-access", refresh_token: "jwt-refresh", expires_in: 3000 } });
+			}
+			if (String(url).includes("/api/v1/usage/stats")) {
+				return jsonResponse({ code: 0, message: "ok", data: { total_actual_cost: 2.5, total_input_tokens: 100, total_output_tokens: 50, total_requests: 3 } });
+			}
+			assert.ok(String(url).endsWith("/api/v1/auth/me"));
+			assert.equal(init.headers.authorization, "Bearer jwt-access");
+			return jsonResponse({ code: 0, message: "ok", data: { id: 42, username: "relay-a-owner", email: "me@example.com", balance: 12.5 } });
+		}
+	});
+	assert.equal(account.status, "ok");
+	assert.equal(account.mode, "balance");
+	assert.equal(account.plan, "relay-a-owner");
+	assert.deepEqual(account.balance, { remaining: 12.5, used: 2.5, currency: "USD", unlimited: false, expiresAt: null });
+	assert.equal(JSON.stringify(account).includes("jwt-access"), false, "access token must never leak into the snapshot");
+	assert.equal(JSON.stringify(account).includes("s3cret"), false, "password must never leak into the snapshot");
+	console.log("sub2api-auth login + balance normalization ok");
+}
+
+{
+	// sub2api-auth: a pre-issued access token avoids storing the panel password.
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth", accessTokenRef: "SUB2API_ACCESS_TOKEN" }
+	} }));
+	const account = await queryAccount(spec, credentials({ SUB2API_ACCESS_TOKEN: "static-jwt" }), {
+		now: () => now,
+		fetch: async (url, init) => {
+			if (String(url).endsWith("/api/v1/auth/login")) { throw new Error("must not log in when a token is provided"); }
+			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
+			assert.equal(String(url).endsWith("/api/v1/auth/me"), true);
+			assert.equal(init.headers.authorization, "Bearer static-jwt");
+			return jsonResponse({ code: 0, message: "ok", data: { id: 1, username: "static", balance: 9.9 } });
+		},
+		sessions: new Map()
+	});
+	assert.equal(account.status, "ok");
+	assert.equal(account.balance.remaining, 9.9);
+	console.log("sub2api-auth static access token path ok");
+}
+
+{
+	// sub2api-auth: a stale JWT (401) triggers one re-login and a successful retry.
+	let meCalls = 0;
+	let loginCount = 0;
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth", usernameRef: "SUB2API_EMAIL", passwordRef: "SUB2API_PASSWORD" }
+	} }));
+	const account = await queryAccount(spec, credentials({ SUB2API_EMAIL: "me@example.com", SUB2API_PASSWORD: "s3cret" }), {
+		now: () => now,
+		sessions: new Map(),
+		fetch: async (url, init) => {
+			if (String(url).endsWith("/api/v1/auth/login")) {
+				loginCount += 1;
+				return jsonResponse({ code: 0, message: "ok", data: { access_token: `jwt-${loginCount}` } });
+			}
+			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
+			assert.ok(String(url).endsWith("/api/v1/auth/me"));
+			meCalls += 1;
+			// The first dashboard request uses the initial(now-stale) token.
+			if (meCalls === 1) return jsonResponse({ code: 0, message: "no" }, 401);
+			assert.equal(init.headers.authorization, "Bearer jwt-2", "retry must use the newer token");
+			return jsonResponse({ code: 0, message: "ok", data: { id: 1, username: "retry", balance: 7.25 } });
+		}
+	});
+	assert.equal(account.status, "ok");
+	assert.equal(account.balance.remaining, 7.25);
+	assert.equal(loginCount, 2, "a stale token must trigger exactly one re-login");
+	console.log("sub2api-auth stale-JWT re-login retry ok");
+}
+
+{
+	// sub2api-auth: persistent login failure surfaces as unauthorized, never a secret leak.
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth", usernameRef: "SUB2API_EMAIL", passwordRef: "SUB2API_PASSWORD" }
+	} }));
+	const account = await queryAccount(spec, credentials({ SUB2API_EMAIL: "me@example.com", SUB2API_PASSWORD: "wrong" }), {
+		now: () => now,
+		fetch: async (url, init) => {
+			if (String(url).endsWith("/api/v1/auth/login")) {
+				return jsonResponse({ code: 401, message: "invalid credentials" });
+			}
+			return jsonResponse({}, 401);
+		}
+	});
+	assert.equal(account.status, "unauthorized");
+	assert.equal(account.balance, null);
+	console.log("sub2api-auth failed login maps to unauthorized ok");
+}
+
+{
+	// sub2api-auth: missing dashboard credentials is not-configured (never a blind request).
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth", usernameRef: "SUB2API_EMAIL", passwordRef: "SUB2API_PASSWORD" }
+	} }));
+	const account = await queryAccount(spec, credentials({}), { now: () => now, fetch: async () => { throw new Error("must not fetch without credentials"); } });
+	assert.equal(account.status, "not-configured");
+	assert.equal(account.balance, null);
+	console.log("sub2api-auth missing credentials is not-configured ok");
+}
+
+{
+	// Config validation: sub2api-auth demands an auth pathway.
+	assert.throws(() => validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth", usernameRef: "SUB2API_EMAIL" }
+	} }), /accessTokenRef or both usernameRef and passwordRef/i);
+	assert.throws(() => validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth", passwordRef: 123 }
+	} }), /must be a credential reference name/i);
+	console.log("sub2api-auth config validation ok");
+}
+
+{
 	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
 		"relay-a": { adapter: "general" }
 	} }));

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -530,23 +530,69 @@ console.log("IPv4/IPv6 private-address classification ok");
 }
 
 {
-	// sub2api-auth: an invalid numeric balance is classified as invalid-response,
-	// and the snapshot surfaces the observed top-level keys for diagnosis.
+	// sub2api-auth: when /user/balance returns no recognizable numeric balance,
+	// the flow falls back to /v1/usage (same model API key).
 	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
 		"relay-a": { adapter: "sub2api-auth" }
 	} }));
 	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
 		now: () => now,
 		fetch: async (url) => {
+			if (String(url).endsWith("/user/balance")) return jsonResponse({});
+			if (String(url).endsWith("/v1/usage")) return jsonResponse({ isValid: true, balance: 6.6, unit: "USD", planName: "Panel" });
 			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
-			assert.equal(String(url).endsWith("/user/balance"), true);
-			return jsonResponse({});
+			throw new Error(`unexpected url: ${url}`);
+		}
+	});
+	assert.equal(account.status, "ok");
+	assert.equal(account.mode, "balance");
+	assert.equal(account.balance.remaining, 6.6);
+	assert.equal(account.plan, "Panel");
+	console.log("sub2api-auth /user/balance empty falls back to /v1/usage ok");
+}
+
+{
+	// sub2api-auth: an SPA HTML response for /user/balance (like real panels'
+	// catch-all) is skipped and the panel's /v1/usage is used instead.
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async (url) => {
+			if (String(url).endsWith("/user/balance")) return new Response("<!doctype html><title>SPA</title>", {
+				status: 200,
+				headers: { "content-type": "text/html" }
+			});
+			if (String(url).endsWith("/v1/usage")) return jsonResponse({ mode: "unrestricted", isValid: true, remaining: 8.25, unit: "USD", balance: 8.25 });
+			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
+			throw new Error(`unexpected url: ${url}`);
+		}
+	});
+	assert.equal(account.status, "ok");
+	assert.equal(account.balance.remaining, 8.25);
+	console.log("sub2api-auth HTML /user/balance falls back to /v1/usage ok");
+}
+
+{
+	// sub2api-auth: when both endpoints fail to yield a balance, the snapshot
+	// stays invalid-response and surfaces the /user/balance top-level keys.
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async (url) => {
+			if (String(url).endsWith("/user/balance")) return jsonResponse({ message: "nope" });
+			if (String(url).endsWith("/v1/usage")) return jsonResponse({});
+			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
+			throw new Error(`unexpected url: ${url}`);
 		}
 	});
 	assert.equal(account.status, "invalid-response");
 	assert.equal(account.balance, null);
-	assert.match(account.reason, /^sub2api-balance-keys:/, "must surface which keys the panel returned");
-	console.log("sub2api-auth missing numeric balance maps to invalid-response ok");
+	assert.match(account.reason, /^sub2api-balance-keys:message/, "must surface which keys the panel returned");
+	console.log("sub2api-auth both endpoints missing balance keeps invalid-response ok");
 }
 
 {
@@ -557,9 +603,10 @@ console.log("IPv4/IPv6 private-address classification ok");
 	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
 		now: () => now,
 		fetch: async (url) => {
+			if (String(url).endsWith("/user/balance")) return jsonResponse({ code: 0, message: "ok", data: { balance: 4.2, unit: "USD" } });
+			if (String(url).endsWith("/v1/usage")) throw new Error("must not fall back when /user/balance already yields a balance");
 			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
-			assert.equal(String(url).endsWith("/user/balance"), true);
-			return jsonResponse({ code: 0, message: "ok", data: { balance: 4.2, unit: "USD" } });
+			throw new Error(`unexpected url: ${url}`);
 		}
 	});
 	assert.equal(account.status, "ok");

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -603,6 +603,96 @@ console.log("IPv4/IPv6 private-address classification ok");
 }
 
 {
+	// Auto-detection hit: a provider with no adapter, shared panel credentials
+	// present, and a public-settings fingerprint is auto-selected as sub2api-auth.
+	const probed = [];
+	const account = await queryAccount(resolveAccountSpec(relay, validateAccountConfig()), credentials({
+		SUB2API_EMAIL: "panel@example.com",
+		SUB2API_PASSWORD: "panel-secret"
+	}), {
+		now: () => now,
+		fetch: async (url, init) => {
+			if (String(url).endsWith("/api/v1/settings/public")) {
+				probed.push(String(url));
+				return jsonResponse({ code: 0, message: "ok", data: { affiliate_enabled: true } });
+			}
+			if (String(url).endsWith("/api/v1/auth/login")) {
+				return jsonResponse({ code: 0, message: "ok", data: { access_token: "auto-jwt" } });
+			}
+			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
+			assert.ok(String(url).endsWith("/api/v1/auth/me"));
+			assert.equal(init.headers.authorization, "Bearer auto-jwt");
+			return jsonResponse({ code: 0, message: "ok", data: { id: 7, username: "panel", balance: 3.5 } });
+		},
+		sessions: new Map(),
+		sub2apiDetection: new Map()
+	});
+	assert.equal(account.status, "ok");
+	assert.equal(account.mode, "balance");
+	assert.equal(account.adapter, "sub2api-auth");
+	assert.equal(account.balance.remaining, 3.5);
+	assert.ok(probed.length === 1, "panel probe must run");
+	console.log("sub2api-auth auto-detection fingerprint hit ok");
+}
+
+{
+	// Auto-detection miss: the probe shows it is not a Sub2API panel → unsupported,
+	// no dashboard login or balance query is attempted.
+	const account = await queryAccount(resolveAccountSpec(relay, validateAccountConfig()), credentials({
+		SUB2API_EMAIL: "panel@example.com",
+		SUB2API_PASSWORD: "panel-secret"
+	}), {
+		now: () => now,
+		fetch: async (url) => {
+			if (String(url).endsWith("/api/v1/settings/public")) {
+				return jsonResponse({ code: 0, message: "ok", data: { affiliate_enabled: "yes" } });
+			}
+			throw new Error("must not query non-panel endpoints when the probe misses");
+		},
+		sub2apiDetection: new Map()
+	});
+	assert.equal(account.status, "unsupported");
+	assert.equal(account.balance, null);
+	console.log("sub2api-auth auto-detection fingerprint miss ok");
+}
+
+{
+	// Auto-detection is gated on shared credentials: without panel credentials the
+	// provider is left unsupported and never probed.
+	let fetched = false;
+	const account = await queryAccount(resolveAccountSpec(relay, validateAccountConfig()), credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async () => { fetched = true; throw new Error("must not probe without panel credentials"); },
+		sub2apiDetection: new Map()
+	});
+	assert.equal(account.status, "unsupported");
+	assert.equal(fetched, false, "no request must fire without panel credentials");
+	console.log("sub2api-auth auto-detection requires shared credentials ok");
+}
+
+{
+	// An explicit adapter always wins over auto-detection: a provider bound to
+	// `new-api` is never probed or overridden even with panel credentials.
+	let fetched = false;
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "new-api" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay", SUB2API_EMAIL: "panel@example.com", SUB2API_PASSWORD: "x" }), {
+		now: () => now,
+		fetch: async (url) => {
+			if (String(url).endsWith("/api/v1/settings/public")) { fetched = true; throw new Error("explicit adapter must not be probed"); }
+			if (String(url).endsWith("/api/status")) return jsonResponse({ data: { quota_per_unit: 500000 } });
+			return jsonResponse({ code: true, data: { total_granted: 10, total_used: 2, total_available: 8 } });
+		},
+		sub2apiDetection: new Map()
+	});
+	assert.equal(account.status, "ok");
+	assert.equal(account.adapter, "new-api");
+	assert.equal(fetched, false, "explicit adapter must bypass the panel probe");
+	console.log("sub2api-auth auto-detection never overrides explicit adapter ok");
+}
+
+{
 	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
 		"relay-a": { adapter: "general" }
 	} }));

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -22,6 +22,13 @@ function jsonResponse(value, status = 200, headers = {}) {
 	});
 }
 
+/** Build a fake provider-status error the way lib/accounts.js statusError() does. */
+function statusErrorFromTest(status, message) {
+	const error = new Error(message);
+	error.providerStatus = status;
+	return error;
+}
+
 const now = Date.parse("2026-08-15T00:00:00Z");
 const relay = {
 	id: "relay-a",
@@ -591,7 +598,7 @@ console.log("IPv4/IPv6 private-address classification ok");
 	});
 	assert.equal(account.status, "invalid-response");
 	assert.equal(account.balance, null);
-	assert.match(account.reason, /^sub2api-balance-keys:message/, "must surface which keys the panel returned");
+	assert.equal(account.reason, "sub2api-balance-shape-unrecognized", "reason must be a fixed enum, never upstream-controlled keys");
 	console.log("sub2api-auth both endpoints missing balance keeps invalid-response ok");
 }
 
@@ -692,6 +699,78 @@ console.log("IPv4/IPv6 private-address classification ok");
 	assert.equal(account.adapter, "new-api");
 	assert.equal(fetched, false, "explicit adapter must bypass the panel probe");
 	console.log("sub2api-auth auto-detection never overrides explicit adapter ok");
+}
+
+{
+	// P1 regression: upstream-controlled JSON property names must never appear
+	// in the normalized snapshot's reason. A hostile panel echoing sensitive
+	// material as an object key (e.g. an API key) must stay out of safeReason.
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async (url) => {
+			if (String(url).endsWith("/user/balance")) return jsonResponse({ "sk-super-secret-api-key": 1 });
+			if (String(url).endsWith("/v1/usage")) return jsonResponse({});
+			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
+			throw new Error(`unexpected url: ${url}`);
+		}
+	});
+	assert.equal(account.status, "invalid-response");
+	assert.equal(account.reason, "sub2api-balance-shape-unrecognized", "reason must be a fixed enum");
+	assert.equal(JSON.stringify(account).includes("sk-super-secret-api-key"), false, "upstream-controlled key must never reach the snapshot");
+	console.log("sub2api-auth upstream key names never leak into snapshot ok");
+}
+
+{
+	// P1 regression: the detection cache must live on the service, so two
+	// refresh/query cycles for the same configKey probe the panel only once.
+	let probes = 0;
+	const service = createAccountService({
+		credentials: credentials({ RELAY_A_KEY: "sk-relay" }),
+		getProviders: async () => [relay],
+		config: { monitors: {} },
+		deps: {
+			now: () => now,
+			fetch: async (url, init) => {
+				if (String(url).endsWith("/api/v1/settings/public")) {
+					probes += 1;
+					return jsonResponse({ code: 0, message: "ok", data: { affiliate_enabled: true } });
+				}
+				if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
+				if (String(url).endsWith("/user/balance")) return jsonResponse({ balance: 1.5, unit: "USD" });
+				throw new Error(`unexpected url: ${url}`);
+			}
+		}
+	});
+	const first = await service.get("relay-a", { force: true });
+	assert.equal(first.adapter, "sub2api-auth");
+	assert.equal(probes, 1, "first cycle must probe exactly once");
+	const second = await service.get("relay-a", { force: true });
+	assert.equal(second.adapter, "sub2api-auth");
+	assert.equal(probes, 1, "second cycle must reuse the persisted detection cache");
+	console.log("sub2api-auth detection cache persists across service refreshes ok");
+}
+
+{
+	// Reviewer suggestion: security-policy/TLS failures on /user/balance must
+	// not be silently swallowed into the /v1/usage fallback — the real error
+	// surfaces instead of being masked.
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async (url) => {
+			if (String(url).endsWith("/user/balance")) {
+				throw statusErrorFromTest("blocked", "account monitor requires HTTPS");
+			}
+			throw new Error(`must not fall back after a security-policy failure: ${url}`);
+		}
+	});
+	assert.equal(account.status, "blocked", "security-policy failures must surface, not fall back");
+	console.log("sub2api-auth security-policy failure not swallowed ok");
 }
 
 {

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -530,7 +530,8 @@ console.log("IPv4/IPv6 private-address classification ok");
 }
 
 {
-	// sub2api-auth: an invalid numeric balance is classified as invalid-response.
+	// sub2api-auth: an invalid numeric balance is classified as invalid-response,
+	// and the snapshot surfaces the observed top-level keys for diagnosis.
 	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
 		"relay-a": { adapter: "sub2api-auth" }
 	} }));
@@ -544,7 +545,26 @@ console.log("IPv4/IPv6 private-address classification ok");
 	});
 	assert.equal(account.status, "invalid-response");
 	assert.equal(account.balance, null);
+	assert.match(account.reason, /^sub2api-balance-keys:/, "must surface which keys the panel returned");
 	console.log("sub2api-auth missing numeric balance maps to invalid-response ok");
+}
+
+{
+	// sub2api-auth: a nested { code, data: { balance } } envelope is recognized.
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async (url) => {
+			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
+			assert.equal(String(url).endsWith("/user/balance"), true);
+			return jsonResponse({ code: 0, message: "ok", data: { balance: 4.2, unit: "USD" } });
+		}
+	});
+	assert.equal(account.status, "ok");
+	assert.equal(account.balance.remaining, 4.2);
+	console.log("sub2api-auth nested data.balance envelope ok");
 }
 
 {

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -473,158 +473,96 @@ console.log("IPv4/IPv6 private-address classification ok");
 }
 
 {
-	// sub2api-auth: email+password login, then the dashboard balance + today usage.
+	// sub2api-auth: reuse the provider's own API key (already configured in the
+	// model) against GET /user/balance — the CC Switch General template.
 	const calls = [];
 	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
-		"relay-a": {
-			adapter: "sub2api-auth",
-			usernameRef: "SUB2API_EMAIL",
-			passwordRef: "SUB2API_PASSWORD"
-		}
+		"relay-a": { adapter: "sub2api-auth" }
 	} }));
-	const account = await queryAccount(spec, credentials({ SUB2API_EMAIL: "me@example.com", SUB2API_PASSWORD: "s3cret" }), {
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
 		now: () => now,
 		fetch: async (url, init) => {
-			calls.push({ url: String(url), method: init?.method ?? "GET", authorization: init?.headers?.authorization });
-			if (String(url).endsWith("/api/v1/auth/login")) {
-				assert.equal(init.method, "POST");
-				const body = JSON.parse(init.body);
-				assert.equal(body.email, "me@example.com");
-				assert.equal(body.password, "s3cret");
-				return jsonResponse({ code: 0, message: "ok", data: { access_token: "jwt-access", refresh_token: "jwt-refresh", expires_in: 3000 } });
-			}
+			calls.push({ url: String(url), authorization: init?.headers?.authorization });
 			if (String(url).includes("/api/v1/usage/stats")) {
-				return jsonResponse({ code: 0, message: "ok", data: { total_actual_cost: 2.5, total_input_tokens: 100, total_output_tokens: 50, total_requests: 3 } });
+				return jsonResponse({ code: 0, message: "ok", data: { total_actual_cost: 2.5, total_input_tokens: 100, total_output_tokens: 50 } });
 			}
-			assert.ok(String(url).endsWith("/api/v1/auth/me"));
-			assert.equal(init.headers.authorization, "Bearer jwt-access");
-			return jsonResponse({ code: 0, message: "ok", data: { id: 42, username: "relay-a-owner", email: "me@example.com", balance: 12.5 } });
+			assert.equal(String(url).endsWith("/user/balance"), true);
+			assert.equal(init.headers.authorization, "Bearer sk-relay");
+			return jsonResponse({ balance: 12.5, unit: "USD", planName: "Relay A" });
 		}
 	});
 	assert.equal(account.status, "ok");
 	assert.equal(account.mode, "balance");
-	assert.equal(account.plan, "relay-a-owner");
+	assert.equal(account.plan, "Relay A");
 	assert.deepEqual(account.balance, { remaining: 12.5, used: 2.5, currency: "USD", unlimited: false, expiresAt: null });
-	assert.equal(JSON.stringify(account).includes("jwt-access"), false, "access token must never leak into the snapshot");
-	assert.equal(JSON.stringify(account).includes("s3cret"), false, "password must never leak into the snapshot");
-	console.log("sub2api-auth login + balance normalization ok");
+	assert.equal(JSON.stringify(account).includes("sk-relay"), false, "provider key must never leak into the snapshot");
+	console.log("sub2api-auth reuses provider API key against /user/balance ok");
 }
 
 {
-	// sub2api-auth: a pre-issued access token avoids storing the panel password.
+	// sub2api-auth: a numeric-string balance and missing currency default to USD.
 	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
-		"relay-a": { adapter: "sub2api-auth", accessTokenRef: "SUB2API_ACCESS_TOKEN" }
+		"relay-a": { adapter: "sub2api-auth" }
 	} }));
-	const account = await queryAccount(spec, credentials({ SUB2API_ACCESS_TOKEN: "static-jwt" }), {
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
 		now: () => now,
-		fetch: async (url, init) => {
-			if (String(url).endsWith("/api/v1/auth/login")) { throw new Error("must not log in when a token is provided"); }
+		fetch: async (url) => {
 			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
-			assert.equal(String(url).endsWith("/api/v1/auth/me"), true);
-			assert.equal(init.headers.authorization, "Bearer static-jwt");
-			return jsonResponse({ code: 0, message: "ok", data: { id: 1, username: "static", balance: 9.9 } });
-		},
-		sessions: new Map()
-	});
-	assert.equal(account.status, "ok");
-	assert.equal(account.balance.remaining, 9.9);
-	console.log("sub2api-auth static access token path ok");
-}
-
-{
-	// sub2api-auth: a stale JWT (401) triggers one re-login and a successful retry.
-	let meCalls = 0;
-	let loginCount = 0;
-	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
-		"relay-a": { adapter: "sub2api-auth", usernameRef: "SUB2API_EMAIL", passwordRef: "SUB2API_PASSWORD" }
-	} }));
-	const account = await queryAccount(spec, credentials({ SUB2API_EMAIL: "me@example.com", SUB2API_PASSWORD: "s3cret" }), {
-		now: () => now,
-		sessions: new Map(),
-		fetch: async (url, init) => {
-			if (String(url).endsWith("/api/v1/auth/login")) {
-				loginCount += 1;
-				return jsonResponse({ code: 0, message: "ok", data: { access_token: `jwt-${loginCount}` } });
-			}
-			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
-			assert.ok(String(url).endsWith("/api/v1/auth/me"));
-			meCalls += 1;
-			// The first dashboard request uses the initial(now-stale) token.
-			if (meCalls === 1) return jsonResponse({ code: 0, message: "no" }, 401);
-			assert.equal(init.headers.authorization, "Bearer jwt-2", "retry must use the newer token");
-			return jsonResponse({ code: 0, message: "ok", data: { id: 1, username: "retry", balance: 7.25 } });
+			assert.equal(String(url).endsWith("/user/balance"), true);
+			return jsonResponse({ balance: "7.25" });
 		}
 	});
 	assert.equal(account.status, "ok");
 	assert.equal(account.balance.remaining, 7.25);
-	assert.equal(loginCount, 2, "a stale token must trigger exactly one re-login");
-	console.log("sub2api-auth stale-JWT re-login retry ok");
+	assert.equal(account.balance.currency, "USD");
+	console.log("sub2api-auth numeric-string balance and default currency ok");
 }
 
 {
-	// sub2api-auth: persistent login failure surfaces as unauthorized, never a secret leak.
+	// sub2api-auth: missing provider API key is not-configured (never a blind request).
 	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
-		"relay-a": { adapter: "sub2api-auth", usernameRef: "SUB2API_EMAIL", passwordRef: "SUB2API_PASSWORD" }
+		"relay-a": { adapter: "sub2api-auth" }
 	} }));
-	const account = await queryAccount(spec, credentials({ SUB2API_EMAIL: "me@example.com", SUB2API_PASSWORD: "wrong" }), {
-		now: () => now,
-		fetch: async (url, init) => {
-			if (String(url).endsWith("/api/v1/auth/login")) {
-				return jsonResponse({ code: 401, message: "invalid credentials" });
-			}
-			return jsonResponse({}, 401);
-		}
-	});
-	assert.equal(account.status, "unauthorized");
-	assert.equal(account.balance, null);
-	console.log("sub2api-auth failed login maps to unauthorized ok");
-}
-
-{
-	// sub2api-auth: missing dashboard credentials is not-configured (never a blind request).
-	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
-		"relay-a": { adapter: "sub2api-auth", usernameRef: "SUB2API_EMAIL", passwordRef: "SUB2API_PASSWORD" }
-	} }));
-	const account = await queryAccount(spec, credentials({}), { now: () => now, fetch: async () => { throw new Error("must not fetch without credentials"); } });
+	const account = await queryAccount(spec, credentials({}), { now: () => now, fetch: async () => { throw new Error("must not fetch without a provider API key"); } });
 	assert.equal(account.status, "not-configured");
 	assert.equal(account.balance, null);
-	console.log("sub2api-auth missing credentials is not-configured ok");
+	console.log("sub2api-auth missing provider key is not-configured ok");
 }
 
 {
-	// Config validation: sub2api-auth demands an auth pathway.
-	assert.throws(() => validateAccountConfig({ monitors: {
-		"relay-a": { adapter: "sub2api-auth", usernameRef: "SUB2API_EMAIL" }
-	} }), /accessTokenRef or both usernameRef and passwordRef/i);
-	assert.throws(() => validateAccountConfig({ monitors: {
-		"relay-a": { adapter: "sub2api-auth", passwordRef: 123 }
-	} }), /must be a credential reference name/i);
-	console.log("sub2api-auth config validation ok");
+	// sub2api-auth: an invalid numeric balance is classified as invalid-response.
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "sub2api-auth" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async (url) => {
+			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
+			assert.equal(String(url).endsWith("/user/balance"), true);
+			return jsonResponse({});
+		}
+	});
+	assert.equal(account.status, "invalid-response");
+	assert.equal(account.balance, null);
+	console.log("sub2api-auth missing numeric balance maps to invalid-response ok");
 }
 
 {
-	// Auto-detection hit: a provider with no adapter, shared panel credentials
-	// present, and a public-settings fingerprint is auto-selected as sub2api-auth.
+	// Auto-detection hit: a relay provider with an API key and a public-settings
+	// fingerprint is auto-selected as sub2api-auth and queried with its own key.
 	const probed = [];
-	const account = await queryAccount(resolveAccountSpec(relay, validateAccountConfig()), credentials({
-		SUB2API_EMAIL: "panel@example.com",
-		SUB2API_PASSWORD: "panel-secret"
-	}), {
+	const account = await queryAccount(resolveAccountSpec(relay, validateAccountConfig()), credentials({ RELAY_A_KEY: "sk-relay" }), {
 		now: () => now,
 		fetch: async (url, init) => {
 			if (String(url).endsWith("/api/v1/settings/public")) {
 				probed.push(String(url));
 				return jsonResponse({ code: 0, message: "ok", data: { affiliate_enabled: true } });
 			}
-			if (String(url).endsWith("/api/v1/auth/login")) {
-				return jsonResponse({ code: 0, message: "ok", data: { access_token: "auto-jwt" } });
-			}
 			if (String(url).includes("/api/v1/usage/stats")) return jsonResponse({ code: 0, message: "ok", data: {} });
-			assert.ok(String(url).endsWith("/api/v1/auth/me"));
-			assert.equal(init.headers.authorization, "Bearer auto-jwt");
-			return jsonResponse({ code: 0, message: "ok", data: { id: 7, username: "panel", balance: 3.5 } });
+			assert.ok(String(url).endsWith("/user/balance"));
+			assert.equal(init.headers.authorization, "Bearer sk-relay");
+			return jsonResponse({ balance: 3.5, unit: "USD" });
 		},
-		sessions: new Map(),
 		sub2apiDetection: new Map()
 	});
 	assert.equal(account.status, "ok");
@@ -637,11 +575,8 @@ console.log("IPv4/IPv6 private-address classification ok");
 
 {
 	// Auto-detection miss: the probe shows it is not a Sub2API panel → unsupported,
-	// no dashboard login or balance query is attempted.
-	const account = await queryAccount(resolveAccountSpec(relay, validateAccountConfig()), credentials({
-		SUB2API_EMAIL: "panel@example.com",
-		SUB2API_PASSWORD: "panel-secret"
-	}), {
+	// no balance query is attempted with the provider key.
+	const account = await queryAccount(resolveAccountSpec(relay, validateAccountConfig()), credentials({ RELAY_A_KEY: "sk-relay" }), {
 		now: () => now,
 		fetch: async (url) => {
 			if (String(url).endsWith("/api/v1/settings/public")) {
@@ -657,27 +592,27 @@ console.log("IPv4/IPv6 private-address classification ok");
 }
 
 {
-	// Auto-detection is gated on shared credentials: without panel credentials the
-	// provider is left unsupported and never probed.
+	// Auto-detection is gated on a provider API key: an unkeyed relay is left
+	// unsupported and never probed.
 	let fetched = false;
-	const account = await queryAccount(resolveAccountSpec(relay, validateAccountConfig()), credentials({ RELAY_A_KEY: "sk-relay" }), {
+	const account = await queryAccount(resolveAccountSpec(relay, validateAccountConfig()), credentials({}), {
 		now: () => now,
-		fetch: async () => { fetched = true; throw new Error("must not probe without panel credentials"); },
+		fetch: async () => { fetched = true; throw new Error("must not probe without a provider API key"); },
 		sub2apiDetection: new Map()
 	});
 	assert.equal(account.status, "unsupported");
-	assert.equal(fetched, false, "no request must fire without panel credentials");
-	console.log("sub2api-auth auto-detection requires shared credentials ok");
+	assert.equal(fetched, false, "no request must fire without a provider API key");
+	console.log("sub2api-auth auto-detection requires a provider API key ok");
 }
 
 {
 	// An explicit adapter always wins over auto-detection: a provider bound to
-	// `new-api` is never probed or overridden even with panel credentials.
+	// `new-api` is never probed or overridden even with a provider API key.
 	let fetched = false;
 	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
 		"relay-a": { adapter: "new-api" }
 	} }));
-	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay", SUB2API_EMAIL: "panel@example.com", SUB2API_PASSWORD: "x" }), {
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
 		now: () => now,
 		fetch: async (url) => {
 			if (String(url).endsWith("/api/v1/settings/public")) { fetched = true; throw new Error("explicit adapter must not be probed"); }


### PR DESCRIPTION
# 支持真实 Sub2API 面板余额查询（sub2api-auth）

## 背景 / Background

仓库原有 `sub2api` 适配器面向的是暴露 `GET /v1/usage` + 静态 API Key 的部署协议。真实 Sub2API 面板（Wei-Shaw/sub2api 系，如本 PR 实测的星渡 v0.1.178）**没有公开的余额查询接口**——上游通常是被代理的订阅，不向推理 Key 开放余额；而面板自身的账户余额需要 dashboard 会话，无法用推理 Key 读取。

经过对真实面板的在线探测（`/api/v1/settings/public` 命中指纹、`/user/balance` 被 SPA 兜底返回 HTML、`/v1/usage` 存在且 401），最终确定方案：**复用 provider 在 DSH 模型页已配置的 API Key，先试 CC Switch 风格的 `/user/balance`，自动回退到面板真实存在的 `/v1/usage`**。

## 改动 / Changes

新增 `sub2api-auth` adapter（`lib/accounts.js`）：

1. **凭据**：直接复用 provider 的 `apiKeyEnv`（模型页已配置的 Key），**无需任何单独的面板凭据**，参考 CC Switch General 模板。
2. **查询顺序**（同一把 Key，按序尝试）：
   - `GET {baseUrl}/user/balance`（CC Switch 形状：`body.balance`，兼容 `data.balance` / `remaining` / `data.remaining`）；
   - 拿到 HTML / 非 JSON / 缺余额时，**自动回退 `GET {baseUrl}/v1/usage`**（旧 Sub2API/passion 形状，解析逻辑抽成 `parseSub2ApiUsage` 复用，支持余额与订阅窗口）。
3. **自动识别真实面板**：对没有显式 adapter 且已配置 API Key 的 provider，探测 `GET /api/v1/settings/public`（返回 `data.affiliate_enabled: boolean` 即命中），命中后自动按 `sub2api-auth` 查询。边界：无 Key 绝不探测；探测按 provider 配置缓存一次；显式 `adapter` 始终优先；后台刷新只纳入有 Key 的候选。
4. **诊断**：两个端点都拿不到余额时，账户快照携带脱敏原因 `sub2api-balance-keys:<顶层键名>`；非 JSON / 坏 JSON / 超大响应也有独立原因（`upstream-not-json` / `upstream-invalid-json` / `upstream-too-large`），客户端展示可读文案（`lib/client.js` 中英文案）。
5. New API 余额（`/api/usage/token/` + `quota_per_unit`）保持不变。

## 测试 / Tests

在 `scripts/test-accounts.mjs` 新增 11 个离线 fixture 测试：

- 复用 provider Key 查 `/user/balance`
- 空对象 / **SPA HTML 响应自动回退 `/v1/usage`**
- 双端点都失败 → `invalid-response` 并携带键名诊断
- `{code,data:{balance}}` 信封解析、字符串金额与默认币种
- 缺 provider Key → `not-configured`
- 自动识别：指纹命中 / 未命中 / 无 Key 不探测 / 显式 adapter 不被覆盖

`npm run check` 与 `npm test`（全部 7 个套件）均通过。

## 配置示例 / Config

面板作为普通 provider 配进 DSH（baseURL 指向面板、API Key 填可用密钥）即可，无需单独写 adapter：

```yaml
# ~/.dsh/profiles/web/cordis.patch.yml（已有 dsh-usage-stats entry 下合并 config）
        monitors:
          relay-b:
            adapter: sub2api-auth
            warning:
              warnBelow: 5
              criticalBelow: 1
```

不写 adapter 时由自动识别接管（需 provider 已配置 API Key）。

## 验证情况 / Verified

- 本地离线测试全绿（见上）。
- 真实面板（aiwtiaw.top，星渡 sub2api v0.1.178）实测：`/user/balance` 返回 SPA HTML → 自动回退 `/v1/usage` 后余额正常显示。
