### PR TITLE
chore: drop dead sub2api-balance-keys client branch, translate shape-unrecognized

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -382,10 +382,7 @@ window.__ModuleLoader__.load({
 			if (value === "all-addresses-unreachable") return translate("account.reason.allAddressesUnreachable");
 			if (value === "upstream-not-json") return translate("account.reason.upstreamNotJson");
 			if (value === "upstream-invalid-json") return translate("account.reason.upstreamInvalidJson");
-			if (value.startsWith("sub2api-balance-keys:")) {
-				const keys = value.slice("sub2api-balance-keys:".length);
-				return `${translate("account.reason.sub2apiUnknownKeys")}: ${keys}`;
-			}
+			if (value === "sub2api-balance-shape-unrecognized") return translate("account.reason.sub2apiBalanceShapeUnrecognized");
 			return value;
 		}
 
@@ -1331,7 +1328,7 @@ window.__ModuleLoader__.load({
 			"account.reason.allAddressesUnreachable": "已验证的网络地址均无法连接。",
 			"account.reason.upstreamNotJson": "上游返回的不是 JSON",
 			"account.reason.upstreamInvalidJson": "上游返回了无法解析的 JSON",
-			"account.reason.sub2apiUnknownKeys": "Sub2API 余额接口返回了未识别的字段，已返回顶层键",
+			"account.reason.sub2apiBalanceShapeUnrecognized": "Sub2API 余额接口返回了未识别的数据结构。",
 			"account.blocked": "账户查询被本地安全策略阻止，请检查 HTTPS、同源和私网访问设置。",
 			"balance.title": "账户余额",
 			"balance.provider": "供应商",
@@ -1419,7 +1416,7 @@ window.__ModuleLoader__.load({
 			"account.reason.allAddressesUnreachable": "None of the validated network addresses could be reached.",
 			"account.reason.upstreamNotJson": "The upstream response was not JSON",
 			"account.reason.upstreamInvalidJson": "The upstream returned unparsable JSON",
-			"account.reason.sub2apiUnknownKeys": "Sub2API balance returned unrecognized fields; top-level keys were",
+			"account.reason.sub2apiBalanceShapeUnrecognized": "The Sub2API balance endpoint returned an unrecognized data shape.",
 			"account.blocked": "The account query was blocked by the local security policy. Check HTTPS, same-origin, and private-network settings.",
 			"balance.title": "Account balance",
 			"balance.provider": "Provider",


### PR DESCRIPTION
#38 合并时留下的两个 P3 尾巴（已在 [review](https://github.com/Ychris12138/dsh-usage-stats/pull/38#pullrequestreview-4969830452) 中说明由我来清理）：

1. **删除客户端死代码**：`sub2api-balance-keys:` 的 reason 分支及两条 i18n——服务端最终采用的是固定枚举 `sub2api-balance-shape-unrecognized`（上游可控的 JSON 键名绝不能泄到浏览器端），keys 分支永远不会被触发；
2. **补 i18n**：`sub2api-balance-shape-unrecognized` 此前没有翻译，UI 会裸显示枚举字符串，补上中英文条目。

无行为变化，smoke + bundle 测试通过。