### PR TITLE
feat: add DSH Community Market catalog source (Path A) for GUI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"
 
 **使用前提（重要）**：市场托管安装只接受 npm registry 的精确稳定版本，git 条目仅可浏览。`dsh-usage-stats` 这个 npm 名已被其他项目占用，因此目录条目身份使用 `@ychris12138/dsh-usage-stats`（当前可用）。要启用 GUI「安装」按钮，需先发布：
 
-1. 把 `package.json` 的 `name` 改为 `@ychris12138/dsh-usage-stats`（或你选定的可用名），去掉 `private: true`，并同步 `cordis.patch.yml` 的 `name` 与 `catalog/v1/plugins.json` 的 `package.name` / `latestVersion`。
+1. 把 `package.json` 的 `name` 改为 `@ychris12138/dsh-usage-stats`（或你选定的可用名），去掉 `private: true`，并同步 `cordis.patch.yml` 的 `name` 与 `catalog/v1/plugins.json` 的 `package.name` / `latestVersion`；**每次发版都要同步 bump `catalog/v1/plugins.json` 的 `latestVersion`**。
 2. `npm publish`（scoped 公开包）。
-3. 把 `catalog/v1/plugins.json` 内容发布到 `https://ycris12138.github.io/dsh-usage-stats/v1/plugins`（GitHub Pages，manifest 与 endpoint 必须同源、HTTPS 443、无凭据）。
-4. 在 DSH 插件市场 → 来源管理 → 添加来源，粘贴 manifest URL：`https://ycris12138.github.io/dsh-usage-stats/catalog-source.json`，选择后即可走「可恢复安装边界」GUI 安装。
+3. 把 `catalog/v1/plugins.json` 内容发布到 `https://ychris12138.github.io/dsh-usage-stats/v1/plugins`（GitHub Pages，manifest 与 endpoint 必须同源、HTTPS 443、无凭据）。
+4. 在 DSH 插件市场 → 来源管理 → 添加来源，粘贴 manifest URL：`https://ychris12138.github.io/dsh-usage-stats/catalog-source.json`，选择后即可走「可恢复安装边界」GUI 安装。
 
 > 若最终包名不同，请同步修改 `catalog-source.json` 的 `providerId`/`transport.endpoint` 与 `catalog/v1/plugins.json` 的身份字段。发布前目录条目可浏览但安装保持禁用（fail-closed，属预期）。
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"
 
 然后重启已经运行的 `dsh web`，并在浏览器中硬刷新。侧边栏底部会出现“用量/余额”（Usage/Balance）入口。
 
