### PR TITLE
feat: add current session provider account pill

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -510,12 +510,16 @@ window.__ModuleLoader__.load({
 			}
 
 			let value = null;
+			let auxiliaryLabel = "";
 			if (account?.mode === "subscription") {
 				const windows = Array.isArray(account.windows)
 					? account.windows.filter((entry) => entry !== null && typeof entry === "object" && typeof entry.remainingPercent === "number" && Number.isFinite(entry.remainingPercent))
 					: [];
 				const tightest = windows.reduce((current, entry) => current === null || entry.remainingPercent < current.remainingPercent ? entry : current, null);
-				if (tightest !== null) value = `${quotaLabel(tightest.kind, translate)} · ${percentLabel(tightest.remainingPercent)}`;
+				if (tightest !== null) {
+					value = `${quotaLabel(tightest.kind, translate)} · ${percentLabel(tightest.remainingPercent)}`;
+					auxiliaryLabel = resetLabel(tightest.resetsAt, translate);
+				}
 			} else if (account?.balance?.unlimited === true) {
 				value = "∞";
 			} else if (account?.balance !== null && account?.balance !== void 0 && account.balance.remaining !== null && account.balance.remaining !== void 0 && Number.isFinite(Number(account.balance.remaining))) {
@@ -535,13 +539,14 @@ window.__ModuleLoader__.load({
 			}
 			const alertLevel = account?.alert?.level;
 			const tone = alertLevel === "normal" || alertLevel === "warning" || alertLevel === "critical" ? alertLevel : "neutral";
+			const accessibleValue = auxiliaryLabel === "" ? value : `${value} · ${auxiliaryLabel}`;
 			return {
 				providerId,
 				providerLabel,
 				status,
 				value,
 				tone,
-				ariaLabel: translate("sessionPill.aria", { provider: providerLabel, value })
+				ariaLabel: translate("sessionPill.aria", { provider: providerLabel, value: accessibleValue })
 			};
 		}
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -31,6 +31,15 @@ window.__ModuleLoader__.load({
 			".usg_badgeOk{color:var(--dsw-alias-state-success-primary)}",
 			".usg_badgeBad{color:var(--dsw-alias-state-error-primary)}",
 			".usg_badgeCount{color:var(--dsw-alias-label-tertiary);font-variant-numeric:tabular-nums;flex:none;margin-left:auto;font-size:12px;line-height:16px}",
+			".usg_sessionPill{box-sizing:border-box;max-width:220px;height:28px;color:var(--dsw-alias-label-tertiary);background:var(--dsw-alias-fill-l1,transparent);border:1px solid var(--dsw-alias-border-l2);border-radius:999px;align-items:center;gap:5px;padding:0 8px;font:inherit;font-size:11px;line-height:16px;cursor:pointer;display:inline-flex;white-space:nowrap;overflow:hidden}",
+			".usg_sessionPill:hover{background:var(--dsw-alias-interactive-bg-hover)}",
+			".usg_sessionPill:focus-visible{outline:2px solid var(--dsw-alias-state-business-primary);outline-offset:1px}",
+			".usg_sessionPill[data-tone=normal]{color:var(--dsw-alias-label-secondary)}",
+			".usg_sessionPill[data-tone=warning]{color:var(--dsw-alias-state-warn-label,var(--dsw-alias-state-warn-primary));border-color:var(--dsw-alias-state-warn-secondary,var(--dsw-alias-border-l2))}",
+			".usg_sessionPill[data-tone=critical]{color:var(--dsw-alias-state-error-primary);border-color:var(--dsw-alias-state-error-secondary,var(--dsw-alias-border-l2))}",
+			".usg_sessionPillProvider{max-width:88px;color:var(--dsw-alias-label-primary);font-weight:500;text-overflow:ellipsis;overflow:hidden}",
+			".usg_sessionPillSeparator{color:var(--dsw-alias-label-caption);flex:none}",
+			".usg_sessionPillValue{max-width:112px;font-variant-numeric:tabular-nums;text-overflow:ellipsis;overflow:hidden}",
 			".usg_layer.usg_rail{width:36px;height:36px;margin:0}",
 			".usg_layer.usg_rail .usg_badge{border-radius:50%;justify-content:center;gap:0;width:36px;height:36px;padding:0}",
 			".usg_layer.usg_rail .usg_footerButtons{flex-direction:column;gap:2px}",
@@ -155,6 +164,10 @@ window.__ModuleLoader__.load({
 			badgeOk: "usg_badgeOk",
 			badgeBad: "usg_badgeBad",
 			badgeCount: "usg_badgeCount",
+			sessionPill: "usg_sessionPill",
+			sessionPillProvider: "usg_sessionPillProvider",
+			sessionPillSeparator: "usg_sessionPillSeparator",
+			sessionPillValue: "usg_sessionPillValue",
 			panel: "usg_panel",
 			header: "usg_header",
 			headerLeft: "usg_headerLeft",
@@ -412,6 +425,200 @@ window.__ModuleLoader__.load({
 			return payload;
 		}
 
+		//#region CurrentSessionPill
+		/**
+		 * Compact event signature from the formal composer slot's point-in-time
+		 * session snapshot. These fields change at turn/message boundaries where
+		 * the server-side currentRoute can change, without reacting to every input
+		 * keystroke or adding a timer/DOM observer.
+		 */
+		function sessionContextSignalOf(session) {
+			const nodes = Array.isArray(session?.nodes) ? session.nodes.length : 0;
+			const order = Array.isArray(session?.chat?.order) ? session.chat.order.length : 0;
+			return `${session?.running === true ? 1 : 0}:${nodes}:${order}:${session?.partial === null || session?.partial === void 0 ? 0 : 1}:${session?.removed === true ? 1 : 0}`;
+		}
+
+		/** Event signature from DSH's existing per-session model selector store. */
+		function modelSelectionSignalOf(snapshot) {
+			const provider = typeof snapshot?.current?.provider === "string" ? snapshot.current.provider : "";
+			const model = typeof snapshot?.current?.model === "string" ? snapshot.current.model : "";
+			return JSON.stringify([provider, model]);
+		}
+
+		/**
+		 * Resolve one explicit DSH session through the server-owned identity and
+		 * account protocols. The account endpoint reads AccountService's existing
+		 * cache; this function owns no provider mapping, credential, or cache.
+		 */
+		async function loadSessionPillSnapshot(sessionId, request = fetchJson, selectedRoute = null) {
+			if (typeof sessionId !== "string" || sessionId === "") return null;
+			const selectionQuery = typeof selectedRoute?.provider === "string" && selectedRoute.provider !== ""
+				&& typeof selectedRoute.model === "string" && selectedRoute.model !== ""
+				? `&provider=${encodeURIComponent(selectedRoute.provider)}&model=${encodeURIComponent(selectedRoute.model)}`
+				: "";
+			const contextPayload = await request(`/api/usage-stats/session-context?session=${encodeURIComponent(sessionId)}${selectionQuery}`);
+			if (contextPayload?.ok !== true || contextPayload.context === null || typeof contextPayload.context !== "object") return null;
+			const context = contextPayload.context;
+			const accountId = typeof context.accountId === "string" && context.accountId !== ""
+				? context.accountId
+				: typeof context.providerId === "string" && context.providerId !== "" ? context.providerId : null;
+			if (accountId === null) return null;
+			try {
+				const accountPayload = await request(`/api/usage-stats/account?provider=${encodeURIComponent(accountId)}`);
+				if (accountPayload?.ok === true && accountPayload.account !== null && typeof accountPayload.account === "object") {
+					return { context, account: accountPayload.account };
+				}
+				return {
+					context,
+					account: null,
+					status: accountPayload?.error === "unknown-provider" ? "unsupported" : "unavailable"
+				};
+			} catch {
+				return { context, account: null, status: "unavailable" };
+			}
+		}
+
+		function percentLabel(value) {
+			return `${value.toFixed(value % 1 === 0 ? 0 : 1)}%`;
+		}
+
+		/** Reduce a server snapshot to display-only fields; never retain secrets. */
+		function sessionPillViewOf(snapshot, translate) {
+			if (snapshot === null || snapshot === void 0 || snapshot.context === null || typeof snapshot.context !== "object") return null;
+			const account = snapshot.account !== null && typeof snapshot.account === "object" ? snapshot.account : null;
+			const providerId = typeof snapshot.context.accountId === "string" && snapshot.context.accountId !== ""
+				? snapshot.context.accountId
+				: typeof snapshot.context.providerId === "string" && snapshot.context.providerId !== "" ? snapshot.context.providerId : null;
+			if (providerId === null) return null;
+			const providerLabel = typeof account?.displayName === "string" && account.displayName !== ""
+				? account.displayName
+				: typeof snapshot.context.providerId === "string" && snapshot.context.providerId !== "" ? snapshot.context.providerId : providerId;
+			let status = typeof account?.status === "string" ? account.status : typeof snapshot.status === "string" ? snapshot.status : "unavailable";
+			if (account?.stale === true && status === "ok") status = "unavailable";
+			if (status !== "ok") {
+				const value = status === "unsupported"
+					? translate("sessionPill.status.unsupported")
+					: subscriptionStatusLabel(status, translate);
+				return {
+					providerId,
+					providerLabel,
+					status,
+					value,
+					tone: "neutral",
+					ariaLabel: translate("sessionPill.aria", { provider: providerLabel, value })
+				};
+			}
+
+			let value = null;
+			if (account?.mode === "subscription") {
+				const windows = Array.isArray(account.windows)
+					? account.windows.filter((entry) => entry !== null && typeof entry === "object" && typeof entry.remainingPercent === "number" && Number.isFinite(entry.remainingPercent))
+					: [];
+				const tightest = windows.reduce((current, entry) => current === null || entry.remainingPercent < current.remainingPercent ? entry : current, null);
+				if (tightest !== null) value = `${quotaLabel(tightest.kind, translate)} · ${percentLabel(tightest.remainingPercent)}`;
+			} else if (account?.balance?.unlimited === true) {
+				value = "∞";
+			} else if (account?.balance !== null && account?.balance !== void 0 && account.balance.remaining !== null && account.balance.remaining !== void 0 && Number.isFinite(Number(account.balance.remaining))) {
+				value = fmtCurrency(account.balance.remaining, account.balance.currency);
+			}
+
+			if (value === null) {
+				const invalid = translate("account.status.invalidResponse");
+				return {
+					providerId,
+					providerLabel,
+					status: "invalid-response",
+					value: invalid,
+					tone: "neutral",
+					ariaLabel: translate("sessionPill.aria", { provider: providerLabel, value: invalid })
+				};
+			}
+			const alertLevel = account?.alert?.level;
+			const tone = alertLevel === "normal" || alertLevel === "warning" || alertLevel === "critical" ? alertLevel : "neutral";
+			return {
+				providerId,
+				providerLabel,
+				status,
+				value,
+				tone,
+				ariaLabel: translate("sessionPill.aria", { provider: providerLabel, value })
+			};
+		}
+
+		const usageStatsPanelOpeners = /* @__PURE__ */ new Set();
+
+		function subscribeUsageStatsPanel(opener) {
+			if (typeof opener !== "function") return () => {};
+			usageStatsPanelOpeners.add(opener);
+			return () => usageStatsPanelOpeners.delete(opener);
+		}
+
+		function requestUsageStatsPanel(providerId) {
+			const openers = [...usageStatsPanelOpeners];
+			openers[openers.length - 1]?.(providerId);
+		}
+
+		/** Pure compact pill view, separated for render/click regression tests. */
+		function CurrentSessionPillView({ snapshot, translate, onOpen = requestUsageStatsPanel }) {
+			const view = sessionPillViewOf(snapshot, translate);
+			if (view === null) return null;
+			return react_jsx_runtime.jsxs("button", {
+				type: "button",
+				className: S.sessionPill,
+				"data-current-session-pill": true,
+				"data-provider": view.providerId,
+				"data-status": view.status,
+				"data-tone": view.tone,
+				"aria-label": view.ariaLabel,
+				title: view.ariaLabel,
+				onClick: () => onOpen(view.providerId),
+				children: [
+					react_jsx_runtime.jsx("span", { className: S.sessionPillProvider, children: view.providerLabel }),
+					react_jsx_runtime.jsx("span", { className: S.sessionPillSeparator, "aria-hidden": true, children: "·" }),
+					react_jsx_runtime.jsx("span", { className: S.sessionPillValue, children: view.value })
+				]
+			});
+		}
+
+		/** Formal `conversation.input.right` slot occupant. */
+		function CurrentSessionPill({ sessionId, session, modelDirectory, request = fetchJson, t }) {
+			const translate = (key, params) => interpolate(t !== void 0 ? t(key) : key, params);
+			const [loaded, setLoaded] = react.useState({ key: null, snapshot: null });
+			const loaderRef = react.useRef(null);
+			if (loaderRef.current === null) loaderRef.current = createLoader();
+			const signal = sessionContextSignalOf(session);
+			const subscribeModelSelection = react.useCallback((notify) => typeof modelDirectory?.subscribe === "function"
+				? modelDirectory.subscribe(notify)
+				: () => {}, [modelDirectory]);
+			const getModelSelectionSignal = react.useCallback(() => modelSelectionSignalOf(
+				typeof modelDirectory?.getSnapshot === "function" ? modelDirectory.getSnapshot() : null
+			), [modelDirectory]);
+			const modelSignal = react.useSyncExternalStore(subscribeModelSelection, getModelSelectionSignal, getModelSelectionSignal);
+			const requestKey = JSON.stringify([sessionId, signal, modelSignal]);
+			const [selectedProvider, selectedModel] = JSON.parse(modelSignal);
+			const selectedRoute = selectedProvider !== "" && selectedModel !== ""
+				? { provider: selectedProvider, model: selectedModel }
+				: null;
+			react.useEffect(() => {
+				const seq = loaderRef.current.start();
+				let mounted = true;
+				setLoaded({ key: requestKey, snapshot: null });
+				loadSessionPillSnapshot(sessionId, request, selectedRoute).then((next) => {
+					if (mounted && loaderRef.current.isCurrent(seq)) setLoaded({ key: requestKey, snapshot: next });
+				}).catch(() => {
+					if (mounted && loaderRef.current.isCurrent(seq)) setLoaded({ key: requestKey, snapshot: null });
+				});
+				return () => {
+					mounted = false;
+				};
+			}, [sessionId, signal, modelSignal, request, requestKey, selectedRoute?.provider, selectedRoute?.model]);
+			return react_jsx_runtime.jsx(CurrentSessionPillView, {
+				snapshot: loaded.key === requestKey ? loaded.snapshot : null,
+				translate
+			});
+		}
+		//#endregion
+
 		/**
 		 * Build one month's calendar heatmap: weeks as rows (Mon-first), only
 		 * the month's own days, padded with null placeholders. Cell tokens come
@@ -500,6 +707,15 @@ window.__ModuleLoader__.load({
 			if (accountLoaderRef.current === null) accountLoaderRef.current = createLoader();
 			const providerChoices = react.useMemo(() => buildProviderChoices(providers), [providers]);
 			const selectedProviderInfo = providerChoices.find((provider) => provider.id === selectedProvider) ?? null;
+			const openForProvider = react.useCallback((providerId) => {
+				if (typeof providerId === "string" && providerId !== "") setSelectedProvider(providerId);
+				setOpen(true);
+			}, []);
+
+			// The composer pill and sidebar panel are separate slot roots. A tiny
+			// in-module subscription bridge opens this existing panel without DOM
+			// clicks, a new panel implementation, or another account state/cache.
+			react.useEffect(() => subscribeUsageStatsPanel(openForProvider), [openForProvider]);
 
 			const loadUsage = react.useCallback(() => {
 				const seq = usageLoaderRef.current.start();
@@ -1043,6 +1259,7 @@ window.__ModuleLoader__.load({
 			if (status === "invalid-response") return translate("account.status.invalidResponse");
 			if (status === "blocked") return translate("account.status.blocked");
 			if (status === "unsupported") return translate("account.status.unsupported");
+			if (status === "unknown") return translate("account.status.unknown");
 			return translate("subscription.status.unavailable");
 		}
 
@@ -1318,6 +1535,8 @@ window.__ModuleLoader__.load({
 		const zh = {
 			"panel.title": "用量与余额",
 			"panel.badge": "用量/余额",
+			"sessionPill.aria": "{provider} 账户：{value}",
+			"sessionPill.status.unsupported": "不支持",
 			"account.title": "供应商账户",
 			"account.provider": "当前供应商",
 			"account.balanceMode": "API 余额",
@@ -1326,6 +1545,7 @@ window.__ModuleLoader__.load({
 			"account.status.blocked": "已阻止",
 			"account.status.unsupported": "不支持余额",
 			"account.status.invalidResponse": "响应异常",
+			"account.status.unknown": "未知",
 			"account.invalidResponse": "供应商返回了无法识别的额度数据。",
 			"account.reason.dnsResolutionFailed": "无法解析供应商域名。",
 			"account.reason.allAddressesUnreachable": "已验证的网络地址均无法连接。",
@@ -1406,6 +1626,8 @@ window.__ModuleLoader__.load({
 		const en = {
 			"panel.title": "Usage & Balance",
 			"panel.badge": "Usage/Balance",
+			"sessionPill.aria": "{provider} account: {value}",
+			"sessionPill.status.unsupported": "Unsupported",
 			"account.title": "Provider account",
 			"account.provider": "Current provider",
 			"account.balanceMode": "API balance",
@@ -1414,6 +1636,7 @@ window.__ModuleLoader__.load({
 			"account.status.blocked": "Blocked",
 			"account.status.unsupported": "Balance unsupported",
 			"account.status.invalidResponse": "Invalid response",
+			"account.status.unknown": "Unknown",
 			"account.invalidResponse": "The provider returned unrecognized quota data.",
 			"account.reason.dnsResolutionFailed": "The provider hostname could not be resolved.",
 			"account.reason.allAddressesUnreachable": "None of the validated network addresses could be reached.",
@@ -1498,7 +1721,8 @@ window.__ModuleLoader__.load({
 		const inject = ["slots", "locale"];
 
 		/**
-		 * Client plugin body: register the dictionaries and the sidebar footer action.
+		 * Client plugin body: register dictionaries, the sidebar account panel, and
+		 * the current-session pill beside the host's model selector.
 		 * @param ctx - client root context.
 		 */
 		function apply(ctx) {
@@ -1509,12 +1733,26 @@ window.__ModuleLoader__.load({
 				locale: NS,
 				order: 10
 			}, UsageStatsPanel));
+			// The model-directory service is optional so older/mutated DSH clients
+			// keep the sidebar panel even when the inline slot cannot be supported.
+			ctx.inject(["slots", "modelDirectories"], (scope) => {
+				const models = scope.modelDirectories;
+				scope.slots.inject("conversation.input.right", () => scope.slots.register({
+					name: "conversation.input.right",
+					id: "usage-stats-current-session-pill",
+					locale: NS,
+					order: 10,
+					inject: (sessionId) => ({ modelDirectory: models.directoryFor(sessionId).store })
+				}, CurrentSessionPill));
+			});
 		}
 		//#endregion
 
 		exports.apply = apply;
 		exports.inject = inject;
 		exports.UsageStatsPanel = UsageStatsPanel;
+		exports.CurrentSessionPill = CurrentSessionPill;
+		exports.CurrentSessionPillView = CurrentSessionPillView;
 		exports.DayDetail = DayDetail;
 		exports.ProviderAccountCard = ProviderAccountCard;
 		exports.MonthHeatmap = MonthHeatmap;
@@ -1529,6 +1767,12 @@ window.__ModuleLoader__.load({
 		exports.badgeWarnOf = badgeWarnOf;
 		exports.shouldDismissPanel = shouldDismissPanel;
 		exports.safeDiagnosticReason = safeDiagnosticReason;
+		exports.loadSessionPillSnapshot = loadSessionPillSnapshot;
+		exports.modelSelectionSignalOf = modelSelectionSignalOf;
+		exports.requestUsageStatsPanel = requestUsageStatsPanel;
+		exports.sessionContextSignalOf = sessionContextSignalOf;
+		exports.sessionPillViewOf = sessionPillViewOf;
+		exports.subscribeUsageStatsPanel = subscribeUsageStatsPanel;
 		return module.exports;
 	}
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -428,22 +428,26 @@ async function configuredProviders(ctx) {
 }
 
 /**
- * Resolve one live DSH session's latest provider/model pair. The incremental
- * usage fold is the single source of truth, so this remains O(new events) and
- * does not add another stream listener or usage ledger.
+ * Resolve one live DSH session's provider/model pair. A bounded route hint from
+ * the formal per-session model selector wins for immediate pre-turn switches;
+ * the incremental event fold remains the no-hint source and history fallback.
+ * Both paths still pass through the shared identity resolver, remain O(new
+ * events), and add no stream listener, provider request, cache, or usage ledger.
  */
-export async function collectSessionContext(ctx, sessionId, config = { monitors: {} }) {
+export async function collectSessionContext(ctx, sessionId, config = { monitors: {} }, selectedRoute = null) {
 	await collectUsage(ctx);
 	const sessions = ctx.get("sessions");
 	const live = sessions?.get?.(sessionId) ?? sessions?.list?.().find((session) => session.id === sessionId);
 	if (live === void 0) return null;
 	const cache = await loadCache();
 	const state = cache.sessions[sessionId];
-	if (state?.kind !== "live" || state.currentRoute === null || state.currentRoute === void 0) return null;
+	if (state?.kind !== "live") return null;
+	const currentRoute = selectedRoute ?? state.currentRoute;
+	if (currentRoute === null || currentRoute === void 0) return null;
 	const providers = await configuredProviders(ctx);
-	const provider = providers.find((entry) => entry.id === state.currentRoute.providerId)
-		?? { id: state.currentRoute.providerId, displayName: state.currentRoute.providerId };
-	return currentSessionContext(sessionId, state, provider, config);
+	const provider = providers.find((entry) => entry.id === currentRoute.providerId)
+		?? { id: currentRoute.providerId, displayName: currentRoute.providerId };
+	return currentSessionContext(sessionId, { ...state, currentRoute }, provider, config);
 }
 
 /** Session context is explicit in multi-session DSH; a single live session is unambiguous. */
@@ -452,6 +456,14 @@ async function handleSessionContext(ctx, config, req, res) {
 	try {
 		const url = new URL(req.url ?? "/", "http://x");
 		const requested = url.searchParams.get("session");
+		const selectedProvider = url.searchParams.get("provider");
+		const selectedModel = url.searchParams.get("model");
+		if ((selectedProvider === null) !== (selectedModel === null)
+			|| selectedProvider !== null && (selectedProvider === "" || selectedProvider.length > 256 || selectedProvider.includes("\0"))
+			|| selectedModel !== null && (selectedModel === "" || selectedModel.length > 512 || selectedModel.includes("\0"))) {
+			json(res, 400, { ok: false, error: "invalid-selection", message: "provider and model must be supplied together as bounded non-empty values" });
+			return;
+		}
 		const sessions = ctx.get("sessions")?.list?.() ?? [];
 		let sessionId = requested === null || requested === "" ? null : requested;
 		if (sessionId === null && sessions.length === 1) sessionId = sessions[0].id;
@@ -467,7 +479,15 @@ async function handleSessionContext(ctx, config, req, res) {
 			json(res, 404, { ok: false, error: "unknown-session", message: `session "${sessionId}" is not live` });
 			return;
 		}
-		json(res, 200, { ok: true, context: await collectSessionContext(ctx, sessionId, config) });
+		// The browser hint comes from DSH's formal per-session model directory.
+		// It carries route identity only; configuredProviders + the shared resolver
+		// below remain authoritative for family/account normalization.
+		const selectedRoute = selectedProvider === null ? null : {
+			providerId: selectedProvider,
+			model: selectedModel,
+			updatedAt: null
+		};
+		json(res, 200, { ok: true, context: await collectSessionContext(ctx, sessionId, config, selectedRoute) });
 	} catch (error) {
 		ctx.logger.warn(`usage-stats: session context failed: ${String(error)}`);
 		json(res, 500, { ok: false, error: "internal", message: error instanceof Error ? error.message : String(error) });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-test-renderer": "^18.3.1"
       }
     },
     "node_modules/js-tokens": {
@@ -34,6 +35,16 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -57,6 +68,42 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmmirror.com/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmmirror.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmmirror.com/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+      "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.3.1",
+        "react-shallow-renderer": "^16.15.0",
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   },
   "devDependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-test-renderer": "^18.3.1"
   },
   "license": "MIT",
   "publishConfig": {

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -370,6 +370,7 @@ if ([CurrentSessionPill, CurrentSessionPillView, loadSessionPillSnapshot, reques
 }
 const pillTranslate = (key, params) => {
 	if (params?.provider !== void 0 && params?.value !== void 0) return `${params.provider}: ${params.value}`;
+	if (key === "subscription.resets" && params?.time !== void 0) return `reset:${params.time}`;
 	return key;
 };
 const pillContext = {
@@ -420,6 +421,24 @@ if (subscriptionPill.providerLabel !== "OpenCode Go" || !subscriptionPill.value.
 	throw new Error(`subscription pill must show the tightest valid window: ${JSON.stringify(subscriptionPill)}`);
 }
 if (subscriptionPill.tone !== "critical") throw new Error("subscription pill tone must come from account.alert.level");
+if (subscriptionPill.ariaLabel.includes("reset:")) throw new Error("subscription pill without resetsAt must not invent reset information");
+const subscriptionPillWithResetSnapshot = {
+	context: { ...pillContext, providerId: "opencode-go", accountId: "opencode-go" },
+	account: {
+		id: "opencode-go",
+		displayName: "OpenCode Go",
+		mode: "subscription",
+		status: "ok",
+		windows: [
+			{ kind: "session", remainingPercent: 42, resetsAt: "2026-08-24T01:00:00Z" },
+			{ kind: "weekly", remainingPercent: 8, resetsAt: "2026-08-30T01:00:00Z" }
+		],
+		alert: { level: "critical", metric: "remaining-percent", value: 8 }
+	}
+};
+const subscriptionPillWithReset = sessionPillViewOf(subscriptionPillWithResetSnapshot, pillTranslate);
+if (!subscriptionPillWithReset.ariaLabel.includes("reset:")) throw new Error("subscription pill must expose the tightest window reset through accessible text");
+if (subscriptionPillWithReset.value !== subscriptionPill.value) throw new Error("reset information must not expand the compact visible pill value");
 const warningPill = sessionPillViewOf({ ...balancePillSnapshot, account: { ...balancePillSnapshot.account, alert: { level: "warning" } } }, pillTranslate);
 if (warningPill.tone !== "warning") throw new Error("warning alert tone must be preserved");
 
@@ -460,6 +479,17 @@ const subscriptionPillElement = CurrentSessionPillView({
 	onOpen: () => {}
 });
 const subscriptionPillMarkup = renderToStaticMarkup(subscriptionPillElement);
+const subscriptionPillWithResetElement = CurrentSessionPillView({
+	snapshot: subscriptionPillWithResetSnapshot,
+	translate: pillTranslate,
+	onOpen: () => {}
+});
+if (!subscriptionPillWithResetElement.props.title.includes("reset:") || subscriptionPillWithResetElement.props["aria-label"] !== subscriptionPillWithResetElement.props.title) {
+	throw new Error("known resetsAt must be exposed consistently through the pill title and aria-label");
+}
+if (subscriptionPillElement.props.title.includes("reset:") || subscriptionPillElement.props["aria-label"].includes("reset:")) {
+	throw new Error("missing resetsAt must leave the pill title and aria-label free of invented reset information");
+}
 if (!balancePillMarkup.includes('data-tone="normal"') || !subscriptionPillMarkup.includes('data-tone="critical"')) throw new Error("pill alert tones missing from markup");
 if (balancePillMarkup.includes("MUST_NOT_RENDER") || balancePillMarkup.includes("secret.invalid")) throw new Error("pill must not render credential or connection fields");
 if (pillElement.type !== subscriptionPillElement.type || balancePillMarkup === subscriptionPillMarkup) throw new Error("provider switch must update the existing pill root");

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -16,6 +16,8 @@ const require = process.env.SMOKE_NODE_MODULES === void 0
 const react = require("react");
 const jsxRuntime = require("react/jsx-runtime");
 const { renderToStaticMarkup } = require("react-dom/server");
+const TestRenderer = require("react-test-renderer");
+const { act } = TestRenderer;
 
 // Fake primitives: every named export is a no-op component (returns its props as children is not needed).
 const Stub = () => null;
@@ -39,6 +41,10 @@ if (!source.includes('translate("panel.badge")')) throw new Error("badge must ke
 if (!source.includes("badgeAmountText !== null &&")) throw new Error("badge amount must be a separate middle element");
 if (!source.includes("S.badgeAmount")) throw new Error("badge amount element is missing its class");
 if (!source.includes("badgeCount !== null && react_jsx_runtime.jsx(\"span\", { className: S.badgeCount")) throw new Error("badge must keep the today token count on the right");
+if (!source.includes('.slots.inject("conversation.input.right"')) throw new Error("current-session pill must use the formal composer control slot");
+const pillSource = source.slice(source.indexOf("//#region CurrentSessionPill"), source.indexOf("//#endregion", source.indexOf("//#region CurrentSessionPill")));
+if (pillSource.includes("setInterval") || pillSource.includes("setTimeout")) throw new Error("current-session pill must not add an independent polling loop");
+if (pillSource.includes("MutationObserver") || pillSource.includes("addEventListener")) throw new Error("current-session pill must use slot session snapshots instead of DOM observers/listeners");
 new Function(source)(); // executes the window.__ModuleLoader__.load call
 
 if (captured === null) throw new Error("loader did not capture the bundle");
@@ -78,18 +84,47 @@ console.log("render ok, markup length:", markup.length);
 
 // Apply against a stub client context.
 const registrations = [];
+const registeredEntries = [];
+const modelSubscribers = new Set();
+let modelSnapshot = { current: { provider: "deepseek-official", model: "deepseek-chat" } };
+const modelDirectory = {
+	subscribe: (fn) => { modelSubscribers.add(fn); return () => modelSubscribers.delete(fn); },
+	getSnapshot: () => modelSnapshot
+};
 const ctx = {
 	effect: () => {},
 	locale: { register: (ns, dict) => { if (ns !== "usageStats") throw new Error(`unexpected ns ${ns}`); if (!dict.zh || !dict.en) throw new Error("missing dictionaries"); } },
-	slots: { inject: (slot, fn) => { registrations.push([slot, fn]); return () => {}; }, register: () => () => {} }
+	inject: (_services, fn) => fn({
+		slots: ctx.slots,
+		modelDirectories: { directoryFor: () => ({ store: modelDirectory }) }
+	}),
+	slots: {
+		inject: (slot, fn) => { registrations.push([slot, fn]); return () => {}; },
+		register: (options, component) => { registeredEntries.push({ options, component }); return () => {}; }
+	}
 };
 exports_.apply(ctx);
-if (registrations.length !== 1) throw new Error("expected one slot injection");
-const [slot, registerFn] = registrations[0];
-if (slot !== "sidebar.footer.action") throw new Error(`unexpected slot ${slot}`);
-const disposer = registerFn();
-if (typeof disposer !== "function") throw new Error("slot registration must return a disposer");
-console.log("apply ok, slot:", slot);
+if (registrations.length !== 2) throw new Error(`expected sidebar + composer slot injections, got ${registrations.length}`);
+const registrationBySlot = new Map(registrations);
+if (!registrationBySlot.has("sidebar.footer.action")) throw new Error("sidebar footer slot registration missing");
+if (!registrationBySlot.has("conversation.input.right")) throw new Error("current-session pill slot registration missing");
+for (const registerFn of registrationBySlot.values()) {
+	const disposer = registerFn();
+	if (typeof disposer !== "function") throw new Error("slot registration must return a disposer");
+}
+const pillEntry = registeredEntries.find((entry) => entry.options.name === "conversation.input.right");
+if (pillEntry?.options.id !== "usage-stats-current-session-pill") throw new Error("pill list entry needs a stable unique id");
+if (typeof pillEntry.component !== "function") throw new Error("pill slot must register a component");
+if (pillEntry.options.inject("session-a").modelDirectory !== modelDirectory) throw new Error("pill must subscribe to the host model-selection store");
+// Missing mount point: the host may never invoke a slot injection callback.
+// apply() must still complete without attempting any DOM fallback or throwing.
+exports_.apply({
+	effect: () => {},
+	locale: ctx.locale,
+	inject: () => () => {},
+	slots: { inject: () => () => {}, register: () => { throw new Error("missing host slot must not register"); } }
+});
+console.log("apply ok, formal slots:", [...registrationBySlot.keys()].join(", "));
 
 // Render the month heatmap with synthetic per-day data (calendar grid + colors).
 const { MonthHeatmap, DayDetail, buildMonthHeatmap } = exports_;
@@ -316,4 +351,275 @@ if (badgeWarnOf(staleSubscription) !== false) throw new Error("stale subscriptio
 const okButStale = { mode: "balance", status: "ok", stale: true, balance: { remaining: 100, currency: "USD" } };
 if (badgeAccountValue(okButStale) !== null) throw new Error("ok-but-stale snapshot must not render a numeric badge");
 console.log("collapsed-badge account value + warning policy ok");
+
+// Current Session Pill: one server-resolved provider/account snapshot is
+// reduced to a compact, neutral-by-default view model. No provider inference
+// or client-owned warning thresholds are allowed here.
+const {
+	CurrentSessionPill,
+	CurrentSessionPillView,
+	loadSessionPillSnapshot,
+	requestUsageStatsPanel,
+	sessionContextSignalOf,
+	sessionPillViewOf,
+	modelSelectionSignalOf,
+	subscribeUsageStatsPanel
+} = exports_;
+if ([CurrentSessionPill, CurrentSessionPillView, loadSessionPillSnapshot, requestUsageStatsPanel, sessionContextSignalOf, sessionPillViewOf, modelSelectionSignalOf, subscribeUsageStatsPanel].some((entry) => typeof entry !== "function")) {
+	throw new Error("current-session pill exports are incomplete");
+}
+const pillTranslate = (key, params) => {
+	if (params?.provider !== void 0 && params?.value !== void 0) return `${params.provider}: ${params.value}`;
+	return key;
+};
+const pillContext = {
+	sessionId: "session/one",
+	providerId: "deepseek-official",
+	providerFamily: "deepseek",
+	model: "deepseek-chat",
+	accountId: "deepseek-official"
+};
+const balancePillSnapshot = {
+	context: pillContext,
+	account: {
+		id: "deepseek-official",
+		displayName: "DeepSeek",
+		mode: "balance",
+		status: "ok",
+		balance: { remaining: 36.44, currency: "CNY", unlimited: false },
+		alert: { level: "normal", metric: "balance", value: 36.44 },
+		credentialRef: "MUST_NOT_RENDER",
+		baseURL: "https://secret.invalid"
+	}
+};
+const balancePill = sessionPillViewOf(balancePillSnapshot, pillTranslate);
+if (balancePill.providerId !== "deepseek-official" || balancePill.providerLabel !== "DeepSeek") throw new Error("balance pill lost server-resolved provider identity");
+if (!balancePill.value.includes("36.44") || balancePill.tone !== "normal") throw new Error(`balance pill value/tone incorrect: ${JSON.stringify(balancePill)}`);
+const unlimitedPill = sessionPillViewOf({
+	context: pillContext,
+	account: { ...balancePillSnapshot.account, balance: { remaining: null, currency: "USD", unlimited: true } }
+}, pillTranslate);
+if (unlimitedPill.value !== "∞") throw new Error("unlimited balance pill must render infinity");
+
+const subscriptionPill = sessionPillViewOf({
+	context: { ...pillContext, providerId: "opencode-go", accountId: "opencode-go" },
+	account: {
+		id: "opencode-go",
+		displayName: "OpenCode Go",
+		mode: "subscription",
+		status: "ok",
+		windows: [
+			{ kind: "session", remainingPercent: 42 },
+			{ kind: "weekly", remainingPercent: 8 },
+			{ kind: "monthly", remainingPercent: null }
+		],
+		alert: { level: "critical", metric: "remaining-percent", value: 8 }
+	}
+}, pillTranslate);
+if (subscriptionPill.providerLabel !== "OpenCode Go" || !subscriptionPill.value.includes("subscription.window.weekly") || !subscriptionPill.value.includes("8%")) {
+	throw new Error(`subscription pill must show the tightest valid window: ${JSON.stringify(subscriptionPill)}`);
+}
+if (subscriptionPill.tone !== "critical") throw new Error("subscription pill tone must come from account.alert.level");
+const warningPill = sessionPillViewOf({ ...balancePillSnapshot, account: { ...balancePillSnapshot.account, alert: { level: "warning" } } }, pillTranslate);
+if (warningPill.tone !== "warning") throw new Error("warning alert tone must be preserved");
+
+const statusKeys = new Map([
+	["not-configured", "subscription.status.notConfigured"],
+	["unauthorized", "subscription.status.unauthorized"],
+	["rate-limited", "subscription.status.rateLimited"],
+	["unavailable", "subscription.status.unavailable"],
+	["invalid-response", "account.status.invalidResponse"],
+	["blocked", "account.status.blocked"],
+	["unsupported", "sessionPill.status.unsupported"],
+	["unknown", "account.status.unknown"]
+]);
+for (const [status, expected] of statusKeys) {
+	const view = sessionPillViewOf({
+		context: pillContext,
+		account: { ...balancePillSnapshot.account, status, alert: { level: "critical" } }
+	}, pillTranslate);
+	if (view.value !== expected || view.tone !== "neutral") throw new Error(`${status} pill must be a neutral status, got ${JSON.stringify(view)}`);
+}
+const unknownProviderPill = sessionPillViewOf({ context: { ...pillContext, providerId: "relay-a", accountId: "relay-a" }, account: null, status: "unsupported" }, pillTranslate);
+if (unknownProviderPill.providerLabel !== "relay-a" || unknownProviderPill.value !== "sessionPill.status.unsupported" || unknownProviderPill.tone !== "neutral") {
+	throw new Error("unknown/no-adapter provider must remain a neutral server identity");
+}
+
+let openedProvider = null;
+const pillElement = CurrentSessionPillView({ snapshot: balancePillSnapshot, translate: pillTranslate, onOpen: (id) => { openedProvider = id; } });
+if (pillElement.type !== "button" || pillElement.props["data-current-session-pill"] !== true) throw new Error("pill view needs one stable button root");
+pillElement.props.onClick();
+if (openedProvider !== "deepseek-official") throw new Error(`pill click must open the account panel at its provider, got ${openedProvider}`);
+const balancePillMarkup = renderToStaticMarkup(pillElement);
+const subscriptionPillElement = CurrentSessionPillView({
+	snapshot: {
+		context: { ...pillContext, providerId: "opencode-go", accountId: "opencode-go" },
+		account: { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: "ok", windows: [{ kind: "weekly", remainingPercent: 8 }], alert: { level: "critical" } }
+	},
+	translate: pillTranslate,
+	onOpen: () => {}
+});
+const subscriptionPillMarkup = renderToStaticMarkup(subscriptionPillElement);
+if (!balancePillMarkup.includes('data-tone="normal"') || !subscriptionPillMarkup.includes('data-tone="critical"')) throw new Error("pill alert tones missing from markup");
+if (balancePillMarkup.includes("MUST_NOT_RENDER") || balancePillMarkup.includes("secret.invalid")) throw new Error("pill must not render credential or connection fields");
+if (pillElement.type !== subscriptionPillElement.type || balancePillMarkup === subscriptionPillMarkup) throw new Error("provider switch must update the existing pill root");
+
+const requests = [];
+let currentProvider = "deepseek-official";
+const fetchPill = async (path) => {
+	requests.push(path);
+	if (path.startsWith("/api/usage-stats/session-context")) return {
+		ok: true,
+		context: { ...pillContext, providerId: currentProvider, accountId: currentProvider }
+	};
+	return {
+		ok: true,
+		account: currentProvider === "deepseek-official"
+			? balancePillSnapshot.account
+			: { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: "ok", windows: [{ kind: "weekly", remainingPercent: 18 }], alert: { level: "warning" } }
+	};
+};
+const firstPillLoad = await loadSessionPillSnapshot("session/one", fetchPill);
+currentProvider = "opencode-go";
+const switchedPillLoad = await loadSessionPillSnapshot("session/one", fetchPill);
+if (firstPillLoad.account.id !== "deepseek-official" || switchedPillLoad.account.id !== "opencode-go") throw new Error("session provider switch must resolve a fresh account snapshot");
+if (requests[0] !== "/api/usage-stats/session-context?session=session%2Fone") throw new Error(`session context request must carry the explicit encoded session id: ${requests[0]}`);
+if (!requests.includes("/api/usage-stats/account?provider=opencode-go")) throw new Error("pill must reuse the unified account endpoint for the resolved provider");
+await loadSessionPillSnapshot("session/one", fetchPill, { provider: "route:two", model: "same/model" });
+if (!requests.includes("/api/usage-stats/session-context?session=session%2Fone&provider=route%3Atwo&model=same%2Fmodel")) {
+	throw new Error("the formal model-selector route must be encoded as a session-context hint");
+}
+let noContextRequests = 0;
+const noContext = await loadSessionPillSnapshot("blank", async () => {
+	noContextRequests += 1;
+	return { ok: true, context: null };
+});
+if (noContext !== null || noContextRequests !== 1) throw new Error("a session without route context must silently omit the pill and skip account lookup");
+const unsupportedLoad = await loadSessionPillSnapshot("unknown", async (path) => path.includes("session-context")
+	? { ok: true, context: { ...pillContext, providerId: "relay-a", accountId: "relay-a" } }
+	: { ok: false, error: "unknown-provider" });
+if (unsupportedLoad.status !== "unsupported" || unsupportedLoad.account !== null) throw new Error("unknown account adapters must degrade to a neutral unsupported snapshot");
+
+const baseSession = { running: false, removed: false, nodes: [], chat: { order: [] }, partial: null };
+const baseSignal = sessionContextSignalOf(baseSession);
+if (sessionContextSignalOf({ ...baseSession }) !== baseSignal) throw new Error("unrelated session object replacement must not trigger a pill request");
+if (sessionContextSignalOf({ ...baseSession, running: true }) === baseSignal) throw new Error("turn start must trigger an event-driven pill refresh");
+if (sessionContextSignalOf({ ...baseSession, nodes: [{}] }) === baseSignal) throw new Error("new message must trigger an event-driven pill refresh");
+if (sessionContextSignalOf({ ...baseSession, partial: {} }) === baseSignal) throw new Error("assistant activity must trigger an event-driven pill refresh");
+if (modelSelectionSignalOf({ current: { provider: "a:b", model: "c" } }) === modelSelectionSignalOf({ current: { provider: "a", model: "b:c" } })) {
+	throw new Error("model selection refresh keys must not collide when route ids contain colons");
+}
+
+// Exercise the actual hook lifecycle. A host model-directory notification must
+// clear the old provider immediately, then replace the same button root after
+// the server-owned session-context/account chain settles.
+let lifecycleProvider = "deepseek-official";
+let resolveSwitchedContext;
+let holdSwitchedContext = false;
+const lifecycleRequests = [];
+const lifecycleRequest = async (path) => {
+	lifecycleRequests.push(path);
+	if (path.startsWith("/api/usage-stats/session-context")) {
+		if (holdSwitchedContext) return new Promise((resolve) => { resolveSwitchedContext = resolve; });
+		return { ok: true, context: { ...pillContext, providerId: lifecycleProvider, accountId: lifecycleProvider } };
+	}
+	return {
+		ok: true,
+		account: lifecycleProvider === "deepseek-official"
+			? balancePillSnapshot.account
+			: { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: "ok", windows: [{ kind: "weekly", remainingPercent: 18 }], alert: { level: "warning" } }
+	};
+};
+let pillRenderer;
+await act(async () => {
+	pillRenderer = TestRenderer.create(react.createElement(CurrentSessionPill, {
+		sessionId: "session-one",
+		session: baseSession,
+		modelDirectory,
+		request: lifecycleRequest,
+		t: (key) => key
+	}));
+	await Promise.resolve();
+	await Promise.resolve();
+});
+if (pillRenderer.root.findAllByProps({ "data-current-session-pill": true }).length !== 1) throw new Error("successful mount must create exactly one pill");
+if (pillRenderer.root.findByType("button").props["data-provider"] !== "deepseek-official") throw new Error("initial lifecycle provider missing");
+
+lifecycleProvider = "opencode-go";
+holdSwitchedContext = true;
+await act(async () => {
+	modelSnapshot = { current: { provider: "opencode-go", model: "same-model" } };
+	for (const subscriber of modelSubscribers) subscriber();
+	await Promise.resolve();
+});
+if (pillRenderer.toJSON() !== null) throw new Error("provider switch must not leave the previous session/account pill clickable while loading");
+holdSwitchedContext = false;
+await act(async () => {
+	resolveSwitchedContext({ ok: true, context: { ...pillContext, providerId: "opencode-go", accountId: "opencode-go" } });
+	await Promise.resolve();
+	await Promise.resolve();
+});
+const switchedButtons = pillRenderer.root.findAllByProps({ "data-current-session-pill": true });
+if (switchedButtons.length !== 1 || switchedButtons[0].props["data-provider"] !== "opencode-go") throw new Error("provider switch must update the existing single pill root");
+if (!lifecycleRequests.includes("/api/usage-stats/session-context?session=session-one&provider=opencode-go&model=same-model")) {
+	throw new Error("model-directory notifications must refresh session-context with the current route hint");
+}
+await act(async () => { pillRenderer.unmount(); });
+
+// Multiple panel roots are not expected, but one unmount must never erase a
+// still-mounted opener. This bus is the cross-slot bridge, not another cache.
+const openedBy = [];
+const stopFirstOpener = subscribeUsageStatsPanel((providerId) => openedBy.push(`first:${providerId}`));
+const stopSecondOpener = subscribeUsageStatsPanel((providerId) => openedBy.push(`second:${providerId}`));
+requestUsageStatsPanel("opencode-go");
+stopSecondOpener();
+requestUsageStatsPanel("deepseek-official");
+stopFirstOpener();
+if (openedBy.join(",") !== "second:opencode-go,first:deepseek-official") throw new Error(`panel opener lifecycle must target one newest mounted subscriber and then fall back: ${openedBy.join(",")}`);
+
+// Mount the real existing panel plus the pill and verify a click opens that
+// panel with the current provider selected. Network and timers are inert test
+// doubles; production still uses the panel's existing refresh/cache path.
+const originalFetch = globalThis.fetch;
+document.addEventListener = () => {};
+document.removeEventListener = () => {};
+window.setInterval = () => 1;
+window.clearInterval = () => {};
+globalThis.fetch = async (path) => ({
+	ok: true,
+	json: async () => {
+		if (String(path).includes("/providers")) return {
+			ok: true,
+			providers: [
+				{ id: "deepseek-official", displayName: "DeepSeek", configured: true, accountMode: "balance" },
+				{ id: "opencode-go", displayName: "OpenCode Go", configured: true, accountMode: "subscription" }
+			]
+		};
+		if (String(path).includes("/account")) return { ok: true, account: { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: "ok", windows: [{ kind: "weekly", remainingPercent: 18 }], alert: { level: "warning" } } };
+		return { ok: true, days: [], total: { tokens: 0 } };
+	}
+});
+let integrationRenderer;
+await act(async () => {
+	integrationRenderer = TestRenderer.create(react.createElement(react.Fragment, {},
+		react.createElement(UsageStatsPanel, { wide: true, t: (key) => key }),
+		react.createElement(CurrentSessionPillView, {
+			snapshot: { ...balancePillSnapshot, context: { ...pillContext, providerId: "opencode-go", accountId: "opencode-go" } },
+			translate: pillTranslate
+		})
+	));
+	await Promise.resolve();
+});
+await act(async () => {
+	integrationRenderer.root.findByProps({ "data-current-session-pill": true }).props.onClick();
+	await Promise.resolve();
+	await Promise.resolve();
+});
+if (integrationRenderer.root.findAllByProps({ "data-usage-stats-panel": true }).length !== 1) throw new Error("pill click must open the existing account panel");
+const selectedPicker = integrationRenderer.root.findByType("select");
+if (selectedPicker.props.value !== "opencode-go") throw new Error(`pill click must select its provider in the existing panel, got ${selectedPicker.props.value}`);
+await act(async () => { integrationRenderer.unmount(); });
+globalThis.fetch = originalFetch;
+
+console.log("current-session pill rendering, switching, hook lifecycle, and request policy ok");
 console.log("SMOKE TEST PASSED");

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -126,6 +126,38 @@ async function testSessionContext(root) {
 	});
 	assert.doesNotMatch(first.body, /SECRET|apiKey|baseURL/i, "session context must not expose connection or credential fields");
 
+	const selectorSwitched = makeResponse();
+	await handler({ method: "GET", url: `${plugin.SESSION_CONTEXT_PATH}?session=live-session&provider=route-b&model=shared-model`, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, selectorSwitched);
+	assert.deepEqual(JSON.parse(selectorSwitched.body).context, {
+		sessionId: "live-session",
+		providerId: "route-b",
+		providerFamily: "ollama",
+		model: "shared-model",
+		accountId: "route-b",
+		updatedAt: null
+	}, "an accepted selector route must override the last request/header immediately");
+	const invalidSelectionQueries = [
+		"provider=route-b",
+		"provider=route-b&model=",
+		`provider=${"p".repeat(257)}&model=m`,
+		`provider=p&model=${"m".repeat(513)}`,
+		"provider=route%00b&model=m",
+		"provider=route-b&model=m%00"
+	];
+	for (const query of invalidSelectionQueries) {
+		const invalidSelection = makeResponse();
+		await handler({ method: "GET", url: `${plugin.SESSION_CONTEXT_PATH}?session=live-session&${query}`, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, invalidSelection);
+		assert.equal(invalidSelection.status, 400, `invalid selector hint must fail closed: ${query.slice(0, 80)}`);
+		assert.equal(JSON.parse(invalidSelection.body).error, "invalid-selection");
+	}
+	const boundaryProvider = "p".repeat(256);
+	const boundaryModel = "m".repeat(512);
+	const boundarySelection = makeResponse();
+	await handler({ method: "GET", url: `${plugin.SESSION_CONTEXT_PATH}?session=live-session&provider=${boundaryProvider}&model=${boundaryModel}`, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, boundarySelection);
+	assert.equal(boundarySelection.status, 200, "bounded selector hint limits must be inclusive");
+	assert.equal(JSON.parse(boundarySelection.body).context.providerId, boundaryProvider);
+	assert.equal(JSON.parse(boundarySelection.body).context.model, boundaryModel);
+
 	events.push(routeEvent(1, "route-b", "shared-model"));
 	const switched = makeResponse();
 	await handler({ method: "GET", url: plugin.SESSION_CONTEXT_PATH, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, switched);


### PR DESCRIPTION
## Summary

Implements PR 2 of the v0.3.0 roadmap: a lightweight Current Session Pill beside the conversation model controls.

Closes #18.
Roadmap: #65.
Depends on the identity and session-context foundation delivered by #60 / #66.

## Data flow

- Reads the current session route from the official per-session model directory store.
- Calls `/api/usage-stats/session-context` with that route as an optional, validated hint so a selector change is reflected before the next request event.
- Uses the shared server-side provider identity resolver; the event-folded `currentRoute` remains the fallback and the client performs no provider inference.
- Calls `/api/usage-stats/account` only for the resolved account and reuses the existing account cache.

## UI behavior

- Balance accounts show the remaining amount or unlimited state.
- Subscription accounts show the tightest remaining quota window.
- Unsupported, unconfigured, unavailable, and other error states use neutral text.
- Visual tone is derived only from `account.alert.level`.
- Clicking the pill opens the existing Usage Stats panel and selects the matching provider.
- The formal `conversation.input.right` slot is used; missing slot/model services degrade silently without affecting the existing sidebar panel.
- Session and model/provider changes invalidate the old snapshot immediately and refresh through store-driven React state.

## Scope boundaries

This change adds no polling loop, DOM observer, provider mapping, provider request listener, token ledger, client cache, pricing, cost, budget, export, or package-version change.

## Verification

- `npm run check`
- `npm test`
- `npm pack --json`
- Package remains `@ychris12138/dsh-usage-stats@0.2.10`.
- Added component lifecycle, route switching, rendering, security, panel-opening, route-hint validation, and boundary regression coverage.
- Fresh isolated DSH rc7 boot: client bundle loaded, sidebar available, providers/session-context endpoints returned 200, and browser error log was empty.
- An earlier rc2 candidate completed end-to-end pill and panel checks. For the final integration, the latest rc2 package source was checked against the formal slot and model-directory contracts; a second clean rc2 dependency build was bounded after prolonged installation rather than reported as a fresh runtime pass.

This PR is intentionally left as Draft for maintainer review.
