### PR TITLE
feat: add provider identity and current session context

### DIFF
--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -9,12 +9,16 @@
  * @module dsh-usage-stats/accounts
  */
 
-import { balanceSchemeOf, queryBalance } from "./balance.js";
+import { queryBalance } from "./balance.js";
+import { isPrivateAddress, isPrivateHostname } from "./network.js";
+import { resolveProviderIdentity } from "./provider-identity.js";
 import { collectSubscription } from "./subscriptions.js";
 import { lookup as dnsLookup } from "node:dns/promises";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
+
+export { isPrivateAddress } from "./network.js";
 
 const DEFAULT_TIMEOUT_MS = 15000;
 const DEFAULT_REFRESH_MS = 300000;
@@ -172,38 +176,8 @@ async function requestJson(url, init, deps = {}) {
 	return parseJsonResponse(response, deps.maxResponseBytes ?? MAX_RESPONSE_BYTES);
 }
 
-function schemeAdapter(scheme) {
-	return `${scheme}-balance`;
-}
-
 function schemeOfAdapter(adapter) {
 	return adapter.endsWith("-balance") ? adapter.slice(0, -8) : null;
-}
-
-function defaultAdapter(provider) {
-	const providerId = provider.id;
-	if (providerId === "opencode-go") return "opencode-go";
-	if (providerId === "zai" || providerId === "zai-coding-cn") return "zai-token-plan";
-	if (providerId === "kimi-coding" || providerId === "kimi-for-coding") return "kimi-token-plan";
-	if (["minimax", "minimaxi", "minimax-cn", "minimax-coding"].includes(providerId)) return "minimax-token-plan";
-	if (providerId === "passion") return "sub2api";
-	try {
-		const hostname = new URL(provider.baseURL).hostname.toLowerCase();
-		if (hostname === "passionapi.com" || hostname.endsWith(".passionapi.com")) return "sub2api";
-		// Ollama Cloud is detected by its canonical host so a user-configured
-		// provider with a custom id still gets the quota adapter; local Ollama
-		// (localhost:11434) never matches and stays without an account adapter.
-		// The id check is gated on the hostname so a local install that happens
-		// to use the canonical "ollama" id is not misread as a cloud account.
-		// Subdomains (e.g. api.ollama.com) are recognized for identification
-		// only: the usage query always targets the canonical ollama.com host,
-		// which is where the /api/usage endpoint is served.
-		if ((providerId === "ollama" || hostname === "ollama.com" || hostname.endsWith(".ollama.com")) && !privateHostname(hostname)) return "ollama";
-	} catch {
-		// A malformed provider URL is handled by the adapter when it is queried.
-	}
-	const scheme = balanceSchemeOf(providerId);
-	return scheme === null ? null : schemeAdapter(scheme);
 }
 
 function adapterMode(adapter, monitor) {
@@ -288,7 +262,7 @@ export function validateAccountConfig(raw = {}) {
 /** Bind one configured Harness provider to its explicit or built-in adapter. */
 export function resolveAccountSpec(provider, config = { monitors: {} }) {
 	const monitor = config.monitors?.[provider.id] ?? {};
-	const adapter = monitor.adapter ?? defaultAdapter(provider);
+	const adapter = resolveProviderIdentity(provider, config).accountAdapter;
 	const mode = adapter === null ? null : adapterMode(adapter, monitor);
 	const apiKeyRef = monitor.credentialRef
 		?? (adapter === "openrouter-balance" ? OPENROUTER_MANAGEMENT_REF : provider.apiKeyEnv);
@@ -334,74 +308,6 @@ function mapped(root, mapping) {
 		return divisor === null ? value : numberOrNull(value) === null ? void 0 : Number(value) / divisor;
 	}
 	return void 0;
-}
-
-function ipv4Private(octets) {
-	const [a, b, c] = octets;
-	return a === 0
-		|| a === 10
-		|| a === 127
-		|| a === 169 && b === 254
-		|| a === 172 && b >= 16 && b <= 31
-		|| a === 192 && b === 168
-		|| a === 192 && b === 0 && (c === 0 || c === 2)
-		|| a === 192 && b === 88 && c === 99
-		|| a === 100 && b >= 64 && b <= 127
-		|| a === 198 && (b === 18 || b === 19)
-		|| a === 198 && b === 51 && c === 100
-		|| a === 203 && b === 0 && c === 113
-		|| a >= 224;
-}
-
-function ipv6Bytes(address) {
-	let value = address.toLowerCase().split("%")[0];
-	let ipv4Tail = null;
-	const lastColon = value.lastIndexOf(":");
-	if (value.slice(lastColon + 1).includes(".")) {
-		const octets = value.slice(lastColon + 1).split(".").map(Number);
-		if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return null;
-		ipv4Tail = [(octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]];
-		value = `${value.slice(0, lastColon)}:${ipv4Tail[0].toString(16)}:${ipv4Tail[1].toString(16)}`;
-	}
-	const halves = value.split("::");
-	if (halves.length > 2) return null;
-	const left = halves[0] === "" ? [] : halves[0].split(":");
-	const right = halves.length === 1 || halves[1] === "" ? [] : halves[1].split(":");
-	const missing = 8 - left.length - right.length;
-	if (missing < 0 || halves.length === 1 && missing !== 0) return null;
-	const words = [...left, ...Array(missing).fill("0"), ...right].map((part) => Number.parseInt(part || "0", 16));
-	if (words.length !== 8 || words.some((part) => !Number.isInteger(part) || part < 0 || part > 0xffff)) return null;
-	const bytes = [];
-	for (const word of words) bytes.push(word >> 8, word & 0xff);
-	return bytes;
-}
-
-/** True for loopback, private, link-local, documentation, multicast, and other non-public IP space. */
-export function isPrivateAddress(address) {
-	const value = String(address ?? "").trim().replace(/^\[|\]$/g, "");
-	if (isIP(value) === 4) return ipv4Private(value.split(".").map(Number));
-	if (isIP(value) !== 6) return false;
-	const bytes = ipv6Bytes(value);
-	if (bytes === null) return true;
-	if (bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === 0xff && bytes[11] === 0xff) return ipv4Private(bytes.slice(12));
-	// Public provider endpoints should resolve to global unicast (2000::/3).
-	// This conservative allow-range excludes loopback/unspecified, NAT64,
-	// discard-only, ULA, link/site-local, multicast, and other special space.
-	const globalUnicast = (bytes[0] & 0xe0) === 0x20;
-	const word0 = (bytes[0] << 8) | bytes[1];
-	const word1 = (bytes[2] << 8) | bytes[3];
-	// IETF protocol assignments 2001:0000::/23 include benchmarking, ORCHID,
-	// and tunnel mechanisms; 2002::/16 (6to4) embeds an unchecked IPv4 target.
-	const ietfSpecial = word0 === 0x2001 && word1 <= 0x01ff;
-	const sixToFour = word0 === 0x2002;
-	const documentation = word0 === 0x2001 && word1 === 0x0db8
-		|| word0 === 0x3fff && (word1 & 0xf000) === 0;
-	return !globalUnicast || ietfSpecial || sixToFour || documentation;
-}
-
-function privateHostname(hostname) {
-	const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
-	return host === "localhost" || host.endsWith(".localhost") || isPrivateAddress(host);
 }
 
 /**
@@ -477,7 +383,7 @@ export function selectResolvedAddress(url, rawAddresses, allowPrivateNetwork = f
 
 async function resolvePublicAddresses(url, spec, deps) {
 	const hostname = url.hostname.replace(/^\[|\]$/g, "");
-	if (privateHostname(hostname) && spec.monitor.allowPrivateNetwork !== true) throw statusError("blocked", "account monitor private-network access requires allowPrivateNetwork");
+	if (isPrivateHostname(hostname) && spec.monitor.allowPrivateNetwork !== true) throw statusError("blocked", "account monitor private-network access requires allowPrivateNetwork");
 	if (isIP(hostname) !== 0) return [{ address: hostname, family: isIP(hostname) }];
 	let addresses;
 	try {
@@ -614,7 +520,7 @@ function customURL(spec) {
 	const base = new URL(spec.baseURL);
 	const providerBase = nonEmptyString(spec.providerBaseURL) === null ? null : new URL(spec.providerBaseURL);
 	if (base.protocol !== "https:" && spec.monitor.allowInsecure !== true) throw statusError("blocked", "custom monitor requires HTTPS");
-	if (privateHostname(base.hostname) && spec.monitor.allowPrivateNetwork !== true) throw statusError("blocked", "custom monitor private-network access requires allowPrivateNetwork");
+	if (isPrivateHostname(base.hostname) && spec.monitor.allowPrivateNetwork !== true) throw statusError("blocked", "custom monitor private-network access requires allowPrivateNetwork");
 	if (providerBase !== null && base.origin !== providerBase.origin && spec.monitor.allowCrossOrigin !== true) throw statusError("blocked", "custom monitor cross-origin access requires allowCrossOrigin");
 	const url = new URL(spec.monitor.request.path, base);
 	if (url.origin !== base.origin) throw statusError("unsupported", "custom monitor request must stay on its configured origin");

--- a/lib/balance.js
+++ b/lib/balance.js
@@ -11,6 +11,8 @@
  * @module dsh-usage-stats/balance
  */
 
+import { balanceSchemeForProviderId } from "./provider-identity.js";
+
 const SCHEMES = {
 	/** DeepSeek: GET {origin}/user/balance — CNY balance_infos entry. */
 	deepseek: {
@@ -95,11 +97,7 @@ function responseStatus(status) {
 
 /** Map a provider id (dsh adapter id or pi-ai route) to a balance scheme id. */
 export function balanceSchemeOf(providerId) {
-	if (providerId === "deepseek-official" || providerId === "deepseek") return "deepseek";
-	if (providerId === "openrouter") return "openrouter";
-	if (providerId === "moonshotai" || providerId === "moonshotai-cn" || providerId === "kimi" || providerId === "kimi-coding") return "moonshot";
-	if (providerId === "zai" || providerId === "zai-coding-cn") return "zai";
-	return null;
+	return balanceSchemeForProviderId(providerId);
 }
 
 /** Query one provider's balance. Throws on transport/HTTP errors. */

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ const SUBSCRIPTIONS_PATH = "/api/usage-stats/subscriptions";
 const ACCOUNT_PATH = "/api/usage-stats/account";
 const SESSION_CONTEXT_PATH = "/api/usage-stats/session-context";
 const UPSTREAM_TIMEOUT_MS = 15000;
-const CACHE_VERSION = 3;
+const CACHE_VERSION = 4;
 
 /** Default DeepSeek connection facts when the settings namespace is absent. */
 const DEEPSEEK_DEFAULTS = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,13 @@
 /**
  * dsh-usage-stats — server half.
  *
- * Registers five read-only, loopback-only endpoints on the web server:
+ * Registers six read-only, loopback-only endpoints on the web server:
  *   GET /api/usage-stats/usage         — per-day token usage across every session
  *   GET /api/usage-stats/providers     — configured providers + balance schemes
  *   GET /api/usage-stats/balance       — balance for one provider (?provider=<id>)
  *   GET /api/usage-stats/subscriptions — OpenCode Go + Z.ai quota windows
  *   GET /api/usage-stats/account       — unified account snapshot for one provider
+ *   GET /api/usage-stats/session-context — provider/model context for one live session
  *
  * Provider configuration is read straight from the harness settings
  * (`llm-deepseek` for the official DeepSeek route, `llm-pi-ai` for every
@@ -33,7 +34,7 @@
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { applyUsageDelta, createUsageState, mergeInto, renderUsage, totalTokens, zeroBuckets } from "./usage.js";
+import { applyUsageDelta, createUsageState, currentSessionContext, mergeInto, renderUsage, resetUsageState, totalTokens, zeroBuckets } from "./usage.js";
 import { ACCOUNT_REFRESH_MS, createAccountService, validateAccountConfig } from "./accounts.js";
 
 /** Stable Cordis plugin name. */
@@ -47,6 +48,7 @@ const PROVIDERS_PATH = "/api/usage-stats/providers";
 const BALANCE_PATH = "/api/usage-stats/balance";
 const SUBSCRIPTIONS_PATH = "/api/usage-stats/subscriptions";
 const ACCOUNT_PATH = "/api/usage-stats/account";
+const SESSION_CONTEXT_PATH = "/api/usage-stats/session-context";
 const UPSTREAM_TIMEOUT_MS = 15000;
 const CACHE_VERSION = 3;
 
@@ -148,7 +150,12 @@ function serializeSession(state) {
 			model: state.lastSample.model,
 			buckets: { ...state.lastSample.buckets }
 		},
-		currentModel: state.currentModel
+		currentModel: state.currentModel,
+		currentRoute: state.currentRoute === null || state.currentRoute === void 0 ? null : {
+			providerId: state.currentRoute.providerId,
+			model: state.currentRoute.model,
+			updatedAt: state.currentRoute.updatedAt
+		}
 	};
 }
 
@@ -199,6 +206,15 @@ function parseSession(raw) {
 		};
 	}
 	if (typeof raw.currentModel === "string") state.currentModel = raw.currentModel;
+	if (raw.currentRoute !== null && typeof raw.currentRoute === "object"
+		&& typeof raw.currentRoute.providerId === "string" && raw.currentRoute.providerId.length > 0
+		&& typeof raw.currentRoute.model === "string" && raw.currentRoute.model.length > 0) {
+		state.currentRoute = {
+			providerId: raw.currentRoute.providerId,
+			model: raw.currentRoute.model,
+			updatedAt: Number.isFinite(raw.currentRoute.updatedAt) ? raw.currentRoute.updatedAt : null
+		};
+	}
 	return state;
 }
 
@@ -277,10 +293,7 @@ export async function collectUsage(ctx) {
 				const state = cache.sessions[session.id] ?? createUsageState();
 				if (state.kind !== "live") {
 					// Live/persisted transition: refold the whole in-memory log.
-					state.days = new Map();
-					state.lastSample = null;
-					state.currentModel = null;
-					state.consumed = 0;
+					resetUsageState(state);
 				}
 				const count = session.events.length;
 				if (count < (state.consumed ?? 0)) {
@@ -290,10 +303,7 @@ export async function collectUsage(ctx) {
 					// full log would silently freeze this session's stats
 					// forever (#23). The cursor is meaningless against the
 					// rebuilt log: refold it from scratch.
-					state.days = new Map();
-					state.lastSample = null;
-					state.currentModel = null;
-					state.consumed = 0;
+					resetUsageState(state);
 				}
 				if ((state.consumed ?? 0) < count) {
 					applyUsageDelta(state, session.events.slice(state.consumed ?? 0));
@@ -331,19 +341,13 @@ export async function collectUsage(ctx) {
 						const fromSeq = wasPersisted ? state.consumed : 0;
 						const { events } = await persistence.readFrom(meta.id, fromSeq);
 						if (!wasPersisted) {
-							state.days = new Map();
-							state.lastSample = null;
-							state.currentModel = null;
-							state.consumed = 0;
+							resetUsageState(state);
 						}
 						const fresh = wasPersisted ? events.filter((event) => event.seq > (state.consumed ?? 0)) : events;
 						const contiguous = fresh.length === 0 ? state.consumed === 0 : fresh[0].seq === state.consumed + 1;
 						if (!contiguous && state.consumed > 0) {
 							// Log truncated or rewritten: refold the whole log.
-							state.days = new Map();
-							state.lastSample = null;
-							state.currentModel = null;
-							state.consumed = 0;
+							resetUsageState(state);
 							const { events: allEvents } = await persistence.readFrom(meta.id, 0);
 							applyUsageDelta(state, allEvents);
 							state.consumed = allEvents.length > 0 ? allEvents[allEvents.length - 1].seq : 0;
@@ -421,6 +425,53 @@ async function configuredProviders(ctx) {
 		}
 	}
 	return providers;
+}
+
+/**
+ * Resolve one live DSH session's latest provider/model pair. The incremental
+ * usage fold is the single source of truth, so this remains O(new events) and
+ * does not add another stream listener or usage ledger.
+ */
+export async function collectSessionContext(ctx, sessionId, config = { monitors: {} }) {
+	await collectUsage(ctx);
+	const sessions = ctx.get("sessions");
+	const live = sessions?.get?.(sessionId) ?? sessions?.list?.().find((session) => session.id === sessionId);
+	if (live === void 0) return null;
+	const cache = await loadCache();
+	const state = cache.sessions[sessionId];
+	if (state?.kind !== "live" || state.currentRoute === null || state.currentRoute === void 0) return null;
+	const providers = await configuredProviders(ctx);
+	const provider = providers.find((entry) => entry.id === state.currentRoute.providerId)
+		?? { id: state.currentRoute.providerId, displayName: state.currentRoute.providerId };
+	return currentSessionContext(sessionId, state, provider, config);
+}
+
+/** Session context is explicit in multi-session DSH; a single live session is unambiguous. */
+async function handleSessionContext(ctx, config, req, res) {
+	if (rejectForeignCaller(req, res)) return;
+	try {
+		const url = new URL(req.url ?? "/", "http://x");
+		const requested = url.searchParams.get("session");
+		const sessions = ctx.get("sessions")?.list?.() ?? [];
+		let sessionId = requested === null || requested === "" ? null : requested;
+		if (sessionId === null && sessions.length === 1) sessionId = sessions[0].id;
+		if (sessionId === null && sessions.length > 1) {
+			json(res, 400, { ok: false, error: "session-required", message: "session query parameter is required when multiple sessions are live" });
+			return;
+		}
+		if (sessionId === null) {
+			json(res, 200, { ok: true, context: null });
+			return;
+		}
+		if (!sessions.some((session) => session.id === sessionId)) {
+			json(res, 404, { ok: false, error: "unknown-session", message: `session "${sessionId}" is not live` });
+			return;
+		}
+		json(res, 200, { ok: true, context: await collectSessionContext(ctx, sessionId, config) });
+	} catch (error) {
+		ctx.logger.warn(`usage-stats: session context failed: ${String(error)}`);
+		json(res, 500, { ok: false, error: "internal", message: error instanceof Error ? error.message : String(error) });
+	}
 }
 
 async function handleProviders(ctx, accounts, req, res) {
@@ -613,7 +664,12 @@ async function apply(ctx, rawConfig = {}, deps = {}) {
 		path: SUBSCRIPTIONS_PATH,
 		handler: (req, res) => handleSubscriptions(ctx, accounts, req, res)
 	}), "usage-stats: subscriptions route");
+	ctx.effect(() => ctx.webServer.register({
+		kind: "exact",
+		path: SESSION_CONTEXT_PATH,
+		handler: (req, res) => handleSessionContext(ctx, config, req, res)
+	}), "usage-stats: session context route");
 	if (deps.disableBackgroundRefresh !== true) ctx.effect(() => startBackgroundRefresh(ctx, accounts), "usage-stats: background account refresh");
 }
 
-export { apply, Config, inject, name, USAGE_PATH, PROVIDERS_PATH, BALANCE_PATH, SUBSCRIPTIONS_PATH, ACCOUNT_PATH, configuredProviders, totalTokens, zeroBuckets };
+export { apply, Config, inject, name, USAGE_PATH, PROVIDERS_PATH, BALANCE_PATH, SUBSCRIPTIONS_PATH, ACCOUNT_PATH, SESSION_CONTEXT_PATH, configuredProviders, totalTokens, zeroBuckets };

--- a/lib/network.js
+++ b/lib/network.js
@@ -1,0 +1,65 @@
+/** Shared pure network classification used by identity and SSRF policy. */
+
+import { isIP } from "node:net";
+
+function ipv4Private(octets) {
+	const [a, b, c] = octets;
+	return a === 0
+		|| a === 10
+		|| a === 127
+		|| a === 169 && b === 254
+		|| a === 172 && b >= 16 && b <= 31
+		|| a === 192 && b === 168
+		|| a === 192 && b === 0 && (c === 0 || c === 2)
+		|| a === 192 && b === 88 && c === 99
+		|| a === 100 && b >= 64 && b <= 127
+		|| a === 198 && (b === 18 || b === 19)
+		|| a === 198 && b === 51 && c === 100
+		|| a === 203 && b === 0 && c === 113
+		|| a >= 224;
+}
+
+function ipv6Bytes(address) {
+	let value = address.toLowerCase().split("%")[0];
+	const lastColon = value.lastIndexOf(":");
+	if (value.slice(lastColon + 1).includes(".")) {
+		const octets = value.slice(lastColon + 1).split(".").map(Number);
+		if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return null;
+		value = `${value.slice(0, lastColon)}:${((octets[0] << 8) | octets[1]).toString(16)}:${((octets[2] << 8) | octets[3]).toString(16)}`;
+	}
+	const halves = value.split("::");
+	if (halves.length > 2) return null;
+	const left = halves[0] === "" ? [] : halves[0].split(":");
+	const right = halves.length === 1 || halves[1] === "" ? [] : halves[1].split(":");
+	const missing = 8 - left.length - right.length;
+	if (missing < 0 || halves.length === 1 && missing !== 0) return null;
+	const words = [...left, ...Array(missing).fill("0"), ...right].map((part) => Number.parseInt(part || "0", 16));
+	if (words.length !== 8 || words.some((part) => !Number.isInteger(part) || part < 0 || part > 0xffff)) return null;
+	const bytes = [];
+	for (const word of words) bytes.push(word >> 8, word & 0xff);
+	return bytes;
+}
+
+/** True for loopback, private, link-local, documentation, multicast, and other non-public IP space. */
+export function isPrivateAddress(address) {
+	const value = String(address ?? "").trim().replace(/^\[|\]$/g, "");
+	if (isIP(value) === 4) return ipv4Private(value.split(".").map(Number));
+	if (isIP(value) !== 6) return false;
+	const bytes = ipv6Bytes(value);
+	if (bytes === null) return true;
+	if (bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === 0xff && bytes[11] === 0xff) return ipv4Private(bytes.slice(12));
+	const globalUnicast = (bytes[0] & 0xe0) === 0x20;
+	const word0 = (bytes[0] << 8) | bytes[1];
+	const word1 = (bytes[2] << 8) | bytes[3];
+	const ietfSpecial = word0 === 0x2001 && word1 <= 0x01ff;
+	const sixToFour = word0 === 0x2002;
+	const documentation = word0 === 0x2001 && word1 === 0x0db8
+		|| word0 === 0x3fff && (word1 & 0xf000) === 0;
+	return !globalUnicast || ietfSpecial || sixToFour || documentation;
+}
+
+/** Whether a URL hostname is local/private without performing DNS resolution. */
+export function isPrivateHostname(hostname) {
+	const host = String(hostname ?? "").toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+	return host === "localhost" || host.endsWith(".localhost") || isPrivateAddress(host);
+}

--- a/lib/provider-identity.js
+++ b/lib/provider-identity.js
@@ -1,0 +1,123 @@
+/**
+ * Provider identity policy shared by account monitoring and session context.
+ *
+ * Identity is route-aware: a configured route id remains the account boundary,
+ * even when two routes use the same upstream model. Classification follows one
+ * strict precedence order: explicit monitor adapter, canonical route id,
+ * canonical base-URL hostname, then unknown. Display labels are presentation
+ * only and never participate in inference.
+ *
+ * @module dsh-usage-stats/provider-identity
+ */
+
+import { isPrivateHostname } from "./network.js";
+
+const ADAPTER_IDENTITIES = Object.freeze({
+	"deepseek-balance": { providerFamily: "deepseek", pricingFamily: "deepseek" },
+	"openrouter-balance": { providerFamily: "openrouter", pricingFamily: "openrouter" },
+	"moonshot-balance": { providerFamily: "moonshot", pricingFamily: "moonshot" },
+	"zai-balance": { providerFamily: "zai", pricingFamily: "zai" },
+	general: { providerFamily: "unknown", pricingFamily: "unknown" },
+	"new-api": { providerFamily: "new-api", pricingFamily: "unknown" },
+	sub2api: { providerFamily: "sub2api", pricingFamily: "unknown" },
+	"sub2api-auth": { providerFamily: "sub2api", pricingFamily: "unknown" },
+	"opencode-go": { providerFamily: "opencode-go", pricingFamily: "opencode-go" },
+	"zai-token-plan": { providerFamily: "zai", pricingFamily: "zai" },
+	"kimi-token-plan": { providerFamily: "kimi", pricingFamily: "kimi" },
+	"minimax-token-plan": { providerFamily: "minimax", pricingFamily: "minimax" },
+	ollama: { providerFamily: "ollama", pricingFamily: "ollama" },
+	declarative: { providerFamily: "unknown", pricingFamily: "unknown" }
+});
+
+const CANONICAL_ROUTES = Object.freeze({
+	"deepseek-official": { providerFamily: "deepseek", accountAdapter: "deepseek-balance", balanceScheme: "deepseek" },
+	deepseek: { providerFamily: "deepseek", accountAdapter: "deepseek-balance", balanceScheme: "deepseek" },
+	openrouter: { providerFamily: "openrouter", accountAdapter: "openrouter-balance", balanceScheme: "openrouter" },
+	moonshotai: { providerFamily: "moonshot", accountAdapter: "moonshot-balance", balanceScheme: "moonshot" },
+	"moonshotai-cn": { providerFamily: "moonshot", accountAdapter: "moonshot-balance", balanceScheme: "moonshot" },
+	kimi: { providerFamily: "moonshot", accountAdapter: "moonshot-balance", balanceScheme: "moonshot" },
+	"kimi-coding": { providerFamily: "kimi", accountAdapter: "kimi-token-plan", balanceScheme: "moonshot" },
+	"kimi-for-coding": { providerFamily: "kimi", accountAdapter: "kimi-token-plan", balanceScheme: null },
+	zai: { providerFamily: "zai", accountAdapter: "zai-token-plan", balanceScheme: "zai" },
+	"zai-coding-cn": { providerFamily: "zai", accountAdapter: "zai-token-plan", balanceScheme: "zai" },
+	"opencode-go": { providerFamily: "opencode-go", accountAdapter: "opencode-go", balanceScheme: null },
+	minimax: { providerFamily: "minimax", accountAdapter: "minimax-token-plan", balanceScheme: null },
+	minimaxi: { providerFamily: "minimax", accountAdapter: "minimax-token-plan", balanceScheme: null },
+	"minimax-cn": { providerFamily: "minimax", accountAdapter: "minimax-token-plan", balanceScheme: null },
+	"minimax-coding": { providerFamily: "minimax", accountAdapter: "minimax-token-plan", balanceScheme: null },
+	passion: { providerFamily: "sub2api", accountAdapter: "sub2api", pricingFamily: "unknown", balanceScheme: null }
+});
+
+function nonEmptyString(value) {
+	return typeof value === "string" && value.trim() !== "" ? value.trim() : null;
+}
+
+function hostnameOf(baseURL) {
+	if (nonEmptyString(baseURL) === null) return null;
+	try {
+		return new URL(baseURL).hostname.toLowerCase().replace(/\.$/, "");
+	} catch {
+		return null;
+	}
+}
+
+function hostRule(hostname) {
+	if (hostname === "api.deepseek.com") return { providerFamily: "deepseek", accountAdapter: "deepseek-balance" };
+	if (hostname === "passionapi.com" || hostname.endsWith(".passionapi.com")) return { providerFamily: "sub2api", accountAdapter: "sub2api", pricingFamily: "unknown" };
+	if (hostname === "ollama.com" || hostname.endsWith(".ollama.com")) return { providerFamily: "ollama", accountAdapter: "ollama" };
+	return null;
+}
+
+function buildProviderIdentity(provider, rule, confidence) {
+	const routeId = nonEmptyString(provider?.id) ?? "unknown";
+	const displayName = nonEmptyString(provider?.displayName) ?? routeId;
+	const baseURL = nonEmptyString(provider?.baseURL);
+	const providerFamily = rule?.providerFamily ?? "unknown";
+	return {
+		routeId,
+		displayName,
+		providerFamily,
+		accountAdapter: rule?.accountAdapter ?? null,
+		pricingFamily: rule?.pricingFamily ?? providerFamily,
+		baseURL,
+		confidence
+	};
+}
+
+/** Return the legacy built-in balance scheme without duplicating route policy. */
+export function balanceSchemeForProviderId(providerId) {
+	return CANONICAL_ROUTES[providerId]?.balanceScheme ?? null;
+}
+
+/**
+ * Resolve one configured provider route to stable semantic boundaries.
+ * Explicit monitor configuration always wins. Unknown or malformed inputs
+ * remain unknown instead of falling back to the human-readable display name.
+ */
+export function resolveProviderIdentity(provider, config = { monitors: {} }) {
+	const routeId = nonEmptyString(provider?.id) ?? "unknown";
+	const monitor = config?.monitors?.[routeId];
+	const explicitAdapter = nonEmptyString(monitor?.adapter);
+	if (explicitAdapter !== null) {
+		const identity = ADAPTER_IDENTITIES[explicitAdapter] ?? { providerFamily: "unknown", pricingFamily: "unknown" };
+		return buildProviderIdentity(provider, { ...identity, accountAdapter: explicitAdapter }, "explicit");
+	}
+
+	const canonical = CANONICAL_ROUTES[routeId];
+	if (canonical !== void 0) return buildProviderIdentity(provider, canonical, "canonical-id");
+
+	const hostname = hostnameOf(provider?.baseURL);
+	if (hostname !== null) {
+		// The canonical Ollama id is meaningful only for a non-private cloud
+		// endpoint. This deliberate safety gate prevents local Ollama from being
+		// mistaken for a subscription account while retaining canonical-id
+		// precedence for actual cloud routes.
+		if (routeId === "ollama" && !isPrivateHostname(hostname)) {
+			return buildProviderIdentity(provider, { providerFamily: "ollama", accountAdapter: "ollama" }, "canonical-id");
+		}
+		const canonicalHost = hostRule(hostname);
+		if (canonicalHost !== null) return buildProviderIdentity(provider, canonicalHost, "canonical-host");
+	}
+
+	return buildProviderIdentity(provider, null, "unknown");
+}

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -17,6 +17,8 @@
  * @module dsh-usage-stats/usage
  */
 
+import { resolveProviderIdentity } from "./provider-identity.js";
+
 /** Local-calendar `YYYY-MM-DD` key for a millisecond epoch. */
 export function dayKey(timeMs) {
 	const date = new Date(timeMs);
@@ -105,16 +107,27 @@ function sampleOf(event) {
  * `request/header` `data.header.config`; samples with no model information
  * land in the `unknown/unknown` bucket.
  */
-function modelOf(event) {
+export function routeModelOf(event) {
 	const source = event.data?.message?.source;
 	if (source !== void 0 && typeof source.model === "string") {
-		return `${typeof source.provider === "string" && source.provider.length > 0 ? source.provider : "unknown"}/${source.model}`;
+		return {
+			providerId: typeof source.provider === "string" && source.provider.length > 0 ? source.provider : "unknown",
+			model: source.model
+		};
 	}
 	const config = event.data?.header?.config;
 	if (config !== void 0 && typeof config.model === "string") {
-		return `${typeof config.provider === "string" && config.provider.length > 0 ? config.provider : "unknown"}/${config.model}`;
+		return {
+			providerId: typeof config.provider === "string" && config.provider.length > 0 ? config.provider : "unknown",
+			model: config.model
+		};
 	}
 	return void 0;
+}
+
+function modelOf(event) {
+	const route = routeModelOf(event);
+	return route === void 0 ? void 0 : `${route.providerId}/${route.model}`;
 }
 
 /** Day entry: totals plus a per-model bucket map. */
@@ -134,14 +147,43 @@ function entryOf(byDay, day) {
  * One session's incremental fold state. `days` holds the already-folded
  * per-day entries; `lastSample`/`currentModel` let a later event slice keep
  * the replace-last-sample semantics and model attribution across fold
- * boundaries without replaying the whole log.
+ * boundaries without replaying the whole log. `currentRoute` is a lightweight
+ * provider/model projection over that same cursor, not a second usage ledger.
  */
 export function createUsageState() {
-	return {
+	return resetUsageState({});
+}
+
+/** Reset only the incremental fold fields while preserving cache metadata. */
+export function resetUsageState(state) {
+	return Object.assign(state, {
 		days: new Map(),
 		lastSample: null,
 		currentModel: null,
+		currentRoute: null,
 		consumed: 0
+	});
+}
+
+/**
+ * Render the secret-free context for one session's latest provider/model pair.
+ * The provider object supplies connection identity only; credentials and
+ * monitor request details are intentionally excluded from the wire shape.
+ */
+export function currentSessionContext(sessionId, state, provider, config = { monitors: {} }) {
+	const current = state?.currentRoute;
+	if (current === null || current === void 0) return null;
+	const identity = resolveProviderIdentity({
+		...(provider ?? {}),
+		id: current.providerId
+	}, config);
+	return {
+		sessionId,
+		providerId: identity.routeId,
+		providerFamily: identity.providerFamily,
+		model: current.model,
+		accountId: identity.routeId,
+		updatedAt: current.updatedAt
 	};
 }
 
@@ -157,10 +199,21 @@ export function createUsageState() {
 export function applyUsageDelta(state, events) {
 	let last = state.lastSample;
 	let currentModel = state.currentModel;
+	let currentRoute = state.currentRoute ?? null;
 	for (const event of events) {
-		if (event.type === "request/header") {
-			const model = modelOf(event);
-			if (model !== void 0) currentModel = model;
+		if (event.type === "request/header" || event.type === "assistant/message") {
+			const route = routeModelOf(event);
+			if (route !== void 0) {
+				// Keep token attribution semantics unchanged: currentModel remains
+				// request/header-driven, while currentRoute may also use the model
+				// source on assistant/message for live context switching.
+				if (event.type === "request/header") currentModel = `${route.providerId}/${route.model}`;
+				currentRoute = {
+					providerId: route.providerId,
+					model: route.model,
+					updatedAt: Number.isFinite(event.time) ? event.time : currentRoute?.updatedAt ?? null
+				};
+			}
 		}
 		const sample = sampleOf(event);
 		if (sample === void 0) continue;
@@ -188,6 +241,7 @@ export function applyUsageDelta(state, events) {
 	}
 	state.lastSample = last;
 	state.currentModel = currentModel;
+	state.currentRoute = currentRoute;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -48,13 +48,14 @@
     }
   },
   "scripts": {
-    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/accounts.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-overlay-layering.mjs && node --check scripts/test-bundle.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/test-accounts.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
-    "test": "npm run test:bundle && npm run test:client && npm run test:overlay && npm run test:server && npm run test:balance && npm run test:subscriptions && npm run test:accounts && npm run test:install",
+    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/network.js && node --check lib/provider-identity.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/accounts.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-overlay-layering.mjs && node --check scripts/test-bundle.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-provider-identity.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/test-accounts.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
+    "test": "npm run test:bundle && npm run test:client && npm run test:overlay && npm run test:server && npm run test:provider-identity && npm run test:balance && npm run test:subscriptions && npm run test:accounts && npm run test:install",
     "test:bundle": "node scripts/test-bundle.mjs",
     "test:client": "node scripts/smoke-client.mjs",
     "test:overlay": "node scripts/test-overlay-layering.mjs",
     "test:install": "node scripts/test-install.mjs",
     "test:server": "node scripts/test-server.mjs",
+    "test:provider-identity": "node scripts/test-provider-identity.mjs",
     "test:balance": "node scripts/test-balance.mjs",
     "test:subscriptions": "node scripts/test-subscriptions.mjs",
     "test:accounts": "node scripts/test-accounts.mjs",

--- a/scripts/test-provider-identity.mjs
+++ b/scripts/test-provider-identity.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+
+import { resolveAccountSpec } from "../lib/accounts.js";
+import { resolveProviderIdentity } from "../lib/provider-identity.js";
+import { applyUsageDelta, createUsageState, currentSessionContext } from "../lib/usage.js";
+
+function provider(id, baseURL, displayName = id) {
+	return { id, displayName, ...(baseURL === void 0 ? {} : { baseURL }) };
+}
+
+function requestEvent(seq, providerId, model, time = Date.UTC(2026, 7, 23, 12, 0, seq)) {
+	return {
+		seq,
+		time,
+		type: "request/header",
+		data: { header: { config: { provider: providerId, model } } }
+	};
+}
+
+function assistantEvent(seq, providerId, model, time = Date.UTC(2026, 7, 23, 12, 1, seq)) {
+	return {
+		seq,
+		time,
+		type: "assistant/message",
+		data: { message: { source: { kind: "model", provider: providerId, model } } }
+	};
+}
+
+{
+	const identity = resolveProviderIdentity(provider("deepseek-official", "https://relay.invalid/v1", "Anything"));
+	assert.deepEqual(identity, {
+		routeId: "deepseek-official",
+		displayName: "Anything",
+		providerFamily: "deepseek",
+		accountAdapter: "deepseek-balance",
+		pricingFamily: "deepseek",
+		baseURL: "https://relay.invalid/v1",
+		confidence: "canonical-id"
+	});
+}
+
+{
+	const identity = resolveProviderIdentity(provider("relay-a", "https://api.deepseek.com/v1", "Not DeepSeek"));
+	assert.equal(identity.providerFamily, "deepseek");
+	assert.equal(identity.accountAdapter, "deepseek-balance");
+	assert.equal(identity.confidence, "canonical-host");
+	assert.equal(resolveAccountSpec(provider("relay-a", "https://api.deepseek.com/v1")).adapter, "deepseek-balance", "AccountService must consume the shared resolver policy");
+}
+
+{
+	const canonical = resolveProviderIdentity(provider("ollama", "https://ollama.com"));
+	assert.equal(canonical.providerFamily, "ollama");
+	assert.equal(canonical.accountAdapter, "ollama");
+	assert.equal(canonical.confidence, "canonical-id");
+
+	const exactHost = resolveProviderIdentity(provider("my-ollama", "https://ollama.com"));
+	assert.equal(exactHost.providerFamily, "ollama");
+	assert.equal(exactHost.accountAdapter, "ollama");
+	assert.equal(exactHost.confidence, "canonical-host");
+
+	const cloud = resolveProviderIdentity(provider("private-ollama-route", "https://api.ollama.com/v1"));
+	assert.equal(cloud.providerFamily, "ollama");
+	assert.equal(cloud.accountAdapter, "ollama");
+	assert.equal(cloud.confidence, "canonical-host");
+
+	for (const baseURL of ["http://localhost:11434", "http://127.0.0.1:11434", "http://[::1]:11434"]) {
+		const local = resolveProviderIdentity(provider("ollama", baseURL, "Ollama Cloud"));
+		assert.equal(local.providerFamily, "unknown", `${baseURL} must not be classified as Ollama Cloud`);
+		assert.equal(local.accountAdapter, null);
+		assert.equal(local.confidence, "unknown");
+	}
+	const customLoopback = resolveProviderIdentity(provider("my-ollama", "http://127.0.0.1:11434", "Ollama Cloud"));
+	assert.equal(customLoopback.providerFamily, "unknown");
+	assert.equal(customLoopback.accountAdapter, null);
+}
+
+{
+	const unknown = resolveProviderIdentity(provider("custom-route", "https://relay.invalid/v1", "DeepSeek"));
+	assert.equal(unknown.providerFamily, "unknown", "displayName alone must never drive identity");
+	assert.equal(unknown.accountAdapter, null);
+	assert.equal(unknown.pricingFamily, "unknown");
+	assert.equal(unknown.confidence, "unknown");
+
+	const malformed = resolveProviderIdentity(provider("custom-route", "not a URL", "Ollama"));
+	assert.equal(malformed.providerFamily, "unknown");
+	assert.equal(malformed.baseURL, "not a URL", "connection facts should be preserved without trusting them");
+
+	const absent = resolveProviderIdentity(provider("custom-route", void 0, "DeepSeek"));
+	assert.equal(absent.providerFamily, "unknown");
+	assert.equal(absent.accountAdapter, null);
+	assert.equal(absent.baseURL, null);
+}
+
+{
+	const identity = resolveProviderIdentity(provider("deepseek", "https://api.deepseek.com"), {
+		monitors: {
+			deepseek: { providerId: "deepseek", adapter: "new-api", usageBaseURL: "https://usage.invalid" }
+		}
+	});
+	assert.equal(identity.providerFamily, "new-api", "explicit monitor adapter must beat canonical id and host");
+	assert.equal(identity.accountAdapter, "new-api");
+	assert.equal(identity.pricingFamily, "unknown", "a gateway adapter does not prove the future model pricing family");
+	assert.equal(identity.confidence, "explicit");
+
+	const generic = resolveProviderIdentity(provider("deepseek", "https://api.deepseek.com"), {
+		monitors: { deepseek: { providerId: "deepseek", adapter: "general" } }
+	});
+	assert.equal(generic.providerFamily, "unknown", "a generic account protocol must not masquerade as provider identity");
+	assert.equal(generic.accountAdapter, "general");
+	assert.equal(generic.pricingFamily, "unknown");
+}
+
+{
+	const state = createUsageState();
+	applyUsageDelta(state, [
+		requestEvent(0, "route-a", "shared-model"),
+		assistantEvent(1, "route-b", "shared-model")
+	]);
+	const context = currentSessionContext("session-1", state, provider("route-b", "https://api.deepseek.com"));
+	assert.deepEqual(context, {
+		sessionId: "session-1",
+		providerId: "route-b",
+		providerFamily: "deepseek",
+		model: "shared-model",
+		accountId: "route-b",
+		updatedAt: Date.UTC(2026, 7, 23, 12, 1, 1)
+	});
+	assert.equal(state.currentModel, "route-a/shared-model", "session context must not change request-driven usage attribution state");
+
+	applyUsageDelta(state, [requestEvent(2, "route-a", "shared-model")]);
+	assert.equal(currentSessionContext("session-1", state, provider("route-a", "https://relay.invalid")).providerId, "route-a");
+	assert.equal(state.currentModel, "route-a/shared-model", "same model on two routes must stay route-distinct");
+}
+
+{
+	const state = createUsageState();
+	assert.equal(currentSessionContext("empty", state, provider("deepseek")), null);
+}
+
+console.log("PROVIDER IDENTITY + SESSION CONTEXT TESTS PASSED");

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -144,6 +144,51 @@ async function testSessionContext(root) {
 	await handler({ method: "GET", url: plugin.SESSION_CONTEXT_PATH, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, ambiguous);
 	assert.equal(ambiguous.status, 400, "multiple live sessions require an explicit id instead of guessing the active browser session");
 	assert.equal(JSON.parse(ambiguous.body).error, "session-required");
+}
+
+async function testV3CacheUpgradeRefoldsCurrentRoute(root) {
+	const home = join(root, "v3-cache-upgrade");
+	const storage = join(home, "storages");
+	await mkdir(storage, { recursive: true });
+	const sessionId = "cached-live-session";
+	await writeFile(join(storage, "usage-stats-cache.json"), JSON.stringify({
+		version: 3,
+		sessions: {
+			[sessionId]: {
+				kind: "live",
+				consumed: 1,
+				days: {},
+				lastSample: null,
+				currentModel: "route-a/deepseek-chat"
+			}
+		}
+	}), "utf8");
+	const plugin = await freshModule("v3-cache-upgrade", home);
+	const session = { id: sessionId, events: [routeEvent(0, "route-a", "deepseek-chat")] };
+	const settings = {
+		get: (name) => name === "llm-pi-ai" ? {
+			providers: {
+				"route-a": { displayName: "Route A", baseURL: "https://api.deepseek.com/v1" }
+			}
+		} : void 0
+	};
+	const context = makeContext({
+		sessions: { get: (id) => id === sessionId ? session : void 0, list: () => [session] },
+		persistence: { listSnapshots: async () => [], list: async () => [] },
+		settings
+	});
+
+	assert.deepEqual(await plugin.collectSessionContext(context, sessionId), {
+		sessionId,
+		providerId: "route-a",
+		providerFamily: "deepseek",
+		model: "deepseek-chat",
+		accountId: "route-a",
+		updatedAt: Date.UTC(2026, 7, 23, 12, 0, 0)
+	}, "a v3 cache without currentRoute must be invalidated and refolded even when no event is new");
+	const migrated = JSON.parse(await readFile(join(storage, "usage-stats-cache.json"), "utf8"));
+	assert.equal(migrated.version, 4, "the rewritten cache must use schema v4");
+	assert.equal(migrated.sessions[sessionId].currentRoute.providerId, "route-a");
 }
 
 async function testConfigValidation(root) {
@@ -309,6 +354,7 @@ const root = await mkdtemp(join(tmpdir(), "dsh-usage-stats-"));
 try {
 	await testRouteFence(root);
 	await testSessionContext(root);
+	await testV3CacheUpgradeRefoldsCurrentRoute(root);
 	await testConfigValidation(root);
 	await testLegacyZaiSubscriptionId(root);
 	await testBackgroundRefresh(root);

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -17,6 +17,15 @@ function usageEvent(seq, inputTokens) {
 	};
 }
 
+function routeEvent(seq, provider, model) {
+	return {
+		seq,
+		time: Date.UTC(2026, 7, 23, 12, 0, seq),
+		type: "request/header",
+		data: { header: { config: { provider, model } } }
+	};
+}
+
 async function freshModule(label, home) {
 	process.env.DSH_HOME = home;
 	return import(new URL(`../lib/index.js?test=${label}-${Date.now()}-${Math.random()}`, import.meta.url));
@@ -71,6 +80,70 @@ async function testRouteFence(root) {
 	await routes.get(plugin.ACCOUNT_PATH)({ method: "GET", url: `${plugin.ACCOUNT_PATH}?provider=deepseek-official`, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, account);
 	assert.equal(account.status, 200);
 	assert.equal(JSON.parse(account.body).account.status, "not-configured");
+	assert.equal(typeof routes.get(plugin.SESSION_CONTEXT_PATH), "function");
+}
+
+async function testSessionContext(root) {
+	const plugin = await freshModule("session-context", join(root, "session-context"));
+	const routes = new Map();
+	const events = [routeEvent(0, "route-a", "shared-model")];
+	const session = { id: "live-session", events };
+	let liveSessions = [session];
+	const sessions = {
+		get: (id) => liveSessions.find((entry) => entry.id === id),
+		list: () => liveSessions
+	};
+	const persistence = { listSnapshots: async () => [], list: async () => [] };
+	const settings = {
+		get: (name) => name === "llm-pi-ai" ? {
+			providers: {
+				"route-a": {
+					displayName: "Friendly label",
+					baseURL: "https://api.deepseek.com/v1",
+					apiKeyEnv: "SECRET_API_KEY_REFERENCE"
+				},
+				"route-b": {
+					displayName: "Another label",
+					baseURL: "https://api.ollama.com/v1",
+					apiKeyEnv: "OTHER_SECRET_REFERENCE"
+				}
+			}
+		} : void 0
+	};
+	await plugin.apply(makeContext({ sessions, persistence, routes, settings }), {}, { disableBackgroundRefresh: true });
+	const handler = routes.get(plugin.SESSION_CONTEXT_PATH);
+
+	const first = makeResponse();
+	await handler({ method: "GET", url: `${plugin.SESSION_CONTEXT_PATH}?session=live-session`, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, first);
+	assert.equal(first.status, 200);
+	assert.deepEqual(JSON.parse(first.body).context, {
+		sessionId: "live-session",
+		providerId: "route-a",
+		providerFamily: "deepseek",
+		model: "shared-model",
+		accountId: "route-a",
+		updatedAt: Date.UTC(2026, 7, 23, 12, 0, 0)
+	});
+	assert.doesNotMatch(first.body, /SECRET|apiKey|baseURL/i, "session context must not expose connection or credential fields");
+
+	events.push(routeEvent(1, "route-b", "shared-model"));
+	const switched = makeResponse();
+	await handler({ method: "GET", url: plugin.SESSION_CONTEXT_PATH, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, switched);
+	assert.equal(switched.status, 200, "one live session may be selected without guessing");
+	assert.equal(JSON.parse(switched.body).context.providerId, "route-b");
+	assert.equal(JSON.parse(switched.body).context.providerFamily, "ollama");
+	assert.equal(JSON.parse(switched.body).context.model, "shared-model");
+
+	const missing = makeResponse();
+	await handler({ method: "GET", url: `${plugin.SESSION_CONTEXT_PATH}?session=missing`, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, missing);
+	assert.equal(missing.status, 404);
+	assert.equal(JSON.parse(missing.body).error, "unknown-session");
+
+	liveSessions = [session, { id: "second-session", events: [] }];
+	const ambiguous = makeResponse();
+	await handler({ method: "GET", url: plugin.SESSION_CONTEXT_PATH, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, ambiguous);
+	assert.equal(ambiguous.status, 400, "multiple live sessions require an explicit id instead of guessing the active browser session");
+	assert.equal(JSON.parse(ambiguous.body).error, "session-required");
 }
 
 async function testConfigValidation(root) {
@@ -235,6 +308,7 @@ async function testZeroUsageRowsFiltered(root) {
 const root = await mkdtemp(join(tmpdir(), "dsh-usage-stats-"));
 try {
 	await testRouteFence(root);
+	await testSessionContext(root);
 	await testConfigValidation(root);
 	await testLegacyZaiSubscriptionId(root);
 	await testBackgroundRefresh(root);


### PR DESCRIPTION
Fixes #60
Reference #65

## Architecture

- Adds a pure route-aware Provider Identity Resolver shared by AccountService, balance scheme lookup, and session context.
- Separates routeId, providerFamily, accountAdapter, pricingFamily, baseURL, and confidence. Generic account protocols do not invent provider or pricing identity.
- Extracts one shared private-network classifier so identity detection and account-monitor SSRF policy cannot drift.
- Reuses the existing incremental usage state and cursor; currentRoute is a lightweight projection, not a second ledger.

## Resolution precedence

1. Explicit monitor adapter/configuration
2. Canonical provider route id
3. Canonical baseURL hostname
4. Only other reliable signals
5. unknown

displayName is presentation-only and never participates in inference. Canonical Ollama identity is gated against local/private endpoints.

## API and context

- Adds loopback-only GET /api/usage-stats/session-context?session=<id>.
- The session id is explicit when multiple sessions are live; a single live session is an unambiguous fallback.
- Returns sessionId, providerId, providerFamily, model, accountId, and updatedAt.
- Credentials, credential references, monitor request details, and base URLs are excluded.
- Provider/model changes are folded from DSH request/header and assistant/message events in O(new events), with no new llm/stream listener.

## Tests

- Provider identity: DeepSeek id/host, canonical and custom Ollama Cloud, localhost/127/IPv6 false positives, explicit precedence, unknown and malformed/absent URL cases.
- Session context: route-distinct identical models, provider/model switching, multi-session selection, unknown sessions, and secret-free response.
- Existing AccountService, balance, subscription, server, client, installer, and bundle regressions remain green.

Validation:

- npm run check — passed
- npm test — passed
- npm pack — passed (15 files; 72.1 kB tarball)

## Scope

No UI, pricing engine, budget, export, new stream listener, second usage ledger, aggregation-semantics change, or version bump is included. Package version remains 0.2.10.