### PR TITLE
chore: prepare v0.2.5 hotfix release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-usage-stats",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-usage-stats",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-usage-stats",
   "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prepare `v0.2.5` as a narrowly scoped crash hotfix.

## Scope

- #39 / #34 — explicitly disable Node 20+/24 network-family autoselection inside each already-pinned request attempt, so an unreachable IPv6 route cannot escape the plugin's validated-address fallback as an unhandled TLSSocket error.
- keep the existing SSRF/private-network/fake-IP policy and outer validated-address fallback unchanged.

## Release policy

- #14 MiniMax remains open pending the newly requested diagnostic text; it is not guessed/fixed in this hotfix.
- #38 Sub2API remains outside this release while its maintainer review blockers are unresolved.
- this PR must remain version-only: `package.json` / `package-lock.json` `0.2.4 → 0.2.5`.
- require full CI green on the exact final head before merge.

Suggested headline: `v0.2.5 — Node 24 / WSL transport crash hotfix`.