### PR TITLE
fix: forward connect-phase socket errors in pinned requests

### DIFF
--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -554,6 +554,14 @@ function pinnedRequest(url, address, init, deps, signal) {
 			});
 		});
 		request.on("error", reject);
+		// Backstop: in the pinned-lookup path a connect-phase failure can surface
+		// directly on the socket before the request's own error forwarding has
+		// attached (#42 — an unhandled TLSSocket 'error' killed the whole dsh web
+		// process). Forward any socket-level error to the request so a transient
+		// network failure rejects this attempt instead of crashing the host.
+		request.on("socket", (socket) => {
+			socket.on("error", (error) => request.emit("error", error));
+		});
 		request.end();
 	});
 }

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -722,6 +722,38 @@ console.log("IPv4/IPv6 private-address classification ok");
 }
 
 {
+	const source = readFileSync(new URL("../lib/accounts.js", import.meta.url), "utf8");
+	assert.match(source, /request\.on\("socket",\s*\(socket\)\s*=>\s*\{[^}]*socket\.on\("error"/, "pinned request must forward connect-phase socket errors to the request (#42)");
+	console.log("pinned request socket error backstop present ok");
+}
+
+{
+	// Real transport regression for #42: a pinned connection to a closed port
+	// must reject through the normal error path (unavailable snapshot), never
+	// escape as an unhandled socket 'error' that kills the host process.
+	const { createServer } = await import("node:http");
+	const probe = createServer();
+	await new Promise((resolve) => probe.listen(0, "127.0.0.1", resolve));
+	const { port } = probe.address();
+	await new Promise((resolve) => probe.close(resolve)); // port is now guaranteed closed
+	const localProvider = { ...relay, baseURL: `http://localhost:${port}/v1` };
+	const spec = resolveAccountSpec(localProvider, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "general", allowPrivateNetwork: true, allowInsecure: true }
+	} }));
+	// No requestPinned mock: exercise the real pinnedRequest transport so the
+	// connect-phase ECONNREFUSED travels the exact socket error path from #42.
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		lookup: async () => [
+			{ address: "127.0.0.1", family: 4 }
+		]
+	});
+	assert.equal(account.status, "unavailable");
+	assert.equal(account.reason, "all-addresses-unreachable");
+	console.log("real socket connect refusal degrades without unhandled error ok");
+}
+
+{
 	const { createServer } = await import("node:http");
 	const server = createServer((req, res) => {
 		assert.equal(req.url, "/user/balance");


### PR DESCRIPTION
## 背景

#42 报告：`dsh web` 进程因账户监控 connect 阶段的 `EHOSTUNREACH` 直接崩溃——错误以 unhandled `'error'` 事件抛在 TLSSocket 上，没有转发给 request 对象。

报告者运行的是 0.2.2。其堆栈中的 `lookupAndConnectMultiple`（autoSelectFamily）路径已经在 v0.2.4/v0.2.5 中被移除（#35 多地址回退 + #39 钉死 family 并禁用 autoselect），但 **socket 级 error 逃逸是一类失败模式而非单一路径**，本 PR 加上报告者建议的兜底作为 defense-in-depth。

## 改动

**`lib/accounts.js` `pinnedRequest()`**：

```js
request.on("socket", (socket) => {
    socket.on("error", (error) => request.emit("error", error));
});
```

connect 阶段任何直接抛在 socket 上的 error 都被转发给 request → promise reject → 上层 `Promise.allSettled` 降级为「本次刷新失败」，进程不再退出。与 Node 自身的 socket error 转发并存时只是重复 reject，无副作用。

## 测试

- 新增源码级守护断言：pinned request 必须带 socket error 兜底（与既有 `autoSelectFamily: false` 源码检查同风格）；
- 新增真实传输回归：把连接钉到**保证关闭的端口**（listen 后 close 取得端口），不 mock `requestPinned`，断言 connect 阶段的 ECONNREFUSED 走正常错误路径降级为 `unavailable / all-addresses-unreachable` 而不是崩溃；
- 本地全部 8 个测试脚本通过。

Closes #42