+### 插件市场 GUI 安装（DSH Community Market，Path A 标准来源）
+
+本仓库按 [DSH Community Market 目录 adapter 指南](https://github.com/anywhere-labs/deepseek-harness-desktop/blob/master/dsh-community-market/docs/catalog-adapter-guide.zh.md) 的**标准来源（Path A）** 接入，无需修改 Market 代码。内置两份目录数据：
+
+- `catalog/catalog-source.json` — 来源 manifest（`catalog-source.schema.json` v1.0.0）
+- `catalog/v1/plugins.json` — 标准 provider page（`catalog-provider-page.schema.json` v1.0.0）
+
+**使用前提（重要）**：市场托管安装只接受 npm registry 的精确稳定版本，git 条目仅可浏览。`dsh-usage-stats` 这个 npm 名已被其他项目占用，因此目录条目身份使用 `@ychris12138/dsh-usage-stats`（当前可用）。要启用 GUI「安装」按钮，需先发布：
+
+1. 把 `package.json` 的 `name` 改为 `@ychris12138/dsh-usage-stats`（或你选定的可用名），去掉 `private: true`，并同步 `cordis.patch.yml` 的 `name` 与 `catalog/v1/plugins.json` 的 `package.name` / `latestVersion`。
+2. `npm publish`（scoped 公开包）。
+3. 把 `catalog/v1/plugins.json` 内容发布到 `https://ycris12138.github.io/dsh-usage-stats/v1/plugins`（GitHub Pages，manifest 与 endpoint 必须同源、HTTPS 443、无凭据）。
+4. 在 DSH 插件市场 → 来源管理 → 添加来源，粘贴 manifest URL：`https://ycris12138.github.io/dsh-usage-stats/catalog-source.json`，选择后即可走「可恢复安装边界」GUI 安装。
+
+> 若最终包名不同，请同步修改 `catalog-source.json` 的 `providerId`/`transport.endpoint` 与 `catalog/v1/plugins.json` 的身份字段。发布前目录条目可浏览但安装保持禁用（fail-closed，属预期）。
+
 升级或卸载：
 
 ```bash

--- a/catalog/catalog-source.json
+++ b/catalog/catalog-source.json
@@ -1,0 +1,27 @@
+{
+  "manifestVersion": "1.0.0",
+  "providerId": "io.github.ycris12138.dsh-usage-stats",
+  "name": "DSH Usage Stats",
+  "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI. 标准来源接入（Path A），便于在 DSH 插件市场内通过 GUI 直接安装。",
+  "homepage": "https://github.com/Ychris12138/dsh-usage-stats",
+  "attribution": {
+    "name": "Ychris12138",
+    "url": "https://github.com/Ychris12138"
+  },
+  "transport": {
+    "kind": "https-json",
+    "endpoint": "https://ycris12138.github.io/dsh-usage-stats/v1/plugins",
+    "method": "GET"
+  },
+  "query": {
+    "supported": [
+      "q",
+      "category",
+      "cursor",
+      "limit"
+    ],
+    "defaultLimit": 50,
+    "maxLimit": 50,
+    "sorts": []
+  }
+}

--- a/catalog/catalog-source.json
+++ b/catalog/catalog-source.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": "1.0.0",
-  "providerId": "io.github.ycris12138.dsh-usage-stats",
+  "providerId": "io.github.ychris12138.dsh-usage-stats",
   "name": "DSH Usage Stats",
   "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI. 标准来源接入（Path A），便于在 DSH 插件市场内通过 GUI 直接安装。",
   "homepage": "https://github.com/Ychris12138/dsh-usage-stats",
@@ -10,7 +10,7 @@
   },
   "transport": {
     "kind": "https-json",
-    "endpoint": "https://ycris12138.github.io/dsh-usage-stats/v1/plugins",
+    "endpoint": "https://ychris12138.github.io/dsh-usage-stats/v1/plugins",
     "method": "GET"
   },
   "query": {

--- a/catalog/v1/plugins.json
+++ b/catalog/v1/plugins.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": "1.0.0",
+  "generatedAt": "2026-08-19T00:00:00.000Z",
+  "revision": "0.2.5",
+  "items": [
+    {
+      "id": "dsh-usage-stats",
+      "name": "@ychris12138/dsh-usage-stats",
+      "displayName": "DSH Usage Stats",
+      "summary": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI.",
+      "description": "在 DSH 对话界面内展示 Token 用量热力图、各 provider 账户余额与订阅配额，数据来自持久化会话日志。catalog 条目身份与 npm 包 `@ychris12138/dsh-usage-stats` 对齐，发布后即可通过插件市场 GUI 直接安装。",
+      "homepage": "https://github.com/Ychris12138/dsh-usage-stats",
+      "latestVersion": "0.2.5",
+      "license": "MIT",
+      "categories": [
+        "development",
+        "analytics"
+      ],
+      "keywords": [
+        "deepseek",
+        "deepseek-harness",
+        "dsh",
+        "token-usage",
+        "balance",
+        "quotas"
+      ],
+      "repository": {
+        "url": "https://github.com/Ychris12138/dsh-usage-stats"
+      },
+      "package": {
+        "registry": "npm",
+        "name": "@ychris12138/dsh-usage-stats"
+      },
+      "publisher": {
+        "name": "Ychris12138",
+        "url": "https://github.com/Ychris12138"
+      },
+      "compatibility": {
+        "hosts": [
+          "dsh"
+        ]
+      },
+      "updatedAt": "2026-08-19T00:00:00.000Z"
+    }
+  ],
+  "page": {}
+}


### PR DESCRIPTION
### Summary / 摘要

Adds standard DSH Community Market catalog-source data so this plugin can be registered as a **Path A (standard source)** catalog and installed from the desktop plugin-market GUI.

本 PR 按 DSH Community Market 目录 adapter 指南的 **Path A（标准来源）** 为插件补充标准目录数据，使其可被登记为市场来源，并支持从桌面插件市场 GUI 直接安装。

---

### Why / 原因

- The plugin currently supports git-only installation (`dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"`). DSH Desktop 2.0.1 blocks the plain `dsh plugin add` path with `plugin add must use the recoverable install boundary`: third-party market GUIs (e.g. dshmarket) that click "Install" hit this guard and fail; the built-in Community Market installs through the recoverable boundary and only consumes standard catalog sources.
- 插件目前仅支持 git 安装（`dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"`）。DSH Desktop 2.0.1 将裸 `dsh plugin add` 通道封禁为 `plugin add must use the recoverable install boundary`：第三方市场 GUI（如 dshmarket）点击「安装」会直接触发该守卫而失败；内置 Community Market 走「可恢复安装边界」，且只消费标准目录来源。
- Following the catalog adapter guide's **Path A** requires no Market code changes: publish a manifest + `GET /v1/plugins` provider page, and after adding the source in the plugin market the plugin can be installed from the GUI. This prepares the repo for market installation once the package is published to npm.
- 按 catalog adapter 指南的 **Path A** 接入无需修改 Market 代码：发布 manifest + `GET /v1/plugins` provider page，用户添加来源后即可在 GUI 安装。本 PR 是包发布到 npm 之后市场安装的标准合规准备。

---

### Changes / 变更

- `catalog/catalog-source.json` — v1.0.0 source manifest（`providerId=io.github.ychris12138.dsh-usage-stats`，HTTPS 443 `/v1/plugins` endpoint，`query.supported=[q,category,cursor,limit]`，default/maxLimit=50）· v1.0.0 来源 manifest
- `catalog/v1/plugins.json` — v1.0.0 provider page（item identity `@ychris12138/dsh-usage-stats@0.2.5`，repository，publisher，categories，keywords，compatibility）· v1.0.0 provider page，条目身份 `@ychris12138/dsh-usage-stats@0.2.5`
- `README.md` — documents the catalog source, the npm publish prerequisite, and how to register the manifest URL in the plugin market · 文档化 catalog 来源、npm 发布前提与市场登记步骤

---

### Note / 说明

Managed installs only accept exact stable npm versions, so the "Install" button stays disabled until the package is published (fail-closed, as the contract expects). This PR is the standard-compliant preparation. Both JSON files validate against the official v1 schemas (`catalog-source` / `catalog-provider-page`) with Ajv2020 in strict mode with formats.

托管安装只接受 npm 精确稳定版本，因此在包发布到 npm 之前，市场条目可浏览但「安装」按钮保持禁用（fail-closed，符合契约预期）。本 PR 是标准合规的准备工作。两份 JSON 均已通过官方 v1 schema（`catalog-source` / `catalog-provider-page`）严格校验（Ajv2020，strict + formats）。

---

### 接入依据 / Reference（官方指南）

本 PR 的目录数据严格按 DSH Community Market **目录 adapter 指南 · Path A（标准来源）** 实现，参考文档：

- 中文：[catalog-adapter-guide.zh.md](https://github.com/anywhere-labs/deepseek-harness-desktop/blob/master/dsh-community-market/docs/catalog-adapter-guide.zh.md)
- English：[catalog-adapter-guide.md](https://github.com/anywhere-labs/deepseek-harness-desktop/blob/master/dsh-community-market/docs/catalog-adapter-guide.md)
- 权威契约：[catalog-provider-contract.zh.md](https://github.com/anywhere-labs/deepseek-harness-desktop/blob/master/dsh-community-market/docs/catalog-provider-contract.zh.md)

**Path A 接入点对照**（指南第 11–21 行）：
- `catalog/catalog-source.json` — 指南第 1 步：`catalog-source` manifest
- `catalog/v1/plugins.json` — 指南第 2 步：`GET /v1/plugins` → `catalog-provider-page`
- `query.supported=[q, category, cursor, limit]`、`defaultLimit/maxLimit=50` — 与指南建议的最小能力一致
- 同一无凭据 HTTPS 443 origin — 符合契约的 origin 约束
