### PR TITLE
fix: quote scoped bundle name and prepare v0.2.7 hotfix

### DIFF
--- a/catalog/v1/plugins.json
+++ b/catalog/v1/plugins.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-20T02:30:00.000Z",
-  "revision": "0.2.6",
+  "generatedAt": "2026-08-20T04:15:00.000Z",
+  "revision": "0.2.7",
   "items": [
     {
       "id": "dsh-usage-stats",
@@ -10,7 +10,7 @@
       "summary": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI.",
       "description": "在 DSH 对话界面内展示 Token 用量热力图、各 provider 账户余额与订阅配额，数据来自持久化会话日志。catalog 条目身份与 npm 包 `@ychris12138/dsh-usage-stats` 对齐，发布后即可通过插件市场 GUI 直接安装。",
       "homepage": "https://github.com/Ychris12138/dsh-usage-stats",
-      "latestVersion": "0.2.6",
+      "latestVersion": "0.2.7",
       "license": "MIT",
       "categories": [
         "development",
@@ -40,7 +40,7 @@
           "dsh"
         ]
       },
-      "updatedAt": "2026-08-20T02:30:00.000Z"
+      "updatedAt": "2026-08-20T04:15:00.000Z"
     }
   ],
   "page": {}

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -2,4 +2,4 @@
 # DeepSeek Harness profile bundle.
 - insert:
     - id: usage-stats
-      name: @ychris12138/dsh-usage-stats
+      name: "@ychris12138/dsh-usage-stats"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ychris12138/dsh-usage-stats",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ychris12138/dsh-usage-stats",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ychris12138/dsh-usage-stats",
   "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Ychris12138/dsh-usage-stats.git"

--- a/scripts/test-bundle.mjs
+++ b/scripts/test-bundle.mjs
@@ -14,9 +14,10 @@ const patchPath = join(root, normalize(patchDeclaration));
 await access(patchPath);
 const patch = await readFile(patchPath, "utf8");
 assert.equal(
-	[...patch.matchAll(/^\s+name:\s*@ychris12138\/dsh-usage-stats\s*$/gm)].length,
+	[...patch.matchAll(/^\s+name:\s+"@ychris12138\/dsh-usage-stats"\s*$/gm)].length,
 	1,
-	"bundle patch must mount @ychris12138/dsh-usage-stats exactly once"
+	"bundle patch must mount the scoped package exactly once as a quoted YAML scalar"
 );
+assert.doesNotMatch(patch, /^\s+name:\s+@ychris12138\/dsh-usage-stats\s*$/m, "scoped package name must not be an unquoted YAML scalar");
 
 console.log("DSH BUNDLE MANIFEST TESTS PASSED");

--- a/scripts/test-install.mjs
+++ b/scripts/test-install.mjs
@@ -95,7 +95,7 @@ try {
 	assert.equal(installed.dsh?.bundle?.patch, "./cordis.patch.yml");
 	assert.match(
 		await readFile(join(home, "profiles", "node_modules", "dsh-usage-stats", "cordis.patch.yml"), "utf8"),
-		/^\s+name:\s*@ychris12138\/dsh-usage-stats\s*$/m
+		/^\s+name:\s+"@ychris12138\/dsh-usage-stats"\s*$/m
 	);
 	assert.equal(await readFile(join(home, "profiles", "node_modules", "dsh-usage-stats", "lib", "index.js"), "utf8").then((text) => text.length > 1000), true);
 	console.log("INSTALLER REGRESSION TESTS PASSED");


### PR DESCRIPTION
Fixes #47.

## Root cause
The first public scoped package changed `cordis.patch.yml` from `dsh-usage-stats` to `@ychris12138/dsh-usage-stats`, but YAML plain scalars cannot begin with `@`. DSH therefore fails while parsing the bundle overlay before the plugin can start.

## Fix
- quote the scoped package name in `cordis.patch.yml`;
- add regression coverage that explicitly rejects the unquoted form;
- keep the legacy GitHub compatibility install path unchanged;
- bump package/lock/catalog metadata to `0.2.7` so Community Market no longer advertises the broken `0.2.6` as the current target.

`0.2.6` should be deprecated on npm after `0.2.7` is published.