### PR TITLE
feat: add account health and adaptive refresh

### DIFF
--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -22,6 +22,26 @@ export { isPrivateAddress } from "./network.js";
 
 const DEFAULT_TIMEOUT_MS = 15000;
 const DEFAULT_REFRESH_MS = 300000;
+const DEFAULT_REFRESH_POLICY = Object.freeze({
+	activeMs: 60000,
+	detailMs: 120000,
+	backgroundMs: 900000,
+	rateLimitBaseMs: 300000,
+	rateLimitMaxMs: 3600000
+});
+const PROVENANCE_KINDS = new Set(["official", "provider", "configured", "experimental", "unknown"]);
+const OFFICIAL_ADAPTERS = new Set([
+	"deepseek-balance",
+	"openrouter-balance",
+	"moonshot-balance",
+	"zai-balance",
+	"opencode-go",
+	"zai-token-plan",
+	"kimi-token-plan",
+	"minimax-token-plan",
+	"ollama"
+]);
+const PROVIDER_ADAPTERS = new Set(["new-api", "sub2api", "sub2api-auth"]);
 const MAX_RESPONSE_BYTES = 1024 * 1024;
 const OPENROUTER_MANAGEMENT_REF = "OPENROUTER_MANAGEMENT_KEY";
 /**
@@ -43,6 +63,23 @@ const ACCOUNT_STATUSES = new Set([
 	"blocked",
 	"unsupported"
 ]);
+const SAFE_REASON_CODES = new Set([
+	"dns-resolution-failed",
+	"timeout",
+	"rate-limited",
+	"unauthorized",
+	"upstream-invalid-json",
+	"upstream-not-json",
+	"upstream-too-large",
+	"upstream-invalid-response",
+	"blocked-network",
+	"all-addresses-unreachable",
+	"no-validated-address",
+	"sub2api-balance-shape-unrecognized",
+	"unknown"
+]);
+const HEALTH_ATTEMPTED = Symbol("account-health-attempted");
+const HEALTH_SUCCEEDED = Symbol("account-health-succeeded");
 const ADAPTERS = new Set([
 	"deepseek-balance",
 	"openrouter-balance",
@@ -97,6 +134,46 @@ function round1(value) {
 	return Math.round(value * 10) / 10;
 }
 
+/** Normalize how trustworthy an account endpoint binding is. */
+export function accountProvenance(spec) {
+	if (PROVENANCE_KINDS.has(spec?.provenanceHint)) return spec.provenanceHint;
+	const adapter = nonEmptyString(spec?.adapter);
+	if (adapter === null) return "unknown";
+	if (adapter === "declarative" || adapter === "general") return "configured";
+	if (OFFICIAL_ADAPTERS.has(adapter)) return "official";
+	if (PROVIDER_ADAPTERS.has(adapter)) return "provider";
+	return "unknown";
+}
+
+/** Derive health age from the last successful sample without mutating cache state. */
+export function withHealthAge(snapshot, now = Date.now()) {
+	if (snapshot === null || snapshot === void 0 || typeof snapshot !== "object") return snapshot;
+	const lastSuccessAt = typeof snapshot.lastSuccessAt === "number" && Number.isFinite(snapshot.lastSuccessAt)
+		? snapshot.lastSuccessAt
+		: null;
+	return {
+		...snapshot,
+		ageMs: lastSuccessAt === null ? null : Math.max(0, now - lastSuccessAt)
+	};
+}
+
+/** Pure central refresh policy; scheduling and I/O stay outside this function. */
+export function refreshPolicy(state, now = Date.now(), overrides = {}) {
+	const intervals = { ...DEFAULT_REFRESH_POLICY, ...overrides };
+	const activity = state?.activity === "active" || state?.activity === "detail" ? state.activity : "background";
+	const lastAttemptAt = typeof state?.lastAttemptAt === "number" && Number.isFinite(state.lastAttemptAt)
+		? state.lastAttemptAt
+		: null;
+	const priority = activity === "active" ? 3 : activity === "detail" ? 2 : 1;
+	if (lastAttemptAt === null) return { activity, priority, delayMs: 0, nextRefreshAt: now };
+	let delayMs = activity === "active" ? intervals.activeMs : activity === "detail" ? intervals.detailMs : intervals.backgroundMs;
+	if ((Number(state?.rateLimitFailures) || 0) > 0) {
+		const failures = Math.max(1, Math.floor(Number(state.rateLimitFailures) || 1));
+		delayMs = Math.min(intervals.rateLimitMaxMs, intervals.rateLimitBaseMs * 2 ** Math.min(20, failures - 1));
+	}
+	return { activity, priority, delayMs, nextRefreshAt: lastAttemptAt + delayMs };
+}
+
 function toIso(value) {
 	if (value === null || value === void 0 || value === "") return null;
 	if (typeof value === "number" && Number.isFinite(value)) {
@@ -123,7 +200,34 @@ function statusOf(error) {
 
 function safeReasonOf(error) {
 	const reason = nonEmptyString(error?.safeReason);
-	return reason === null ? null : reason.slice(0, 120);
+	if (reason !== null && SAFE_REASON_CODES.has(reason)) return reason;
+	const status = statusOf(error);
+	if (error?.name === "TimeoutError" || error?.name === "AbortError") return "timeout";
+	if (status === "rate-limited") return "rate-limited";
+	if (status === "unauthorized") return "unauthorized";
+	if (status === "blocked") return "blocked-network";
+	if (status === "invalid-response") return "upstream-invalid-response";
+	return status === "unavailable" ? "unknown" : null;
+}
+
+function providerReasonOf(reason, status) {
+	const value = nonEmptyString(reason);
+	if (value !== null && SAFE_REASON_CODES.has(value)) return value;
+	if (status === "rate-limited") return "rate-limited";
+	if (status === "unauthorized") return "unauthorized";
+	if (status === "blocked") return "blocked-network";
+	if (status === "invalid-response") return "upstream-invalid-response";
+	if (status === "unavailable") return "unknown";
+	return null;
+}
+
+/** Attach service-internal query facts without expanding the wire protocol. */
+function annotateQuerySnapshot(snapshot, { attempted, succeeded }) {
+	Object.defineProperties(snapshot, {
+		[HEALTH_ATTEMPTED]: { value: attempted === true },
+		[HEALTH_SUCCEEDED]: { value: succeeded === true }
+	});
+	return snapshot;
 }
 
 async function resolveCredential(credentials, ref) {
@@ -468,7 +572,7 @@ function pinnedRequest(url, address, init, deps, signal) {
 			let size = 0;
 			response.on("data", (chunk) => {
 				size += chunk.length;
-				if (size > (deps.maxResponseBytes ?? MAX_RESPONSE_BYTES)) request.destroy(statusError("invalid-response", "upstream response exceeds the size limit"));
+				if (size > (deps.maxResponseBytes ?? MAX_RESPONSE_BYTES)) request.destroy(statusError("invalid-response", "upstream response exceeds the size limit", void 0, "upstream-too-large"));
 				else chunks.push(chunk);
 			});
 			response.on("end", () => {
@@ -571,6 +675,7 @@ function baseSnapshot(spec, status, now) {
 		displayName: spec.displayName,
 		mode: spec.mode ?? "balance",
 		adapter: spec.adapter,
+		provenance: accountProvenance(spec),
 		status,
 		fetchedAt: now
 	};
@@ -864,7 +969,8 @@ function sub2apiAuthSpec(spec) {
 	return {
 		...spec,
 		adapter: "sub2api-auth",
-		mode: "balance"
+		mode: "balance",
+		provenanceHint: "experimental"
 	};
 }
 
@@ -942,7 +1048,7 @@ async function querySub2ApiAuth(spec, credentials, deps, now) {
 		// unrecognized shape. Never include upstream-controlled content (JSON
 		// property names, values, messages) in safeReason — a hostile upstream
 		// could otherwise echo sensitive material across the server→browser
-		// boundary, since safeReasonOf() only truncates.
+		// boundary. safeReasonOf() accepts only the fixed vocabulary above.
 		if (balanceBody !== null && typeof balanceBody === "object") {
 			error.safeReason = "sub2api-balance-shape-unrecognized";
 		}
@@ -1006,9 +1112,28 @@ async function queryDeclarative(spec, credentials, deps, now) {
 /** Query one adapter and return a secret-free normalized account snapshot. */
 export async function queryAccount(spec, credentials, deps = {}) {
 	const now = (deps.now ?? Date.now)();
-	if (spec === null || spec === void 0) return unavailableSnapshot({ id: "unknown", displayName: "Unknown", adapter: null, mode: "balance" }, "unsupported", now);
+	if (spec === null || spec === void 0) {
+		return annotateQuerySnapshot(
+			unavailableSnapshot({ id: "unknown", displayName: "Unknown", adapter: null, mode: "balance" }, "unsupported", now),
+			{ attempted: false, succeeded: false }
+		);
+	}
+	let attempted = false;
+	const upstreamFetch = deps.fetch === void 0
+		? (url, init) => pinnedFetch(url, init, spec, deps)
+		: deps.fetch;
+	const safeDeps = {
+		...deps,
+		fetch: (url, init) => {
+			attempted = true;
+			return upstreamFetch(url, init);
+		}
+	};
+	const finish = (snapshot, succeeded = snapshot.status === "ok") => annotateQuerySnapshot(snapshot, {
+		attempted: attempted || succeeded,
+		succeeded
+	});
 	try {
-		const safeDeps = deps.fetch === void 0 ? { ...deps, fetch: (url, init) => pinnedFetch(url, init, spec, deps) } : deps;
 		// A relay provider with no built-in/explicit adapter may be a real
 		// Sub2API panel. Only when it also has a model-configured API key do we
 		// probe its public settings endpoint; a matching fingerprint selects the
@@ -1016,21 +1141,21 @@ export async function queryAccount(spec, credentials, deps = {}) {
 		// adapters always win, and unkeyed relays are never probed.
 		if (spec.adapter === null || spec.mode === null) {
 			const providerKey = await resolveCredential(credentials, spec.apiKeyRef);
-			if (providerKey === "") return unavailableSnapshot(spec, "unsupported", now);
+			if (providerKey === "") return finish(unavailableSnapshot(spec, "unsupported", now), false);
 			const probeable = { ...spec, adapter: null, mode: "balance" };
 			if (await probeSub2ApiPanel(probeable, safeDeps)) {
-				return await querySub2ApiAuth(sub2apiAuthSpec(probeable), credentials, safeDeps, now);
+				return finish(await querySub2ApiAuth(sub2apiAuthSpec(probeable), credentials, safeDeps, now));
 			}
-			return unavailableSnapshot(spec, "unsupported", now);
+			return finish(unavailableSnapshot(spec, "unsupported", now), false);
 		}
-		if (spec.adapter === "declarative") return await queryDeclarative(spec, credentials, safeDeps, now);
-		if (spec.adapter === "sub2api-auth") return await querySub2ApiAuth(spec, credentials, safeDeps, now);
+		if (spec.adapter === "declarative") return finish(await queryDeclarative(spec, credentials, safeDeps, now));
+		if (spec.adapter === "sub2api-auth") return finish(await querySub2ApiAuth(spec, credentials, safeDeps, now));
 		const credential = await resolveCredential(credentials, spec.apiKeyRef);
-		if (spec.adapter !== "opencode-go" && credential === "") return unavailableSnapshot(spec, "not-configured", now, { missingCredentials: spec.apiKeyRef === void 0 ? [] : [spec.apiKeyRef] });
-		if (schemeOfAdapter(spec.adapter) !== null) return await queryBuiltInBalance(spec, credential, safeDeps, now);
-		if (spec.adapter === "general") return await queryGeneral(spec, credential, safeDeps, now);
-		if (spec.adapter === "new-api") return await queryNewApi(spec, credentials, credential, safeDeps, now);
-		if (spec.adapter === "sub2api") return await querySub2Api(spec, credential, safeDeps, now);
+		if (spec.adapter !== "opencode-go" && credential === "") return finish(unavailableSnapshot(spec, "not-configured", now, { missingCredentials: spec.apiKeyRef === void 0 ? [] : [spec.apiKeyRef] }), false);
+		if (schemeOfAdapter(spec.adapter) !== null) return finish(await queryBuiltInBalance(spec, credential, safeDeps, now), true);
+		if (spec.adapter === "general") return finish(await queryGeneral(spec, credential, safeDeps, now));
+		if (spec.adapter === "new-api") return finish(await queryNewApi(spec, credentials, credential, safeDeps, now));
+		if (spec.adapter === "sub2api") return finish(await querySub2Api(spec, credential, safeDeps, now));
 		const subscriptionId = spec.adapter === "zai-token-plan" ? "zai"
 			: spec.adapter === "kimi-token-plan" ? "kimi"
 				: spec.adapter === "minimax-token-plan" ? "minimax"
@@ -1044,10 +1169,11 @@ export async function queryAccount(spec, credentials, deps = {}) {
 			baseURL: spec.monitor.usageBaseURL
 		}, safeDeps);
 		const windows = Array.isArray(provider.windows) ? provider.windows : [];
-		return { ...baseSnapshot(spec, provider.status, now), plan: provider.plan, windows, alert: subscriptionAlert(windows), ...(provider.missingCredentials === void 0 ? {} : { missingCredentials: provider.missingCredentials }), ...(provider.reason === void 0 ? {} : { reason: provider.reason }) };
+		const reason = providerReasonOf(provider.reason, provider.status);
+		return finish({ ...baseSnapshot(spec, provider.status, now), plan: provider.plan, windows, alert: subscriptionAlert(windows), ...(provider.missingCredentials === void 0 ? {} : { missingCredentials: provider.missingCredentials }), ...(reason === null ? {} : { reason }) });
 	} catch (error) {
 		const reason = safeReasonOf(error);
-		return unavailableSnapshot(spec, statusOf(error), now, reason === null ? {} : { reason });
+		return finish(unavailableSnapshot(spec, statusOf(error), now, reason === null ? {} : { reason }), false);
 	}
 }
 
@@ -1055,29 +1181,60 @@ function isTransient(status) {
 	return status === "unavailable" || status === "rate-limited" || status === "invalid-response";
 }
 
-function withStaleData(previous, current) {
-	if (previous?.status !== "ok" || !isTransient(current.status)) return current;
-	return {
+function mergeRefreshHealth(previous, current) {
+	const lastSuccessAt = previous?.lastSuccessAt
+		?? (previous?.status === "ok" ? previous.fetchedAt : null);
+	const attempted = current[HEALTH_ATTEMPTED] === true;
+	const successful = current[HEALTH_SUCCEEDED] === true || current.status === "ok";
+	const attemptAt = attempted ? current.fetchedAt : previous?.lastAttemptAt ?? null;
+	const currentWithHealth = {
+		...current,
+		lastAttemptAt: attemptAt,
+		lastSuccessAt: successful ? attemptAt : lastSuccessAt,
+		stale: false
+	};
+	delete currentWithHealth.ageMs;
+	const canRetain = !successful
+		&& lastSuccessAt !== null
+		&& (previous?.status === "ok" || previous?.stale === true)
+		&& isTransient(current.status);
+	if (!canRetain) return currentWithHealth;
+	const stale = {
 		...previous,
 		status: current.status,
-		fetchedAt: current.fetchedAt,
-		lastSuccessAt: previous.lastSuccessAt ?? previous.fetchedAt,
+		fetchedAt: attemptAt,
+		lastAttemptAt: attemptAt,
+		lastSuccessAt,
+		provenance: current.provenance ?? previous.provenance ?? "unknown",
 		stale: true
 	};
+	delete stale.ageMs;
+	if (current.reason === void 0) delete stale.reason;
+	else stale.reason = current.reason;
+	return stale;
 }
 
 /**
- * In-memory account cache with per-provider single-flight and forced bulk
- * refresh. Background scheduling is owned by the server plugin so it can also
- * refresh local token-usage aggregation in the same five-minute cycle.
+ * In-memory account cache with per-provider single-flight, health history, and
+ * adaptive due-time calculation. One server-owned scheduler coordinates it
+ * with the existing local token-usage aggregation lifecycle.
  */
 export function createAccountService({ credentials, getProviders, config = { monitors: {} }, deps = {} }) {
 	const cache = new Map();
 	const inflight = new Map();
-	const refreshMs = deps.refreshMs ?? DEFAULT_REFRESH_MS;
+	const refreshGenerations = new Map();
+	const now = deps.now ?? Date.now;
+	const policyOverrides = {
+		...(deps.refreshMs === void 0 ? {} : { backgroundMs: deps.refreshMs }),
+		...(deps.refreshPolicy ?? {})
+	};
+	const activeProviders = new Set();
+	const activityTouches = new Map();
+	const policyListeners = new Set();
+	const activityTtlMs = deps.activityTtlMs ?? 600000;
 	// Long-lived Sub2API panel-detection cache, keyed by the provider's config
 	// key. It lives on the service so auto-detection probes once per
-	// (provider × config) even across five-minute background refreshes; a caller
+	// (provider × config) even across background refreshes; a caller
 	// may still inject its own Map (e.g. tests) by passing deps.sub2apiDetection.
 	const sub2apiDetection = deps.sub2apiDetection ?? new Map();
 	const serviceDeps = { ...deps, sub2apiDetection };
@@ -1116,44 +1273,136 @@ export function createAccountService({ credentials, getProviders, config = { mon
 		return (await specs()).find((spec) => spec.id === providerId) ?? null;
 	}
 
-	async function refresh(spec) {
-		const existing = inflight.get(spec.id);
-		if (existing !== void 0) return existing;
-		const promise = queryAccount(spec, credentials, serviceDeps).then((current) => {
-			const next = withStaleData(cache.get(spec.id)?.account, current);
-			cache.set(spec.id, { configKey: spec.configKey, account: next });
-			return next;
-		}).finally(() => inflight.delete(spec.id));
-		inflight.set(spec.id, promise);
-		return promise;
+	function notifyPolicyChange() {
+		for (const listener of policyListeners) listener();
 	}
 
-	async function get(providerId, { force = false } = {}) {
+	function subscribePolicyChanges(listener) {
+		if (typeof listener !== "function") return () => {};
+		policyListeners.add(listener);
+		return () => policyListeners.delete(listener);
+	}
+
+	function touch(providerId, activity) {
+		if (typeof providerId !== "string" || providerId === "") return;
+		if (activity !== "active" && activity !== "detail") return;
+		const at = now();
+		const before = activityOf(providerId, at);
+		const previous = activityTouches.get(providerId) ?? {};
+		activityTouches.set(providerId, { ...previous, [`${activity}At`]: at });
+		if (activityOf(providerId, at) !== before) notifyPolicyChange();
+	}
+
+	function setActiveProviders(providerIds) {
+		const next = new Set([...(providerIds ?? [])].filter((providerId) => typeof providerId === "string" && providerId !== ""));
+		const changed = next.size !== activeProviders.size || [...next].some((providerId) => !activeProviders.has(providerId));
+		activeProviders.clear();
+		for (const providerId of next) activeProviders.add(providerId);
+		if (changed) notifyPolicyChange();
+	}
+
+	function activityOf(providerId, at) {
+		const touched = activityTouches.get(providerId);
+		if (activeProviders.has(providerId) || at - (touched?.activeAt ?? -Infinity) < activityTtlMs) return "active";
+		if (at - (touched?.detailAt ?? -Infinity) < activityTtlMs) return "detail";
+		return "background";
+	}
+
+	function policyOf(spec, at) {
+		const hit = cache.get(spec.id);
+		if (hit?.configKey !== spec.configKey) return refreshPolicy({ activity: activityOf(spec.id, at), status: "pending", lastAttemptAt: null }, at, policyOverrides);
+		return refreshPolicy({
+			activity: activityOf(spec.id, at),
+			status: hit.account.status,
+			rateLimitFailures: hit.rateLimitFailures ?? 0,
+			// Scheduling must advance even when a local credential/config check
+			// correctly produces no provider attempt (and lastAttemptAt stays null).
+			lastAttemptAt: hit.lastEvaluatedAt ?? hit.account.lastAttemptAt ?? hit.account.fetchedAt ?? null
+		}, at, policyOverrides);
+	}
+
+	async function refresh(spec) {
+		const existing = inflight.get(spec.id);
+		if (existing?.configKey === spec.configKey) return existing.promise;
+		const generation = (refreshGenerations.get(spec.id) ?? 0) + 1;
+		refreshGenerations.set(spec.id, generation);
+		const promise = queryAccount(spec, credentials, serviceDeps).then((current) => {
+			const previous = cache.get(spec.id);
+			const sameConfig = previous?.configKey === spec.configKey;
+			const previousAccount = sameConfig ? previous.account : null;
+			const previousRateLimitFailures = sameConfig ? previous.rateLimitFailures ?? 0 : 0;
+			const next = mergeRefreshHealth(previousAccount, current);
+			const successful = current[HEALTH_SUCCEEDED] === true || current.status === "ok";
+			const rateLimitFailures = current.status === "rate-limited"
+				? previousRateLimitFailures + 1
+				: successful ? 0 : previousRateLimitFailures;
+			// A late completion from a replaced binding may resolve its own caller,
+			// but must never overwrite the newer binding's cache state.
+			if (refreshGenerations.get(spec.id) === generation) {
+				cache.set(spec.id, {
+					configKey: spec.configKey,
+					account: next,
+					rateLimitFailures,
+					lastEvaluatedAt: current.fetchedAt
+				});
+			}
+			return withHealthAge(next, now());
+		});
+		let entry;
+		const tracked = promise.finally(() => {
+			if (inflight.get(spec.id) === entry) inflight.delete(spec.id);
+		});
+		entry = { configKey: spec.configKey, promise: tracked };
+		inflight.set(spec.id, entry);
+		return tracked;
+	}
+
+	async function get(providerId, { force = false, activity = null } = {}) {
 		const spec = await specById(providerId);
 		if (spec === null) return null;
+		if (activity !== null) touch(providerId, activity);
 		const hit = cache.get(providerId);
-		const age = (deps.now ?? Date.now)() - (hit?.account?.fetchedAt ?? 0);
-		if (!force && hit?.configKey === spec.configKey && age >= 0 && age < refreshMs) return hit.account;
+		const at = now();
+		if (!force && hit?.configKey === spec.configKey && policyOf(spec, at).nextRefreshAt > at) return withHealthAge(hit.account, at);
 		return refresh(spec);
 	}
 
-	async function refreshAll() {
+	async function refreshableSpecs() {
 		const all = await specs();
-		// Auto-detection only probes null-adapter relays that have a configured
-		// API key, so the background refresh stays bounded and never touches
-		// unrelated, unkeyed providers.
 		const keyed = await Promise.all(all.map(async (spec) => ({
 			spec,
 			probe: spec.adapter === null
 				? (await resolveCredential(credentials, spec.apiKeyRef)) !== ""
 				: true
 		})));
-		return Promise.all(keyed.filter((entry) => entry.probe).map((entry) => refresh(entry.spec)));
+		return keyed.filter((entry) => entry.probe).map((entry) => entry.spec);
+	}
+
+	async function refreshAll() {
+		// Auto-detection only probes null-adapter relays that have a configured
+		// API key, so the background refresh stays bounded and never touches
+		// unrelated, unkeyed providers.
+		return Promise.all((await refreshableSpecs()).map((spec) => refresh(spec)));
+	}
+
+	async function refreshDue({ force = false } = {}) {
+		const at = now();
+		const all = await refreshableSpecs();
+		const due = force ? all : all.filter((spec) => policyOf(spec, at).nextRefreshAt <= at);
+		return Promise.all(due.map((spec) => refresh(spec)));
+	}
+
+	async function nextRefreshAt() {
+		const at = now();
+		const all = await refreshableSpecs();
+		if (all.length === 0) return null;
+		return Math.min(...all.map((spec) => policyOf(spec, at).nextRefreshAt));
 	}
 
 	async function providerViews() {
 		return Promise.all((await specs()).map(async (spec) => {
-			const account = cache.get(spec.id)?.account;
+			const hit = cache.get(spec.id);
+			const account = withHealthAge(hit?.configKey === spec.configKey ? hit.account : void 0, now());
 			const credentialConfigured = account === void 0 && spec.apiKeyRef !== void 0
 				? await resolveCredential(credentials, spec.apiKeyRef) !== ""
 				: false;
@@ -1165,6 +1414,12 @@ export function createAccountService({ credentials, getProviders, config = { mon
 				configured: account === void 0 ? credentialConfigured : account.status !== "not-configured",
 				status: account?.status ?? "pending",
 				fetchedAt: account?.fetchedAt ?? null,
+				stale: account?.stale ?? false,
+				lastAttemptAt: account?.lastAttemptAt ?? null,
+				lastSuccessAt: account?.lastSuccessAt ?? null,
+				ageMs: account?.ageMs ?? null,
+				provenance: account?.provenance ?? accountProvenance(spec),
+				reason: account?.reason ?? null,
 				alert: account?.alert ?? null
 			};
 		}));
@@ -1179,10 +1434,15 @@ export function createAccountService({ credentials, getProviders, config = { mon
 	return {
 		get,
 		refreshAll,
+		refreshDue,
+		nextRefreshAt,
+		touch,
+		setActiveProviders,
+		subscribePolicyChanges,
 		providerViews,
 		subscriptionAccounts,
 		validate: async () => { await specs(); },
-		cached: (providerId) => cache.get(providerId)?.account ?? null
+		cached: (providerId) => withHealthAge(cache.get(providerId)?.account ?? null, now())
 	};
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -82,6 +82,9 @@ window.__ModuleLoader__.load({
 			".usg_accountPlan{color:var(--dsw-alias-label-tertiary);text-overflow:ellipsis;white-space:nowrap;font-size:10px;line-height:14px;overflow:hidden}",
 			".usg_accountStatus{color:var(--dsw-alias-label-tertiary);background:var(--dsw-alias-fill-l2);border-radius:999px;padding:2px 7px;font-size:10px;line-height:16px;white-space:nowrap}",
 			".usg_accountStatus[data-status=ok]{color:var(--usg-providerAccent);background:color-mix(in srgb,var(--usg-providerAccent) 12%,transparent)}",
+			".usg_accountHealth{border-top:1px solid var(--dsw-alias-border-l1);grid-template-columns:auto minmax(0,1fr);gap:3px 10px;margin:2px 0 0;padding-top:7px;display:grid}",
+			".usg_accountHealth dt{color:var(--dsw-alias-label-caption);font-size:10px;line-height:15px}",
+			".usg_accountHealth dd{color:var(--dsw-alias-label-secondary);min-width:0;margin:0;font-size:10px;line-height:15px;text-align:right;overflow-wrap:anywhere}",
 			".usg_quotaList{flex-direction:column;gap:8px;display:flex}",
 			".usg_quotaRow{display:flex;flex-direction:column;gap:4px}",
 			".usg_quotaMeta{align-items:baseline;gap:8px;display:flex}",
@@ -191,6 +194,7 @@ window.__ModuleLoader__.load({
 			accountName: "usg_accountName",
 			accountPlan: "usg_accountPlan",
 			accountStatus: "usg_accountStatus",
+			accountHealth: "usg_accountHealth",
 			quotaList: "usg_quotaList",
 			quotaRow: "usg_quotaRow",
 			quotaMeta: "usg_quotaMeta",
@@ -380,13 +384,25 @@ window.__ModuleLoader__.load({
 			return !inside(layer) && !inside(panel);
 		}
 
+		const SAFE_DIAGNOSTIC_REASONS = new Set([
+			"dns-resolution-failed",
+			"timeout",
+			"rate-limited",
+			"unauthorized",
+			"upstream-invalid-json",
+			"upstream-not-json",
+			"upstream-too-large",
+			"upstream-invalid-response",
+			"blocked-network",
+			"all-addresses-unreachable",
+			"no-validated-address",
+			"sub2api-balance-shape-unrecognized",
+			"unknown"
+		]);
+
 		/** Defense-in-depth filter for server-provided, secret-free diagnostic reasons. */
 		function safeDiagnosticReason(reason) {
-			if (typeof reason !== "string") return null;
-			const value = reason.trim();
-			if (value === "" || value.length > 160) return null;
-			if (/(authorization|bearer\s|api[_-]?key|cookie|token\s*[=:]|sk-[a-z0-9])/i.test(value)) return null;
-			return value;
+			return typeof reason === "string" && SAFE_DIAGNOSTIC_REASONS.has(reason) ? reason : null;
 		}
 
 		function diagnosticReasonText(reason, translate) {
@@ -396,8 +412,15 @@ window.__ModuleLoader__.load({
 			if (value === "all-addresses-unreachable") return translate("account.reason.allAddressesUnreachable");
 			if (value === "upstream-not-json") return translate("account.reason.upstreamNotJson");
 			if (value === "upstream-invalid-json") return translate("account.reason.upstreamInvalidJson");
+			if (value === "upstream-too-large") return translate("account.reason.upstreamTooLarge");
+			if (value === "upstream-invalid-response") return translate("account.reason.upstreamInvalidResponse");
+			if (value === "timeout") return translate("account.reason.timeout");
+			if (value === "rate-limited") return translate("account.reason.rateLimited");
+			if (value === "unauthorized") return translate("account.reason.unauthorized");
+			if (value === "blocked-network") return translate("account.reason.blockedNetwork");
+			if (value === "no-validated-address") return translate("account.reason.noValidatedAddress");
 			if (value === "sub2api-balance-shape-unrecognized") return translate("account.reason.sub2apiBalanceShapeUnrecognized");
-			return value;
+			return translate("account.reason.unknown");
 		}
 
 		/**
@@ -464,7 +487,7 @@ window.__ModuleLoader__.load({
 				: typeof context.providerId === "string" && context.providerId !== "" ? context.providerId : null;
 			if (accountId === null) return null;
 			try {
-				const accountPayload = await request(`/api/usage-stats/account?provider=${encodeURIComponent(accountId)}`);
+				const accountPayload = await request(`/api/usage-stats/account?provider=${encodeURIComponent(accountId)}&activity=active`);
 				if (accountPayload?.ok === true && accountPayload.account !== null && typeof accountPayload.account === "object") {
 					return { context, account: accountPayload.account };
 				}
@@ -483,7 +506,7 @@ window.__ModuleLoader__.load({
 		}
 
 		/** Reduce a server snapshot to display-only fields; never retain secrets. */
-		function sessionPillViewOf(snapshot, translate) {
+		function sessionPillViewOf(snapshot, translate, now = Date.now()) {
 			if (snapshot === null || snapshot === void 0 || snapshot.context === null || typeof snapshot.context !== "object") return null;
 			const account = snapshot.account !== null && typeof snapshot.account === "object" ? snapshot.account : null;
 			const providerId = typeof snapshot.context.accountId === "string" && snapshot.context.accountId !== ""
@@ -518,7 +541,7 @@ window.__ModuleLoader__.load({
 				const tightest = windows.reduce((current, entry) => current === null || entry.remainingPercent < current.remainingPercent ? entry : current, null);
 				if (tightest !== null) {
 					value = `${quotaLabel(tightest.kind, translate)} · ${percentLabel(tightest.remainingPercent)}`;
-					auxiliaryLabel = resetLabel(tightest.resetsAt, translate);
+					auxiliaryLabel = resetLabel(tightest.resetsAt, translate, now);
 				}
 			} else if (account?.balance?.unlimited === true) {
 				value = "∞";
@@ -564,8 +587,8 @@ window.__ModuleLoader__.load({
 		}
 
 		/** Pure compact pill view, separated for render/click regression tests. */
-		function CurrentSessionPillView({ snapshot, translate, onOpen = requestUsageStatsPanel }) {
-			const view = sessionPillViewOf(snapshot, translate);
+		function CurrentSessionPillView({ snapshot, translate, onOpen = requestUsageStatsPanel, now = Date.now() }) {
+			const view = sessionPillViewOf(snapshot, translate, now);
 			if (view === null) return null;
 			return react_jsx_runtime.jsxs("button", {
 				type: "button",
@@ -752,7 +775,7 @@ window.__ModuleLoader__.load({
 				}).catch(() => { setProvidersLoaded(true); });
 			}, []);
 
-			const loadAccount = react.useCallback((providerId, force = false) => {
+			const loadAccount = react.useCallback((providerId, force = false, activity = null) => {
 				const seq = accountLoaderRef.current.start();
 				setAccountLoading(true);
 				setAccountError(null);
@@ -762,7 +785,8 @@ window.__ModuleLoader__.load({
 					setAccountError("no providers");
 					return;
 				}
-				const query = `?provider=${encodeURIComponent(target)}${force ? "&refresh=1" : ""}`;
+				const activityQuery = activity === "detail" ? "&activity=detail" : "";
+				const query = `?provider=${encodeURIComponent(target)}${force ? "&refresh=1" : ""}${activityQuery}`;
 				fetchJson(`/api/usage-stats/account${query}`).then((payload) => {
 					if (!mountedRef.current || !accountLoaderRef.current.isCurrent(seq)) return;
 					if (payload.ok !== true) {
@@ -855,18 +879,18 @@ window.__ModuleLoader__.load({
 			}, [open, loadUsage, loadProviders]);
 
 			// Fetch the selected account for BOTH the panel and the collapsed
-			// sidebar badge. The server refreshes all providers in the background
-			// (five-minute cache); the client re-reads that cache every five
-			// minutes (no refresh=1 — the upstream fetch stays server-owned) so
-			// the badge/panel never stays on a stale balance or quota value.
+			// sidebar badge. The server owns the adaptive upstream schedule; this
+			// pre-existing shared panel path only re-reads that cache every five
+			// minutes (no refresh=1), and marks an open detail view as active.
 			react.useEffect(() => {
 				if (selectedProvider === null) return;
-				loadAccount(selectedProvider);
-				const cacheTimer = window.setInterval(() => loadAccount(selectedProvider), 300000);
+				const activity = open ? "detail" : null;
+				loadAccount(selectedProvider, false, activity);
+				const cacheTimer = window.setInterval(() => loadAccount(selectedProvider, false, activity), 300000);
 				return () => {
 					window.clearInterval(cacheTimer);
 				};
-			}, [selectedProvider, loadAccount]);
+			}, [selectedProvider, loadAccount, open]);
 
 			const dayMap = react.useMemo(() => {
 				const map = new Map();
@@ -944,7 +968,7 @@ window.__ModuleLoader__.load({
 			const retry = () => {
 				loadUsage();
 				loadProviders();
-				if (selectedProvider !== null) loadAccount(selectedProvider, true);
+				if (selectedProvider !== null) loadAccount(selectedProvider, true, open ? "detail" : null);
 			};
 
 			const updatedLabel = refreshedAt === null ? "" : translate("panel.updatedAt", {
@@ -1033,7 +1057,7 @@ window.__ModuleLoader__.load({
 												accountLoading,
 												accountError,
 												translate,
-												onRetry: () => loadAccount(selectedProvider, true)
+												onRetry: () => loadAccount(selectedProvider, true, "detail")
 												}, selectedProviderInfo.id)
 											}),
 											react_jsx_runtime.jsx("section", {
@@ -1278,12 +1302,69 @@ window.__ModuleLoader__.load({
 			return kind;
 		}
 
-		function resetLabel(resetsAt, translate) {
+		function durationLabel(totalMinutes, translate) {
+			if (totalMinutes >= 1440) {
+				const days = Math.floor(totalMinutes / 1440);
+				const hours = Math.floor(totalMinutes % 1440 / 60);
+				return translate("duration.daysHours", { days, hours });
+			}
+			if (totalMinutes >= 60) {
+				const hours = Math.floor(totalMinutes / 60);
+				const minutes = totalMinutes % 60;
+				return translate("duration.hoursMinutes", { hours, minutes });
+			}
+			return translate("duration.minutes", { minutes: totalMinutes });
+		}
+
+		function formatResetCountdown(resetsAt, now, translate) {
 			if (typeof resetsAt !== "string") return "";
 			const date = new Date(resetsAt);
 			if (Number.isNaN(date.getTime())) return "";
-			return translate("subscription.resets", {
-				time: date.toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+			const diffMs = date.getTime() - now;
+			if (diffMs <= 0) return translate("subscription.resetDue");
+			const totalMinutes = Math.max(1, Math.ceil(diffMs / 60000));
+			return translate("subscription.resets", { time: durationLabel(totalMinutes, translate) });
+		}
+
+		function resetLabel(resetsAt, translate, now = Date.now()) {
+			return formatResetCountdown(resetsAt, now, translate);
+		}
+
+		function provenanceLabel(provenance, translate) {
+			if (provenance === "official") return translate("account.provenance.official");
+			if (provenance === "provider") return translate("account.provenance.provider");
+			if (provenance === "configured") return translate("account.provenance.configured");
+			if (provenance === "experimental") return translate("account.provenance.experimental");
+			return translate("account.provenance.unknown");
+		}
+
+		function healthTimeLabel(value) {
+			if (typeof value !== "number" || !Number.isFinite(value)) return "";
+			const date = new Date(value);
+			return Number.isNaN(date.getTime()) ? "" : date.toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+		}
+
+		function healthAgeLabel(value, translate) {
+			if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return "";
+			return durationLabel(Math.floor(value / 60000), translate);
+		}
+
+		function AccountHealth({ account, translate }) {
+			if (account === null || account === void 0 || typeof account !== "object") return null;
+			const rows = [];
+			const attempted = healthTimeLabel(account.lastAttemptAt);
+			const succeeded = healthTimeLabel(account.lastSuccessAt);
+			const age = healthAgeLabel(account.ageMs, translate);
+			if (attempted !== "") rows.push(["account.health.lastAttempt", attempted]);
+			if (succeeded !== "") rows.push(["account.health.lastSuccess", succeeded]);
+			if (age !== "") rows.push(["account.health.age", age]);
+			rows.push(["account.health.provenance", provenanceLabel(account.provenance, translate)]);
+			return react_jsx_runtime.jsx("dl", {
+				className: S.accountHealth,
+				children: rows.flatMap(([label, value]) => [
+					react_jsx_runtime.jsx("dt", { children: translate(label) }, `${label}-term`),
+					react_jsx_runtime.jsx("dd", { children: value }, `${label}-value`)
+				])
 			});
 		}
 
@@ -1337,7 +1418,8 @@ window.__ModuleLoader__.load({
 			const mode = account?.mode ?? provider.accountMode ?? "balance";
 			const subscriptionMode = mode === "subscription";
 			const status = accountLoading && account === null ? "loading" : account?.status ?? "unavailable";
-			const statusText = status === "loading" ? translate("account.status.loading")
+			const statusText = account?.stale === true ? translate("account.status.stale")
+				: status === "loading" ? translate("account.status.loading")
 				: status === "blocked" ? translate("account.status.blocked")
 					: status === "unsupported" ? translate("account.status.unsupported")
 						: subscriptionStatusLabel(status, translate);
@@ -1355,6 +1437,7 @@ window.__ModuleLoader__.load({
 				"data-provider": provider.id,
 				"data-adapter": provider.adapter ?? provider.accountMode ?? "",
 				"data-account-mode": mode,
+				"data-account-stale": account?.stale === true,
 				children: [
 					react_jsx_runtime.jsxs("div", {
 						className: S.accountHead,
@@ -1381,7 +1464,8 @@ window.__ModuleLoader__.load({
 							? react_jsx_runtime.jsx("p", { className: S.quotaEmpty, children: translate("subscription.loading") })
 							: react_jsx_runtime.jsx(SubscriptionContent, { provider: account ?? { status: "unavailable", windows: [] }, translate })
 						: react_jsx_runtime.jsx(BalanceContent, { balance: account?.balance ?? null, state: balanceState, message: balanceMessage, translate, onRetry }),
-					reasonText !== null && status !== "ok" ? react_jsx_runtime.jsx("p", { className: S.note, children: reasonText }) : null
+				react_jsx_runtime.jsx(AccountHealth, { account, translate }),
+				reasonText !== null && status !== "ok" ? react_jsx_runtime.jsx("p", { className: S.note, children: reasonText }) : null
 				]
 			});
 		}
@@ -1547,6 +1631,7 @@ window.__ModuleLoader__.load({
 			"account.balanceMode": "API 余额",
 			"account.loading": "正在加载供应商…",
 			"account.status.loading": "查询中",
+			"account.status.stale": "数据已过期",
 			"account.status.blocked": "已阻止",
 			"account.status.unsupported": "不支持余额",
 			"account.status.invalidResponse": "响应异常",
@@ -1557,6 +1642,23 @@ window.__ModuleLoader__.load({
 			"account.reason.upstreamNotJson": "上游返回的不是 JSON",
 			"account.reason.upstreamInvalidJson": "上游返回了无法解析的 JSON",
 			"account.reason.sub2apiBalanceShapeUnrecognized": "Sub2API 余额接口返回了未识别的数据结构。",
+			"account.reason.timeout": "账户请求超时。",
+			"account.reason.rateLimited": "供应商限制了账户查询频率。",
+			"account.reason.unauthorized": "账户凭据未通过验证。",
+			"account.reason.upstreamTooLarge": "上游响应超过安全大小限制。",
+			"account.reason.upstreamInvalidResponse": "上游返回了无法识别的响应。",
+			"account.reason.blockedNetwork": "账户请求被本地网络安全策略阻止。",
+			"account.reason.noValidatedAddress": "没有可安全连接的供应商地址。",
+			"account.reason.unknown": "账户查询失败，未提供可安全展示的诊断信息。",
+			"account.health.lastAttempt": "上次尝试",
+			"account.health.lastSuccess": "上次成功",
+			"account.health.age": "数据年龄",
+			"account.health.provenance": "数据来源",
+			"account.provenance.official": "官方接口",
+			"account.provenance.provider": "供应商接口",
+			"account.provenance.configured": "自定义配置",
+			"account.provenance.experimental": "实验性探测",
+			"account.provenance.unknown": "未知",
 			"account.blocked": "账户查询被本地安全策略阻止，请检查 HTTPS、同源和私网访问设置。",
 			"balance.title": "账户余额",
 			"balance.provider": "供应商",
@@ -1587,7 +1689,11 @@ window.__ModuleLoader__.load({
 			"subscription.window.quota": "总额度",
 			"subscription.window.mcp": "MCP 月度额度",
 			"subscription.used": "已用 {value}%",
-			"subscription.resets": "{time} 重置",
+			"subscription.resets": "{time}后重置",
+			"subscription.resetDue": "已到重置时间",
+			"duration.minutes": "{minutes} 分钟",
+			"duration.hoursMinutes": "{hours} 小时 {minutes} 分钟",
+			"duration.daysHours": "{days} 天 {hours} 小时",
 			"subscription.notConfigured": "配置 {refs} 后显示真实订阅比例。",
 			"subscription.unauthorized": "凭据已失效，请更新后重试。",
 			"subscription.rateLimited": "供应商暂时限制查询，请稍后重试。",
@@ -1638,6 +1744,7 @@ window.__ModuleLoader__.load({
 			"account.balanceMode": "API balance",
 			"account.loading": "Loading providers…",
 			"account.status.loading": "Loading",
+			"account.status.stale": "Stale data",
 			"account.status.blocked": "Blocked",
 			"account.status.unsupported": "Balance unsupported",
 			"account.status.invalidResponse": "Invalid response",
@@ -1648,6 +1755,23 @@ window.__ModuleLoader__.load({
 			"account.reason.upstreamNotJson": "The upstream response was not JSON",
 			"account.reason.upstreamInvalidJson": "The upstream returned unparsable JSON",
 			"account.reason.sub2apiBalanceShapeUnrecognized": "The Sub2API balance endpoint returned an unrecognized data shape.",
+			"account.reason.timeout": "The account request timed out.",
+			"account.reason.rateLimited": "The provider rate limited account checks.",
+			"account.reason.unauthorized": "The account credential was rejected.",
+			"account.reason.upstreamTooLarge": "The upstream response exceeded the safety size limit.",
+			"account.reason.upstreamInvalidResponse": "The upstream returned an unrecognized response.",
+			"account.reason.blockedNetwork": "The account request was blocked by the local network policy.",
+			"account.reason.noValidatedAddress": "No validated provider address was available.",
+			"account.reason.unknown": "The account check failed without a safe diagnostic detail.",
+			"account.health.lastAttempt": "Last attempt",
+			"account.health.lastSuccess": "Last success",
+			"account.health.age": "Data age",
+			"account.health.provenance": "Source",
+			"account.provenance.official": "Official API",
+			"account.provenance.provider": "Provider API",
+			"account.provenance.configured": "Configured",
+			"account.provenance.experimental": "Experimental",
+			"account.provenance.unknown": "Unknown",
 			"account.blocked": "The account query was blocked by the local security policy. Check HTTPS, same-origin, and private-network settings.",
 			"balance.title": "Account balance",
 			"balance.provider": "Provider",
@@ -1678,7 +1802,11 @@ window.__ModuleLoader__.load({
 			"subscription.window.quota": "Total quota",
 			"subscription.window.mcp": "Monthly MCP quota",
 			"subscription.used": "{value}% used",
-			"subscription.resets": "Resets {time}",
+			"subscription.resets": "Resets in {time}",
+			"subscription.resetDue": "Reset due",
+			"duration.minutes": "{minutes}m",
+			"duration.hoursMinutes": "{hours}h {minutes}m",
+			"duration.daysHours": "{days}d {hours}h",
 			"subscription.notConfigured": "Configure {refs} to show live subscription usage.",
 			"subscription.unauthorized": "The credential has expired; update it and retry.",
 			"subscription.rateLimited": "The provider is rate limiting checks; retry later.",
@@ -1772,6 +1900,7 @@ window.__ModuleLoader__.load({
 		exports.badgeWarnOf = badgeWarnOf;
 		exports.shouldDismissPanel = shouldDismissPanel;
 		exports.safeDiagnosticReason = safeDiagnosticReason;
+		exports.formatResetCountdown = formatResetCountdown;
 		exports.loadSessionPillSnapshot = loadSessionPillSnapshot;
 		exports.modelSelectionSignalOf = modelSelectionSignalOf;
 		exports.requestUsageStatsPanel = requestUsageStatsPanel;

--- a/lib/index.js
+++ b/lib/index.js
@@ -450,8 +450,27 @@ export async function collectSessionContext(ctx, sessionId, config = { monitors:
 	return currentSessionContext(sessionId, { ...state, currentRoute }, provider, config);
 }
 
+/** Resolve the current account ids for every live session without a new ledger or provider guess. */
+export async function collectActiveAccountIds(ctx, config = { monitors: {} }) {
+	await collectUsage(ctx);
+	const sessions = ctx.get("sessions")?.list?.() ?? [];
+	const cache = await loadCache();
+	const providers = await configuredProviders(ctx);
+	const byId = new Map(providers.map((provider) => [provider.id, provider]));
+	const accountIds = new Set();
+	for (const session of sessions) {
+		const state = cache.sessions[session.id];
+		if (state?.kind !== "live" || state.currentRoute === null || state.currentRoute === void 0) continue;
+		const provider = byId.get(state.currentRoute.providerId)
+			?? { id: state.currentRoute.providerId, displayName: state.currentRoute.providerId };
+		const context = currentSessionContext(session.id, state, provider, config);
+		if (typeof context?.accountId === "string" && context.accountId !== "") accountIds.add(context.accountId);
+	}
+	return [...accountIds];
+}
+
 /** Session context is explicit in multi-session DSH; a single live session is unambiguous. */
-async function handleSessionContext(ctx, config, req, res) {
+async function handleSessionContext(ctx, config, accounts, req, res) {
 	if (rejectForeignCaller(req, res)) return;
 	try {
 		const url = new URL(req.url ?? "/", "http://x");
@@ -487,7 +506,9 @@ async function handleSessionContext(ctx, config, req, res) {
 			model: selectedModel,
 			updatedAt: null
 		};
-		json(res, 200, { ok: true, context: await collectSessionContext(ctx, sessionId, config, selectedRoute) });
+		const context = await collectSessionContext(ctx, sessionId, config, selectedRoute);
+		if (typeof context?.accountId === "string" && context.accountId !== "") accounts.touch?.(context.accountId, "active");
+		json(res, 200, { ok: true, context });
 	} catch (error) {
 		ctx.logger.warn(`usage-stats: session context failed: ${String(error)}`);
 		json(res, 500, { ok: false, error: "internal", message: error instanceof Error ? error.message : String(error) });
@@ -521,7 +542,9 @@ async function handleAccount(ctx, accounts, req, res) {
 	try {
 		const url = new URL(req.url ?? "/", "http://x");
 		const providerId = await selectedProviderId(req, accounts);
-		const account = providerId === null ? null : await accounts.get(providerId, { force: url.searchParams.get("refresh") === "1" });
+		const requestedActivity = url.searchParams.get("activity");
+		const activity = requestedActivity === "active" || requestedActivity === "detail" ? requestedActivity : null;
+		const account = providerId === null ? null : await accounts.get(providerId, { force: url.searchParams.get("refresh") === "1", activity });
 		if (account === null) {
 			json(res, 200, { ok: false, error: "unknown-provider", message: `provider "${providerId}" is not configured` });
 			return;
@@ -597,36 +620,90 @@ async function handleSubscriptions(ctx, accounts, req, res) {
 	}
 }
 
-/** Start an immediate refresh and repeat account + local usage refresh every 5 minutes. */
+/** One adaptive account scheduler plus the existing five-minute usage fold. */
 export function startBackgroundRefresh(ctx, accounts, deps = {}) {
 	let running = false;
 	let stopped = false;
 	let active = Promise.resolve();
-	const run = async () => {
-		if (running || stopped) return;
+	let timer = null;
+	let scheduleGeneration = 0;
+	let nextUsageAt = 0;
+	const now = deps.now ?? Date.now;
+	const usageIntervalMs = deps.usageIntervalMs ?? ACCOUNT_REFRESH_MS;
+	const setTimer = deps.setTimeout ?? setTimeout;
+	const clearTimer = deps.clearTimeout ?? clearTimeout;
+	const config = deps.config ?? { monitors: {} };
+
+	const clearScheduled = () => {
+		if (timer === null) return;
+		clearTimer(timer);
+		timer = null;
+	};
+
+	const schedule = async () => {
+		if (stopped) return;
+		const generation = ++scheduleGeneration;
+		clearScheduled();
+		let accountNext = null;
+		try {
+			accountNext = await accounts.nextRefreshAt();
+		} catch (error) {
+			ctx.logger.warn(`usage-stats: refresh scheduling failed: ${String(error)}`);
+		}
+		if (stopped || generation !== scheduleGeneration) return;
+		const target = Math.min(accountNext ?? Infinity, nextUsageAt);
+		const delay = Math.max(1000, Number.isFinite(target) ? target - now() : usageIntervalMs);
+		timer = setTimer(() => {
+			timer = null;
+			void run();
+		}, delay);
+		timer?.unref?.();
+	};
+
+	const run = async (force = false) => {
+		if (stopped) return;
+		if (running) {
+			await active;
+			return force && !stopped ? run(true) : void 0;
+		}
+		clearScheduled();
 		running = true;
 		active = (async () => {
-			const results = await Promise.allSettled([accounts.refreshAll(), collectUsage(ctx)]);
-			for (const result of results) if (result.status === "rejected") ctx.logger.warn(`usage-stats: background refresh failed: ${String(result.reason)}`);
+			const at = now();
+			if (force || at >= nextUsageAt) {
+				try {
+					accounts.setActiveProviders(await collectActiveAccountIds(ctx, config));
+				} catch (error) {
+					ctx.logger.warn(`usage-stats: background usage refresh failed: ${String(error)}`);
+				}
+				nextUsageAt = now() + usageIntervalMs;
+			}
+			try {
+				await accounts.refreshDue({ force });
+			} catch (error) {
+				ctx.logger.warn(`usage-stats: background account refresh failed: ${String(error)}`);
+			}
 		})().finally(() => {
 			running = false;
 		});
-		return active;
+		await active;
+		await schedule();
 	};
-	void run();
-	const setTimer = deps.setInterval ?? setInterval;
-	const clearTimer = deps.clearInterval ?? clearInterval;
-	const timer = setTimer(run, deps.intervalMs ?? ACCOUNT_REFRESH_MS);
-	timer?.unref?.();
+	const unsubscribePolicyChanges = accounts.subscribePolicyChanges?.(() => {
+		// Activity changes only rearm this one central timer. The service remains
+		// responsible for deciding whether an upstream refresh is actually due.
+		if (!stopped && !running) void schedule();
+	}) ?? (() => {});
+	const ready = run();
 	const stop = async () => {
 		stopped = true;
-		clearTimer(timer);
+		scheduleGeneration += 1;
+		clearScheduled();
+		unsubscribePolicyChanges();
 		await active;
 	};
-	stop.refreshNow = async () => {
-		await active;
-		return run();
-	};
+	stop.ready = ready;
+	stop.refreshNow = () => run(true);
 	return stop;
 }
 
@@ -687,9 +764,9 @@ async function apply(ctx, rawConfig = {}, deps = {}) {
 	ctx.effect(() => ctx.webServer.register({
 		kind: "exact",
 		path: SESSION_CONTEXT_PATH,
-		handler: (req, res) => handleSessionContext(ctx, config, req, res)
+		handler: (req, res) => handleSessionContext(ctx, config, accounts, req, res)
 	}), "usage-stats: session context route");
-	if (deps.disableBackgroundRefresh !== true) ctx.effect(() => startBackgroundRefresh(ctx, accounts), "usage-stats: background account refresh");
+	if (deps.disableBackgroundRefresh !== true) ctx.effect(() => startBackgroundRefresh(ctx, accounts, { config }), "usage-stats: background account refresh");
 }
 
 export { apply, Config, inject, name, USAGE_PATH, PROVIDERS_PATH, BALANCE_PATH, SUBSCRIPTIONS_PATH, ACCOUNT_PATH, SESSION_CONTEXT_PATH, configuredProviders, totalTokens, zeroBuckets };

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -4,6 +4,7 @@
 // 3. render <UsageStatsPanel wide t> with react-dom/server
 // 4. run apply(ctx) against a stub client context
 import { createRequire } from "node:module";
+import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -213,15 +214,16 @@ const translateAccount = (key, params) => {
 	if (params?.ref !== void 0) return `${key}:${params.ref}`;
 	return key;
 };
+const deepseekAccount = {
+	id: "deepseek-official",
+	displayName: "DeepSeek",
+	mode: "balance",
+	status: "ok",
+	balance: { remaining: 36.44, currency: "CNY", unlimited: false, breakdown: { toppedUp: 20, granted: 16.44 } }
+};
 const deepseekMarkup = renderToStaticMarkup(react.createElement(ProviderAccountCard, {
 	provider: { id: "deepseek-official", displayName: "DeepSeek", accountMode: "balance" },
-	account: {
-		id: "deepseek-official",
-		displayName: "DeepSeek",
-		mode: "balance",
-		status: "ok",
-		balance: { remaining: 36.44, currency: "CNY", unlimited: false, breakdown: { toppedUp: 20, granted: 16.44 } }
-	},
+	account: deepseekAccount,
 	accountLoading: false,
 	accountError: null,
 	translate: translateAccount,
@@ -285,6 +287,29 @@ if (blockedMarkup.includes("balance.unsupported")) throw new Error("blocked must
 if (blockedMarkup.includes("balance.blocked") || blockedSubMarkup.includes("balance.blocked")) throw new Error("blocked must not reuse the balance-specific explanation");
 if (!source.includes('"account.status.blocked"') || !source.includes('"account.blocked"')) throw new Error("blocked status keys missing from client locales");
 if (source.includes('"balance.blocked"')) throw new Error("balance-specific blocked copy must not be reintroduced");
+
+const healthMarkup = renderToStaticMarkup(react.createElement(ProviderAccountCard, {
+	provider: { id: "deepseek-official", displayName: "DeepSeek", accountMode: "balance", adapter: "deepseek-balance" },
+	account: {
+		...deepseekAccount,
+		status: "rate-limited",
+		stale: true,
+		lastAttemptAt: Date.parse("2026-08-24T01:00:00Z"),
+		lastSuccessAt: Date.parse("2026-08-24T00:00:00Z"),
+		ageMs: 3600000,
+		provenance: "official",
+		reason: "rate-limited",
+		secret: "SECRET_API_KEY"
+	},
+	accountLoading: false,
+	accountError: null,
+	translate: translateAccount,
+	onRetry: () => {}
+}));
+for (const expected of ["account.status.stale", "account.health.lastAttempt", "account.health.lastSuccess", "account.health.age", "account.health.provenance", "account.provenance.official", "account.reason.rateLimited"]) {
+	if (!healthMarkup.includes(expected)) throw new Error(`account health detail is missing ${expected}`);
+}
+if (!healthMarkup.includes('data-account-stale="true"') || healthMarkup.includes("SECRET_API_KEY")) throw new Error("stale health metadata must be explicit and secret-free");
 
 const choices = buildProviderChoices([
 	{ id: "deepseek-official", displayName: "DeepSeek", adapter: "deepseek-balance", accountMode: "balance", configured: true },
@@ -358,6 +383,7 @@ console.log("collapsed-badge account value + warning policy ok");
 const {
 	CurrentSessionPill,
 	CurrentSessionPillView,
+	formatResetCountdown,
 	loadSessionPillSnapshot,
 	requestUsageStatsPanel,
 	sessionContextSignalOf,
@@ -365,12 +391,31 @@ const {
 	modelSelectionSignalOf,
 	subscribeUsageStatsPanel
 } = exports_;
-if ([CurrentSessionPill, CurrentSessionPillView, loadSessionPillSnapshot, requestUsageStatsPanel, sessionContextSignalOf, sessionPillViewOf, modelSelectionSignalOf, subscribeUsageStatsPanel].some((entry) => typeof entry !== "function")) {
+if ([CurrentSessionPill, CurrentSessionPillView, formatResetCountdown, loadSessionPillSnapshot, requestUsageStatsPanel, sessionContextSignalOf, sessionPillViewOf, modelSelectionSignalOf, subscribeUsageStatsPanel].some((entry) => typeof entry !== "function")) {
 	throw new Error("current-session pill exports are incomplete");
 }
+const resetTranslate = (key, params) => {
+	if (key === "duration.minutes") return `${params.minutes}m`;
+	if (key === "duration.hoursMinutes") return `${params.hours}h ${params.minutes}m`;
+	if (key === "duration.daysHours") return `${params.days}d ${params.hours}h`;
+	if (key === "subscription.resets") return `Resets in ${params.time}`;
+	if (key === "subscription.resetDue") return "Reset due";
+	return key;
+};
+const resetNow = Date.parse("2026-08-24T00:00:00Z");
+assert.equal(formatResetCountdown(null, resetNow, resetTranslate), "");
+assert.equal(formatResetCountdown("invalid", resetNow, resetTranslate), "");
+assert.equal(formatResetCountdown("2026-08-23T23:59:00Z", resetNow, resetTranslate), "Reset due");
+assert.equal(formatResetCountdown("2026-08-24T00:05:00Z", resetNow, resetTranslate), "Resets in 5m");
+assert.equal(formatResetCountdown("2026-08-24T02:37:00Z", resetNow, resetTranslate), "Resets in 2h 37m");
+assert.equal(formatResetCountdown("2026-08-27T14:00:00Z", resetNow, resetTranslate), "Resets in 3d 14h");
 const pillTranslate = (key, params) => {
 	if (params?.provider !== void 0 && params?.value !== void 0) return `${params.provider}: ${params.value}`;
+	if (key === "duration.minutes") return `${params.minutes}m`;
+	if (key === "duration.hoursMinutes") return `${params.hours}h ${params.minutes}m`;
+	if (key === "duration.daysHours") return `${params.days}d ${params.hours}h`;
 	if (key === "subscription.resets" && params?.time !== void 0) return `reset:${params.time}`;
+	if (key === "subscription.resetDue") return "reset:due";
 	return key;
 };
 const pillContext = {
@@ -436,7 +481,7 @@ const subscriptionPillWithResetSnapshot = {
 		alert: { level: "critical", metric: "remaining-percent", value: 8 }
 	}
 };
-const subscriptionPillWithReset = sessionPillViewOf(subscriptionPillWithResetSnapshot, pillTranslate);
+const subscriptionPillWithReset = sessionPillViewOf(subscriptionPillWithResetSnapshot, pillTranslate, resetNow);
 if (!subscriptionPillWithReset.ariaLabel.includes("reset:")) throw new Error("subscription pill must expose the tightest window reset through accessible text");
 if (subscriptionPillWithReset.value !== subscriptionPill.value) throw new Error("reset information must not expand the compact visible pill value");
 const warningPill = sessionPillViewOf({ ...balancePillSnapshot, account: { ...balancePillSnapshot.account, alert: { level: "warning" } } }, pillTranslate);
@@ -482,6 +527,7 @@ const subscriptionPillMarkup = renderToStaticMarkup(subscriptionPillElement);
 const subscriptionPillWithResetElement = CurrentSessionPillView({
 	snapshot: subscriptionPillWithResetSnapshot,
 	translate: pillTranslate,
+	now: resetNow,
 	onOpen: () => {}
 });
 if (!subscriptionPillWithResetElement.props.title.includes("reset:") || subscriptionPillWithResetElement.props["aria-label"] !== subscriptionPillWithResetElement.props.title) {
@@ -514,7 +560,7 @@ currentProvider = "opencode-go";
 const switchedPillLoad = await loadSessionPillSnapshot("session/one", fetchPill);
 if (firstPillLoad.account.id !== "deepseek-official" || switchedPillLoad.account.id !== "opencode-go") throw new Error("session provider switch must resolve a fresh account snapshot");
 if (requests[0] !== "/api/usage-stats/session-context?session=session%2Fone") throw new Error(`session context request must carry the explicit encoded session id: ${requests[0]}`);
-if (!requests.includes("/api/usage-stats/account?provider=opencode-go")) throw new Error("pill must reuse the unified account endpoint for the resolved provider");
+if (!requests.includes("/api/usage-stats/account?provider=opencode-go&activity=active")) throw new Error("pill must reuse the unified account endpoint and mark the server-owned active provider");
 await loadSessionPillSnapshot("session/one", fetchPill, { provider: "route:two", model: "same/model" });
 if (!requests.includes("/api/usage-stats/session-context?session=session%2Fone&provider=route%3Atwo&model=same%2Fmodel")) {
 	throw new Error("the formal model-selector route must be encoded as a session-context hint");
@@ -611,24 +657,28 @@ if (openedBy.join(",") !== "second:opencode-go,first:deepseek-official") throw n
 // panel with the current provider selected. Network and timers are inert test
 // doubles; production still uses the panel's existing refresh/cache path.
 const originalFetch = globalThis.fetch;
+const integrationRequests = [];
 document.addEventListener = () => {};
 document.removeEventListener = () => {};
 window.setInterval = () => 1;
 window.clearInterval = () => {};
-globalThis.fetch = async (path) => ({
-	ok: true,
-	json: async () => {
-		if (String(path).includes("/providers")) return {
-			ok: true,
-			providers: [
-				{ id: "deepseek-official", displayName: "DeepSeek", configured: true, accountMode: "balance" },
-				{ id: "opencode-go", displayName: "OpenCode Go", configured: true, accountMode: "subscription" }
-			]
-		};
-		if (String(path).includes("/account")) return { ok: true, account: { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: "ok", windows: [{ kind: "weekly", remainingPercent: 18 }], alert: { level: "warning" } } };
-		return { ok: true, days: [], total: { tokens: 0 } };
-	}
-});
+globalThis.fetch = async (path) => {
+	integrationRequests.push(String(path));
+	return {
+		ok: true,
+		json: async () => {
+			if (String(path).includes("/providers")) return {
+				ok: true,
+				providers: [
+					{ id: "deepseek-official", displayName: "DeepSeek", configured: true, accountMode: "balance" },
+					{ id: "opencode-go", displayName: "OpenCode Go", configured: true, accountMode: "subscription" }
+				]
+			};
+			if (String(path).includes("/account")) return { ok: true, account: { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: "ok", windows: [{ kind: "weekly", remainingPercent: 18 }], alert: { level: "warning" } } };
+			return { ok: true, days: [], total: { tokens: 0 } };
+		}
+	};
+};
 let integrationRenderer;
 await act(async () => {
 	integrationRenderer = TestRenderer.create(react.createElement(react.Fragment, {},
@@ -648,6 +698,7 @@ await act(async () => {
 if (integrationRenderer.root.findAllByProps({ "data-usage-stats-panel": true }).length !== 1) throw new Error("pill click must open the existing account panel");
 const selectedPicker = integrationRenderer.root.findByType("select");
 if (selectedPicker.props.value !== "opencode-go") throw new Error(`pill click must select its provider in the existing panel, got ${selectedPicker.props.value}`);
+if (!integrationRequests.some((path) => path.includes("/account?provider=opencode-go&activity=detail"))) throw new Error("the open detail panel must signal its provider to the central scheduler");
 await act(async () => { integrationRenderer.unmount(); });
 globalThis.fetch = originalFetch;
 

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
+	accountProvenance,
 	createAccountService,
 	isPrivateAddress,
 	queryAccount,
+	refreshPolicy,
 	resolveAccountSpec,
 	selectResolvedAddress,
 	selectResolvedAddresses,
-	validateAccountConfig
+	validateAccountConfig,
+	withHealthAge
 } from "../lib/accounts.js";
 
 function credentials(values) {
@@ -51,6 +54,59 @@ const deepseek = {
 	apiKeyEnv: "DEEPSEEK_API_KEY",
 	baseURL: "https://api.deepseek.com"
 };
+
+{
+	const provenanceCases = new Map([
+		["deepseek-balance", "official"],
+		["openrouter-balance", "official"],
+		["moonshot-balance", "official"],
+		["zai-balance", "official"],
+		["opencode-go", "official"],
+		["zai-token-plan", "official"],
+		["kimi-token-plan", "official"],
+		["minimax-token-plan", "official"],
+		["ollama", "official"],
+		["new-api", "provider"],
+		["sub2api", "provider"],
+		["sub2api-auth", "provider"],
+		["general", "configured"],
+		["declarative", "configured"],
+		[null, "unknown"]
+	]);
+	for (const [adapter, expected] of provenanceCases) assert.equal(accountProvenance({ adapter }), expected, `${adapter} provenance`);
+	assert.equal(accountProvenance(resolveAccountSpec(deepseek, validateAccountConfig())), "official");
+	assert.equal(accountProvenance({ ...resolveAccountSpec(relay, validateAccountConfig()), provenanceHint: "experimental" }), "experimental");
+	console.log("account provenance vocabulary ok");
+}
+
+{
+	const active = refreshPolicy({ activity: "active", status: "ok", rateLimitFailures: 0, lastAttemptAt: now }, now);
+	const detail = refreshPolicy({ activity: "detail", status: "ok", rateLimitFailures: 0, lastAttemptAt: now }, now);
+	const background = refreshPolicy({ activity: "background", status: "ok", rateLimitFailures: 0, lastAttemptAt: now }, now);
+	assert.ok(active.nextRefreshAt < background.nextRefreshAt, "active providers must refresh sooner than background providers");
+	assert.ok(detail.nextRefreshAt < background.nextRefreshAt, "detail providers must refresh sooner than background providers");
+	const first429 = refreshPolicy({ activity: "active", status: "rate-limited", rateLimitFailures: 1, lastAttemptAt: now }, now);
+	const second429 = refreshPolicy({ activity: "active", status: "rate-limited", rateLimitFailures: 2, lastAttemptAt: now }, now);
+	const failedRetry = refreshPolicy({ activity: "active", status: "unavailable", rateLimitFailures: 2, lastAttemptAt: now }, now);
+	const bounded429 = refreshPolicy({ activity: "active", status: "rate-limited", rateLimitFailures: 99, lastAttemptAt: now }, now);
+	assert.ok(first429.nextRefreshAt > active.nextRefreshAt, "429 must override the fast activity interval");
+	assert.ok(second429.nextRefreshAt > first429.nextRefreshAt, "consecutive 429 responses must increase backoff");
+	assert.equal(failedRetry.nextRefreshAt, second429.nextRefreshAt, "a non-success retry must preserve the existing rate-limit backoff");
+	assert.ok(bounded429.nextRefreshAt - now <= 3600000, "429 backoff must remain bounded");
+	assert.equal(refreshPolicy({ activity: "background", status: "pending", rateLimitFailures: 0, lastAttemptAt: null }, now).nextRefreshAt, now);
+	console.log("adaptive refresh policy and bounded 429 backoff ok");
+}
+
+{
+	const stored = { status: "ok", lastSuccessAt: now, fetchedAt: now };
+	const first = withHealthAge(stored, now + 1000);
+	const second = withHealthAge(stored, now + 9000);
+	assert.equal(first.ageMs, 1000);
+	assert.equal(second.ageMs, 9000);
+	assert.equal(Object.hasOwn(stored, "ageMs"), false, "ageMs must never become a cached dead value");
+	assert.equal(withHealthAge({ status: "unavailable", lastSuccessAt: null }, now).ageMs, null);
+	console.log("health age is derived at read time ok");
+}
 
 assert.equal(isPrivateAddress("127.0.0.1"), true);
 assert.equal(isPrivateAddress("::ffff:127.0.0.1"), true);
@@ -163,6 +219,33 @@ console.log("IPv4/IPv6 private-address classification ok");
 	assert.equal(account.status, "unavailable");
 	assert.equal(account.balance.available, false);
 	assert.equal(account.balance.remaining, 12.5);
+	let clock = now;
+	let available = true;
+	const service = createAccountService({
+		credentials: credentials({ DEEPSEEK_API_KEY: "sk-test" }),
+		getProviders: async () => [deepseek],
+		config: validateAccountConfig(),
+		deps: {
+			includeLegacyProviders: false,
+			now: () => clock,
+			fetch: async () => jsonResponse({
+				is_available: available,
+				balance_infos: [{ currency: "CNY", total_balance: available ? "20.00" : "12.50", granted_balance: "0", topped_up_balance: available ? "20.00" : "12.50" }]
+			})
+		}
+	});
+	const healthy = await service.get("deepseek-official");
+	assert.equal(healthy.status, "ok");
+	assert.equal(healthy.lastSuccessAt, now);
+	available = false;
+	clock += 1000;
+	const observed = await service.get("deepseek-official", { force: true });
+	assert.equal(observed.status, "unavailable");
+	assert.equal(observed.stale, false, "a valid unavailable response must replace rather than retain the previous balance");
+	assert.equal(observed.balance.remaining, 12.5);
+	assert.equal(observed.lastAttemptAt, clock);
+	assert.equal(observed.lastSuccessAt, clock, "a valid DeepSeek response must advance health success even when the account is unavailable");
+	assert.equal(observed.ageMs, 0);
 	console.log("DeepSeek provider-reported unavailable state ok");
 }
 
@@ -176,6 +259,15 @@ console.log("IPv4/IPv6 private-address classification ok");
 	});
 	assert.equal(inferenceOnly.status, "not-configured");
 	assert.deepEqual(inferenceOnly.missingCredentials, ["OPENROUTER_MANAGEMENT_KEY"]);
+	const unconfiguredService = createAccountService({
+		credentials: credentials({ OPENROUTER_API_KEY: "inference-key" }),
+		getProviders: async () => [provider],
+		config: validateAccountConfig(),
+		deps: { includeLegacyProviders: false, now: () => now, fetch: async () => { throw new Error("must not request upstream"); } }
+	});
+	const unconfigured = await unconfiguredService.get("openrouter");
+	assert.equal(unconfigured.lastAttemptAt, null, "missing management credentials must not count as a provider attempt");
+	assert.equal(unconfigured.lastSuccessAt, null);
 	const account = await queryAccount(spec, credentials({ OPENROUTER_MANAGEMENT_KEY: "management-key" }), {
 		now: () => now,
 		fetch: async (_url, init) => {
@@ -449,6 +541,7 @@ console.log("IPv4/IPv6 private-address classification ok");
 		fetch: async () => jsonResponse({ balance: 1 }, 200, { "content-length": String(1024 * 1024 + 1) })
 	});
 	assert.equal(account.status, "invalid-response");
+	assert.equal(account.reason, "upstream-too-large");
 	console.log("declarative response-size limit ok");
 }
 
@@ -943,24 +1036,255 @@ console.log("IPv4/IPv6 private-address classification ok");
 			fetch: async (url) => {
 				if (String(url).endsWith("/api/status")) return jsonResponse({ data: { quota_per_unit: 1 } });
 				if (phase === "transient") return jsonResponse({}, 503);
+				if (phase === "rate-limited") return jsonResponse({}, 429);
 				if (phase === "auth") return jsonResponse({}, 401);
 				return jsonResponse({ code: true, data: { total_granted: 10, total_used: 2, total_available: 8 } });
 			}
 		}
 	});
-	assert.equal((await service.get("relay-a")).status, "ok");
+	const success = await service.get("relay-a");
+	assert.equal(success.status, "ok");
+	assert.equal(success.lastAttemptAt, now);
+	assert.equal(success.lastSuccessAt, now);
+	assert.equal(success.ageMs, 0);
+	assert.equal(success.stale, false);
+	assert.equal(success.provenance, "provider");
+	clock += 1000;
+	const successAgain = await service.get("relay-a", { force: true });
+	const successfulAt = clock;
+	assert.equal(successAgain.lastAttemptAt, successfulAt);
+	assert.equal(successAgain.lastSuccessAt, successfulAt, "consecutive success must advance both health timestamps");
+	assert.equal(successAgain.ageMs, 0);
+	const providerView = (await service.providerViews()).find((entry) => entry.id === "relay-a");
+	assert.deepEqual({
+		stale: providerView.stale,
+		lastAttemptAt: providerView.lastAttemptAt,
+		lastSuccessAt: providerView.lastSuccessAt,
+		ageMs: providerView.ageMs,
+		provenance: providerView.provenance,
+		reason: providerView.reason
+	}, { stale: false, lastAttemptAt: successfulAt, lastSuccessAt: successfulAt, ageMs: 0, provenance: "provider", reason: null });
+	clock += 1000;
+	assert.equal((await service.get("relay-a")).ageMs, 1000, "cached health age must advance at read time");
 	phase = "transient";
 	clock += 300000;
 	const stale = await service.get("relay-a", { force: true });
 	assert.equal(stale.status, "unavailable");
 	assert.equal(stale.stale, true);
 	assert.equal(stale.balance.remaining, 8);
-	phase = "auth";
+	assert.equal(stale.lastAttemptAt, clock);
+	assert.equal(stale.lastSuccessAt, successfulAt);
+	assert.equal(stale.ageMs, 301000);
+	assert.equal(stale.reason, "unknown");
+	phase = "rate-limited";
+	clock += 1000;
+	const limited = await service.get("relay-a", { force: true });
+	assert.equal(limited.status, "rate-limited");
+	assert.equal(limited.stale, true);
+	assert.equal(limited.balance.remaining, 8);
+	assert.equal(limited.lastSuccessAt, successfulAt);
+	assert.equal(limited.reason, "rate-limited");
+	assert.equal(await service.nextRefreshAt(), clock + 300000, "the first 429 must schedule bounded backoff");
 	clock += 300000;
+	const limitedAgain = await service.get("relay-a", { force: true });
+	assert.equal(limitedAgain.status, "rate-limited");
+	assert.equal(await service.nextRefreshAt(), clock + 600000, "consecutive 429 responses must increase backoff per provider");
+	phase = "transient";
+	clock += 1000;
+	const failedRetry = await service.get("relay-a", { force: true });
+	assert.equal(failedRetry.status, "unavailable");
+	assert.equal(failedRetry.stale, true);
+	assert.equal(await service.nextRefreshAt(), clock + 600000, "a failed retry must not clear rate-limit backoff before recovery");
+	phase = "auth";
+	clock += 1000;
 	const unauthorized = await service.get("relay-a", { force: true });
 	assert.equal(unauthorized.status, "unauthorized");
 	assert.equal(unauthorized.balance, null, "auth failures must not retain stale account data");
-	console.log("transient stale retention and auth clearing ok");
+	assert.equal(unauthorized.stale, false);
+	assert.equal(unauthorized.lastSuccessAt, successfulAt, "non-transient failures must not erase health history");
+	assert.equal(unauthorized.reason, "unauthorized");
+	phase = "ok";
+	clock += 1000;
+	const recovered = await service.get("relay-a", { force: true });
+	assert.equal(recovered.status, "ok");
+	assert.equal(recovered.stale, false);
+	assert.equal(recovered.lastSuccessAt, clock);
+	assert.equal(recovered.ageMs, 0);
+	assert.equal(await service.nextRefreshAt(), clock + 900000, "success must clear rate-limit backoff");
+	console.log("account health transitions, stale retention, and 429 recovery ok");
+}
+
+{
+	let phase = "ok";
+	let provider = { ...relay };
+	const service = createAccountService({
+		credentials: credentials({ RELAY_A_KEY: "sk-relay" }),
+		getProviders: async () => [provider],
+		config: validateAccountConfig({ monitors: { "relay-a": { adapter: "general" } } }),
+		deps: {
+			includeLegacyProviders: false,
+			now: () => now,
+			fetch: async () => phase === "ok"
+				? jsonResponse({ balance: 42, currency: "USD" })
+				: jsonResponse({}, 503)
+		}
+	});
+	const first = await service.get("relay-a");
+	assert.equal(first.balance.remaining, 42);
+	provider = { ...provider, baseURL: "https://replacement.example.com/v1" };
+	const reboundView = (await service.providerViews()).find((entry) => entry.id === "relay-a");
+	assert.equal(reboundView.status, "pending", "provider views must not expose a snapshot from a different config key");
+	assert.equal(reboundView.fetchedAt, null);
+	assert.equal(reboundView.lastSuccessAt, null);
+	phase = "unavailable";
+	const changed = await service.get("relay-a", { force: true });
+	assert.equal(changed.status, "unavailable");
+	assert.equal(changed.stale, false, "a new provider binding must not retain data from the previous config key");
+	assert.equal(changed.balance, null);
+	assert.equal(changed.lastSuccessAt, null);
+	console.log("account config changes invalidate stale-data and backoff history ok");
+}
+
+{
+	let clock = now;
+	let configured = true;
+	let calls = 0;
+	const service = createAccountService({
+		credentials: { resolve: async () => configured ? { value: "sk-relay" } : void 0 },
+		getProviders: async () => [relay],
+		config: validateAccountConfig({ monitors: { "relay-a": { adapter: "general" } } }),
+		deps: {
+			includeLegacyProviders: false,
+			now: () => clock,
+			fetch: async () => {
+				calls += 1;
+				return jsonResponse({ balance: 42, currency: "USD" });
+			}
+		}
+	});
+	const success = await service.get("relay-a");
+	assert.equal(success.lastAttemptAt, now);
+	configured = false;
+	clock += 900000;
+	await service.refreshDue();
+	const unconfigured = service.cached("relay-a");
+	assert.equal(unconfigured.status, "not-configured");
+	assert.equal(unconfigured.lastAttemptAt, now, "a local missing-credential evaluation must preserve the last real provider attempt");
+	assert.equal(unconfigured.lastSuccessAt, now);
+	assert.equal(await service.nextRefreshAt(), clock + 900000, "a no-attempt evaluation must still advance the scheduler deadline");
+	clock += 900000;
+	await service.refreshDue();
+	assert.equal(await service.nextRefreshAt(), clock + 900000, "consecutive missing-credential evaluations must never create a one-second loop");
+	assert.equal(calls, 1, "missing credentials must not create extra provider requests");
+	console.log("no-attempt evaluations remain health-accurate and scheduler-bounded ok");
+}
+
+{
+	let provider = { ...relay, baseURL: "https://old.example.com/v1" };
+	let releaseOld;
+	const calls = [];
+	const service = createAccountService({
+		credentials: credentials({ RELAY_A_KEY: "sk-relay" }),
+		getProviders: async () => [provider],
+		config: validateAccountConfig({ monitors: { "relay-a": { adapter: "general" } } }),
+		deps: {
+			includeLegacyProviders: false,
+			now: () => now,
+			fetch: async (url) => {
+				calls.push(String(url));
+				if (String(url).includes("old.example.com")) {
+					await new Promise((resolve) => { releaseOld = resolve; });
+					return jsonResponse({ balance: 10, currency: "USD" });
+				}
+				return jsonResponse({ balance: 99, currency: "USD" });
+			}
+		}
+	});
+	const oldRequest = service.get("relay-a", { force: true });
+	await new Promise((resolve) => setImmediate(resolve));
+	provider = { ...provider, baseURL: "https://new.example.com/v1" };
+	const newAccount = await service.get("relay-a", { force: true });
+	assert.equal(newAccount.balance.remaining, 99, "a rebound provider must not share the previous config's inflight request");
+	releaseOld();
+	const oldAccount = await oldRequest;
+	assert.equal(oldAccount.balance.remaining, 10);
+	assert.equal((await service.get("relay-a")).balance.remaining, 99, "a late old-config completion must not overwrite the new binding cache");
+	assert.deepEqual(calls, ["https://old.example.com/user/balance", "https://new.example.com/user/balance"]);
+	console.log("single-flight is config-aware and rejects late old-binding cache writes ok");
+}
+
+{
+	const secret = "SECRET_API_KEY_sk-danger";
+	const service = createAccountService({
+		credentials: credentials({ RELAY_A_KEY: secret }),
+		getProviders: async () => [relay],
+		config: validateAccountConfig({ monitors: { "relay-a": { adapter: "general" } } }),
+		deps: {
+			includeLegacyProviders: false,
+			now: () => now,
+			fetch: async () => {
+				const error = new Error(`Authorization: Bearer ${secret}; Cookie=session-secret; upstream body=${secret}`);
+				error.providerStatus = "unavailable";
+				error.safeReason = `Authorization: Bearer ${secret}`;
+				throw error;
+			}
+		}
+	});
+	const account = await service.get("relay-a", { force: true });
+	assert.equal(account.reason, "unknown");
+	assert.equal(account.lastAttemptAt, now);
+	assert.equal(account.lastSuccessAt, null);
+	assert.equal(account.ageMs, null, "an account that never succeeded has no data age");
+	const wire = JSON.stringify({ account, providers: await service.providerViews() });
+	assert.equal(wire.includes(secret), false);
+	assert.equal(/Authorization|Cookie|upstream body/i.test(wire), false);
+	console.log("account health diagnostics never expose hostile upstream secrets ok");
+}
+
+{
+	let clock = now;
+	let releaseRelayA;
+	let holdRelayA = true;
+	const calls = new Map([["relay-a", 0], ["relay-b", 0]]);
+	const relayB = { ...relay, id: "relay-b", displayName: "Relay B", apiKeyEnv: "RELAY_B_KEY", baseURL: "https://relay-b.example.com/v1" };
+	const service = createAccountService({
+		credentials: credentials({ RELAY_A_KEY: "sk-a", RELAY_B_KEY: "sk-b" }),
+		getProviders: async () => [relay, relayB],
+		config: validateAccountConfig({ monitors: {
+			"relay-a": { adapter: "general" },
+			"relay-b": { adapter: "general" }
+		} }),
+		deps: {
+			includeLegacyProviders: false,
+			now: () => clock,
+			fetch: async (url) => {
+				const id = String(url).includes("relay-b") ? "relay-b" : "relay-a";
+				calls.set(id, calls.get(id) + 1);
+				if (id === "relay-a" && holdRelayA) await new Promise((resolve) => { releaseRelayA = resolve; });
+				return jsonResponse({ balance: id === "relay-a" ? 10 : 20, currency: "USD" });
+			}
+		}
+	});
+	let policyChanges = 0;
+	const unsubscribe = service.subscribePolicyChanges(() => { policyChanges += 1; });
+	service.touch("relay-a", "detail");
+	assert.equal(policyChanges, 1, "background-to-detail activity must notify the central scheduler");
+	service.touch("relay-a", "detail");
+	assert.equal(policyChanges, 1, "refreshing the same activity hint must not create redundant scheduler wakes");
+	service.setActiveProviders(["relay-a"]);
+	assert.equal(policyChanges, 2, "detail-to-active activity must notify the central scheduler");
+	const direct = service.get("relay-a", { force: true, activity: "active" });
+	await new Promise((resolve) => setImmediate(resolve));
+	const central = service.refreshDue({ force: true });
+	holdRelayA = false;
+	releaseRelayA();
+	await Promise.all([direct, central]);
+	assert.deepEqual(Object.fromEntries(calls), { "relay-a": 1, "relay-b": 1 }, "detail/background overlap must preserve one upstream request per provider");
+	clock += 60000;
+	await service.refreshDue();
+	assert.deepEqual(Object.fromEntries(calls), { "relay-a": 2, "relay-b": 1 }, "active and background providers must keep independent due times");
+	unsubscribe();
+	console.log("adaptive refresh preserves single-flight and per-provider independence ok");
 }
 
 {
@@ -1178,7 +1502,7 @@ console.log("IPv4/IPv6 private-address classification ok");
 		}
 	});
 	assert.equal(account.status, "unavailable");
-	assert.equal(account.reason, void 0, "TLS failures must not trigger address fallback or expose raw diagnostics");
+	assert.equal(account.reason, "unknown", "TLS failures must expose only a fixed diagnostic code");
 	assert.equal(attempts, 1, "non-connection failures must not retry another IP");
 	console.log("TLS failure does not bypass validation via address fallback ok");
 }

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -110,7 +110,15 @@ async function testSessionContext(root) {
 			}
 		} : void 0
 	};
-	await plugin.apply(makeContext({ sessions, persistence, routes, settings }), {}, { disableBackgroundRefresh: true });
+	const touches = [];
+	const accounts = {
+		validate: async () => {},
+		touch: (providerId, activity) => touches.push([providerId, activity]),
+		providerViews: async () => [],
+		get: async () => null,
+		subscriptionAccounts: async () => []
+	};
+	await plugin.apply(makeContext({ sessions, persistence, routes, settings }), {}, { disableBackgroundRefresh: true, accounts });
 	const handler = routes.get(plugin.SESSION_CONTEXT_PATH);
 
 	const first = makeResponse();
@@ -125,6 +133,7 @@ async function testSessionContext(root) {
 		updatedAt: Date.UTC(2026, 7, 23, 12, 0, 0)
 	});
 	assert.doesNotMatch(first.body, /SECRET|apiKey|baseURL/i, "session context must not expose connection or credential fields");
+	assert.deepEqual(touches.at(-1), ["route-a", "active"], "session context must signal only its resolver-owned account identity");
 
 	const selectorSwitched = makeResponse();
 	await handler({ method: "GET", url: `${plugin.SESSION_CONTEXT_PATH}?session=live-session&provider=route-b&model=shared-model`, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, selectorSwitched);
@@ -136,6 +145,7 @@ async function testSessionContext(root) {
 		accountId: "route-b",
 		updatedAt: null
 	}, "an accepted selector route must override the last request/header immediately");
+	assert.deepEqual(touches.at(-1), ["route-b", "active"], "selector route changes must update central scheduler activity");
 	const invalidSelectionQueries = [
 		"provider=route-b",
 		"provider=route-b&model=",
@@ -252,11 +262,15 @@ async function testLegacyZaiSubscriptionId(root) {
 		status: "ok",
 		windows: []
 	};
+	let accountRead = null;
 	const accounts = {
 		validate: async () => {},
 		subscriptionAccounts: async () => [account],
-		providerViews: async () => [],
-		get: async () => null,
+		providerViews: async () => [{ id: "zai-coding-cn", configured: true }],
+		get: async (providerId, options) => {
+			accountRead = { providerId, options };
+			return account;
+		},
 		refreshAll: async () => []
 	};
 	await plugin.apply(makeContext({ sessions: { list: () => [] }, persistence: { listSnapshots: async () => [], list: async () => [] }, routes }), {}, {
@@ -268,36 +282,62 @@ async function testLegacyZaiSubscriptionId(root) {
 	const legacy = JSON.parse(response.body).subscriptions[0];
 	assert.equal(legacy.id, "zai", "0.1.x clients require the canonical Z.ai subscription id");
 	assert.equal(account.id, "zai-coding-cn", "legacy canonicalization must not mutate the account protocol");
+	const detail = makeResponse();
+	await routes.get(plugin.ACCOUNT_PATH)({ method: "GET", url: `${plugin.ACCOUNT_PATH}?provider=zai-coding-cn&activity=detail`, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, detail);
+	assert.equal(detail.status, 200);
+	assert.deepEqual(accountRead, { providerId: "zai-coding-cn", options: { force: false, activity: "detail" } }, "detail activity must stay a small server-owned AccountService hint");
 }
 
 async function testBackgroundRefresh(root) {
 	const plugin = await freshModule("background", join(root, "background"));
 	let refreshes = 0;
-	let interval = null;
+	let delay = null;
 	let tick = null;
 	let cleared = false;
+	let unsubscribed = false;
+	let policyChanged = null;
+	let clock = Date.UTC(2026, 7, 24, 0, 0, 0);
+	let accountDeadline = clock + 60000;
+	const activeSets = [];
+	const session = { id: "active-session", events: [routeEvent(0, "route-a", "shared-model")] };
 	const ctx = makeContext({
-		sessions: { list: () => [] },
+		sessions: { list: () => [session], get: (id) => id === session.id ? session : void 0 },
 		persistence: { listSnapshots: async () => [], list: async () => [] }
 	});
 	const cleanup = plugin.startBackgroundRefresh(ctx, {
-		refreshAll: async () => { refreshes += 1; }
+		setActiveProviders: (ids) => { activeSets.push([...ids]); },
+		refreshDue: async () => { refreshes += 1; },
+		nextRefreshAt: async () => accountDeadline,
+		subscribePolicyChanges: (listener) => {
+			policyChanged = listener;
+			return () => { unsubscribed = true; };
+		}
 	}, {
-		setInterval: (callback, ms) => {
+		config: { monitors: {} },
+		now: () => clock,
+		setTimeout: (callback, ms) => {
 			tick = callback;
-			interval = ms;
+			delay = ms;
 			return { unref: () => {} };
 		},
-		clearInterval: () => { cleared = true; }
+		clearTimeout: () => { cleared = true; }
 	});
-	await new Promise((resolve) => setImmediate(resolve));
-	assert.equal(interval, 300000);
+	await cleanup.ready;
+	assert.equal(delay, 60000, "one central timer must target the earliest account/usage deadline");
 	assert.equal(refreshes, 1, "background refresh must run immediately at startup");
+	assert.deepEqual(activeSets.at(-1), ["route-a"], "active providers must come from existing session route identity");
 	assert.equal(typeof tick, "function");
+	accountDeadline = clock + 15000;
+	policyChanged();
+	await new Promise((resolve) => setImmediate(resolve));
+	assert.equal(delay, 15000, "an activity priority change must rearm the same central timer to the earlier deadline");
+	assert.equal(cleared, true, "rearming must clear the previously scheduled central timer");
+	clock += 15000;
 	await cleanup.refreshNow();
-	assert.equal(refreshes, 2, "the five-minute timer must refresh accounts again");
+	assert.equal(refreshes, 2, "manual scheduler wake must reuse the central refresh path");
 	await cleanup();
 	assert.equal(cleared, true);
+	assert.equal(unsubscribed, true, "scheduler cleanup must unsubscribe from AccountService policy changes");
 }
 
 async function testPersistedToLive(root) {


### PR DESCRIPTION
Closes #61
Reference #65
Depends on #60 / #66 and #18 / #68

## Summary

- extend unified account snapshots with health timestamps, read-time age, safe diagnostic codes, and normalized provenance
- preserve last-good values only for transient failures while keeping config-key boundaries strict
- render relative quota reset countdowns and account health details in the existing Pill/panel surfaces
- replace fixed all-provider refreshes with one adaptive central scheduler for active, detail, background, and bounded rate-limit backoff states
- preserve one AccountService cache and config-aware single-flight behavior; no pricing, cost, budget, export, or version changes

## Refresh and safety notes

- active: 1 minute; detail: 2 minutes; background: 15 minutes
- 429 backoff starts at 5 minutes, doubles per consecutive rate limit, and caps at 60 minutes
- non-success retries preserve existing rate-limit backoff; a valid success clears it
- policy changes only rearm the existing central timer; no per-provider timer or new client polling loop was added
- reasons exposed to the browser come from a fixed safe vocabulary; hostile upstream text, headers, bodies, and credentials are rejected
- config-key changes invalidate stale/backoff history, isolate provider views, and cannot share or overwrite newer inflight work

## Validation

- `npm run check`
- `npm test`
- `npm pack --json` (`@ychris12138/dsh-usage-stats@0.2.10`, 15 files)
- isolated real DSH Web validation: plugin/sidebar/panel loaded; provider switching worked; reset countdown and health/provenance rendered; 429 retained stale values with a safe reason; recovery returned to fresh state; no plugin-load error was observed
- Standards review: PASS, no actionable findings
- Spec review: PASS, no actionable findings

Package version remains `0.2.10`. This PR is intentionally Draft and does not start pricing, cost, budget, or export work.