### PR TITLE
fix: do not refold unchanged persisted sessions in the fallback path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -337,7 +337,14 @@ export async function collectUsage(ctx) {
 							state.consumed = 0;
 						}
 						const fresh = wasPersisted ? events.filter((event) => event.seq > (state.consumed ?? 0)) : events;
-						const contiguous = fresh.length === 0 ? state.consumed === 0 : fresh[0].seq === state.consumed + 1;
+						// readFrom is inclusive: an unchanged log returns exactly the
+						// already-folded cursor event (seq === consumed). An empty
+						// fresh slice with the cursor still present is therefore NOT a
+						// rewrite — only a log that no longer contains the cursor
+						// (truncated/rewritten) must refold from scratch.
+						const contiguous = fresh.length === 0
+							? wasPersisted && events.some((event) => event.seq === (state.consumed ?? 0))
+							: fresh[0].seq === state.consumed + 1;
 						if (!contiguous && state.consumed > 0) {
 							// Log truncated or rewritten: refold the whole log.
 							state.days = new Map();

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -190,6 +190,38 @@ async function testRevisionRewrite(root) {
 	assert.equal(reads, 3, "rewrite detection must retry from seq 0");
 }
 
+async function testFallbackIncremental(root) {
+	const plugin = await freshModule("fallback-incremental", join(root, "fallback-incremental"));
+	const id = "fallback-session";
+	// No listSnapshots (the fallback path) means every cycle re-reads, but an
+	// unchanged log must read only the delta tail — not refold from seq 0 —
+	// while a truncated log must still refold from scratch.
+	const log = [usageEvent(1, 5), usageEvent(2, 7), usageEvent(3, 11)];
+	const reads = [];
+	const persistence = {
+		list: async () => [{ id }],
+		readFrom: async (_id, fromSeq) => {
+			reads.push(fromSeq);
+			return { events: log.filter((event) => event.seq >= fromSeq) };
+		}
+	};
+	const ctx = makeContext({ sessions: { list: () => [] }, persistence });
+	assert.equal((await plugin.collectUsage(ctx)).total.tokens, 23);
+	assert.deepEqual(reads, [0], "the initial fold reads from seq 0");
+	reads.length = 0;
+	assert.equal((await plugin.collectUsage(ctx)).total.tokens, 23, "an unchanged fallback log must keep the folded total");
+	assert.deepEqual(reads, [3], "an unchanged fallback log must not refold from seq 0");
+	log.push(usageEvent(4, 13));
+	reads.length = 0;
+	assert.equal((await plugin.collectUsage(ctx)).total.tokens, 36, "new events must fold incrementally in the fallback path");
+	assert.deepEqual(reads, [3], "only the delta tail is read");
+	log.length = 0;
+	log.push(usageEvent(1, 5));
+	reads.length = 0;
+	assert.equal((await plugin.collectUsage(ctx)).total.tokens, 5, "a truncated fallback log must refold");
+	assert.deepEqual(reads, [4, 0], "truncation detection retries from seq 0");
+}
+
 async function testLiveLogShrink(root) {
 	const plugin = await freshModule("shrink", join(root, "shrink"));
 	const id = "shrink-session";
@@ -240,6 +272,7 @@ try {
 	await testBackgroundRefresh(root);
 	await testPersistedToLive(root);
 	await testRevisionRewrite(root);
+	await testFallbackIncremental(root);
 	await testLiveLogShrink(root);
 	await testZeroUsageRowsFiltered(root);
 	console.log("SERVER REGRESSION TESTS PASSED");


### PR DESCRIPTION
## 背景

#57 报告：当 `sessionPersistence.listSnapshots()` 缺失或抛错时（回退路径），每次 `collectUsage`——后台每 5 分钟一次，加上每次请求 `/api/usage-stats/usage`——都会把已经折叠完、没有任何新事件的 persisted 会话从 seq 0 整段重折。回退分支的本意是"每次都读增量"（代码注释 L261-263），实际行为是每轮 O(全量日志)，会话多、日志长时会明显拖慢请求。

## 根因

`persistence.readFrom(id, fromSeq)` 的语义是 `seq >= fromSeq`（含端点）。日志没变化时 `readFrom(id, consumed)` 返回 `[seq === consumed]` 那一条，过滤后 `fresh` 为空，原判定 `fresh.length === 0 ? state.consumed === 0 : ...` 把"没有新事件"误判成"日志被截断/重写"，于是整段重折。

## 改动

**`lib/index.js` `collectUsage()` persisted 分支**：`fresh` 为空时检查 `readFrom` 返回的原始事件里是否还含 `seq === consumed` 的折叠游标——

```js
const contiguous = fresh.length === 0
    ? wasPersisted && events.some((event) => event.seq === (state.consumed ?? 0))
    : fresh[0].seq === state.consumed + 1;
```

- 游标仍在 → 日志没变，保留折叠状态（不再重折）；
- 游标消失 → 被截断/重写，照旧从 seq 0 重折；
- `fresh` 非空 → 原有的连续性判定不变。

不碰默认路径（`listSnapshots` 可用时行为完全一致），只修回退路径。

## 测试

- 新增 `testFallbackIncremental`：mock 无 `listSnapshots` 的 persistence，断言未变化日志第二轮只 `readFrom(3)` 不再 `readFrom(0)`、新增事件仍走增量（`[3]`）、截断后仍重折（`[4,0]`）；
- 本地全部 8 个测试脚本通过。

Closes #57

---

补充：本 PR 由 dsh（DeepSeek Harness agent）辅助排查、修复并起草（与 #57 同源），发布前作者本人已审阅。
