### PR TITLE
fix(client): 使用带 npm scope 的模块 id 注册客户端 bundle

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -8,7 +8,7 @@
  * half's loopback-only endpoints via same-origin fetch.
  */
 window.__ModuleLoader__.load({
-	id: "dsh-usage-stats",
+	id: "@ychris12138/dsh-usage-stats",
 	factory: (require) => {
 		var module = { exports: {} };
 		var exports = module.exports;
@@ -139,7 +139,7 @@ window.__ModuleLoader__.load({
 		const tagId = "dsh-usage-stats/UsageStats.module.css";
 		if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId) + "]") === null) {
 			const tag = document.createElement("style");
-			tag.dataset.plugin = "dsh-usage-stats";
+			tag.dataset.plugin = "@ychris12138/dsh-usage-stats";
 			tag.dataset.pluginCss = tagId;
 			tag.textContent = css;
 			document.head.appendChild(tag);

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -42,7 +42,7 @@ if (!source.includes("badgeCount !== null && react_jsx_runtime.jsx(\"span\", { c
 new Function(source)(); // executes the window.__ModuleLoader__.load call
 
 if (captured === null) throw new Error("loader did not capture the bundle");
-if (captured.id !== "dsh-usage-stats") throw new Error(`unexpected id ${captured.id}`);
+if (captured.id !== "@ychris12138/dsh-usage-stats") throw new Error(`unexpected id ${captured.id}`);
 
 const exports_ = captured.factory((spec) => {
 	if (spec === "react") return react;


### PR DESCRIPTION
## 概述

修复插件安装后重启 harness 时客户端 bundle 无法加载的问题。

**根因**：`lib/client.js` 用 `window.__ModuleLoader__.load` 注册客户端模块时使用的是 `dsh-usage-stats`，缺少 `@ychris12138/` 这个 npm scope 前缀。而 DSH 的客户端模块系统（`dsh-client-modules`）以**完整包名**作为图谱条目 id，因此该 bundle 加载完成后，加载器在校验阶段找不到以 `@ychris12138/dsh-usage-stats` 注册的工厂，抛出：

```
client-modules: bundle /plugins/@ychris12138/dsh-usage-stats/client.js?rev=... loaded without registering "@ychris12138/dsh-usage-stats" via __ModuleLoader__.load
```

详见关联 issue #50。

## 改动内容

- **`lib/client.js`**
  - `__ModuleLoader__.load` 的注册 id：`"dsh-usage-stats"` → `"@ychris12138/dsh-usage-stats"`，与包名/图排行 id 对齐
  - CSS `<style>` 标签的 `data-plugin` 属性同步改为 `"@ychris12138/dsh-usage-stats"`，与 DSH `claimStyles` 的按 id 认领逻辑保持一致（利于 HMR 正确管理该插件的样式）
- **`scripts/smoke-client.mjs`**
  - 冒烟测试中对捕获注册 id 的断言同步更新为 `@ychris12138/dsh-usage-stats`

## 验证

本地执行通过：

- `npm run check` ✅（所有文件语法校验通过）
- `npm run test:bundle` ✅（DSH BUNDLE MANIFEST TESTS PASSED）
- `npm run test:client` ✅（SMOKE TEST PASSED）
- `npm run test:overlay` / `test:server` / `test:install` ✅ 均通过

## 影响范围

仅涉及客户端 bundle 的模块注册 id 与其配套属性、以及对应测试断言；不改变任何业务逻辑、接口或服务端行为。

---

> 🤖 本 PR 由 AI 生成并提交（仓库账号 noneowl / DeepSeek Harness agent），在人工 review 后合并。提交者也以 `noneowl` 身份署名。
