### PR TITLE
chore: prepare v0.2.10 release

### DIFF
--- a/catalog/v1/plugins.json
+++ b/catalog/v1/plugins.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-20T11:30:00.595Z",
-  "revision": "0.2.9",
+  "generatedAt": "2026-08-22T06:49:00.000Z",
+  "revision": "0.2.10",
   "items": [
     {
       "id": "dsh-usage-stats",
@@ -10,7 +10,7 @@
       "summary": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI.",
       "description": "在 DSH 对话界面内展示 Token 用量热力图、各 provider 账户余额与订阅配额，数据来自持久化会话日志。catalog 条目身份与 npm 包 `@ychris12138/dsh-usage-stats` 对齐，发布后即可通过插件市场 GUI 直接安装。",
       "homepage": "https://github.com/Ychris12138/dsh-usage-stats",
-      "latestVersion": "0.2.9",
+      "latestVersion": "0.2.10",
       "license": "MIT",
       "categories": [
         "development",
@@ -40,7 +40,7 @@
           "dsh"
         ]
       },
-      "updatedAt": "2026-08-20T11:30:00.595Z"
+      "updatedAt": "2026-08-22T06:49:00.000Z"
     }
   ],
   "page": {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ychris12138/dsh-usage-stats",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ychris12138/dsh-usage-stats",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ychris12138/dsh-usage-stats",
   "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Ychris12138/dsh-usage-stats.git"


### PR DESCRIPTION
## Summary

Prepare the next stable release after #55.

### Included
- bump npm package metadata from `0.2.9` to `0.2.10`;
- sync `package-lock.json`;
- sync Community Market catalog `revision` / `latestVersion` to `0.2.10`.

The functional change itself is the already-reviewed and merged Ollama Cloud support from #55. This PR intentionally contains release metadata only.

### Release gate
- repository CI must pass on the final release tree;
- no tag or GitHub Release will be created until npm `0.2.10` is published successfully.