### PR TITLE
feat: add provider-aware historical pricing engine

### DIFF
--- a/lib/pricing.js
+++ b/lib/pricing.js
@@ -280,9 +280,12 @@ function hostnameOf(baseURL) {
 
 function isOfficialDeepSeekIdentity(identity) {
 	if (identity?.providerFamily !== "deepseek" || identity?.pricingFamily !== "deepseek") return false;
+	const configuredBaseURL = nonEmptyString(identity.baseURL);
 	// An exact official billing host remains authoritative even when an explicit
 	// account monitor caused the shared resolver's confidence to be `explicit`.
-	if (hostnameOf(identity.baseURL) === "api.deepseek.com") return true;
+	if (configuredBaseURL !== null) return hostnameOf(configuredBaseURL) === "api.deepseek.com";
+	// Without a configured URL, a canonical route id is the remaining safe
+	// signal. An explicit custom or malformed URL must never be overridden by it.
 	if (identity.confidence === "canonical-id" && (identity.routeId === "deepseek" || identity.routeId === "deepseek-official")) return true;
 	return false;
 }

--- a/lib/pricing.js
+++ b/lib/pricing.js
@@ -1,0 +1,388 @@
+/**
+ * Pure, provider-aware token pricing primitives.
+ *
+ * Pricing is derived from route identity, exact model id, event timestamp,
+ * token buckets, and an immutable historical rule catalog. This module owns no
+ * network access, timer, cache, UI, endpoint, or token aggregation state.
+ *
+ * @module dsh-usage-stats/pricing
+ */
+
+const TOKENS_PER_MILLION = 1_000_000;
+const DEEPSEEK_PRICE_SOURCE = Object.freeze({
+	kind: "official",
+	provider: "deepseek",
+	url: "https://api-docs.deepseek.com/quick_start/pricing/"
+});
+const CATALOG_UPDATED_AT = "2026-08-23T00:00:00.000Z";
+const TIME_BAND_V1_FROM = "2026-08-16T16:00:00.000Z";
+const WEEKDAY_SCHEDULE_FROM = "2026-08-22T16:00:00.000Z";
+const SHANGHAI_TIME_BANDS = Object.freeze([
+	Object.freeze(["09:00", "12:00"]),
+	Object.freeze(["14:00", "18:00"])
+]);
+const BUCKET_COMPONENTS = Object.freeze([
+	Object.freeze(["inputTokens", "input"]),
+	Object.freeze(["cacheReadTokens", "cacheRead"]),
+	Object.freeze(["cacheWriteTokens", "cacheWrite"]),
+	Object.freeze(["outputTokens", "output"])
+]);
+const WEEKDAY_NUMBER = Object.freeze({ Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 });
+
+function exactModel(model) {
+	return Object.freeze({ type: "exact", model });
+}
+
+function unitPrices({ input, cacheRead, cacheWrite = null, output }) {
+	return Object.freeze({ input, cacheRead, cacheWrite, output });
+}
+
+function flatRule({ id, model, effectiveFrom = null, effectiveTo = null, prices }) {
+	return Object.freeze({
+		id,
+		providerFamily: "deepseek",
+		pricingFamily: "deepseek",
+		modelMatcher: exactModel(model),
+		effectiveFrom,
+		effectiveTo,
+		pricing: Object.freeze({ flat: unitPrices(prices) }),
+		currency: "USD",
+		schedule: null,
+		source: DEEPSEEK_PRICE_SOURCE,
+		updatedAt: CATALOG_UPDATED_AT
+	});
+}
+
+function timeBandRule({ id, model, effectiveFrom, effectiveTo = null, peakDays, offPeak, peak }) {
+	return Object.freeze({
+		id,
+		providerFamily: "deepseek",
+		pricingFamily: "deepseek",
+		modelMatcher: exactModel(model),
+		effectiveFrom,
+		effectiveTo,
+		pricing: Object.freeze({
+			offPeak: unitPrices(offPeak),
+			peak: unitPrices(peak)
+		}),
+		currency: "USD",
+		schedule: Object.freeze({
+			timezone: "Asia/Shanghai",
+			peakDays: Object.freeze([...peakDays]),
+			peakWindows: SHANGHAI_TIME_BANDS,
+			otherwise: "offPeak"
+		}),
+		source: DEEPSEEK_PRICE_SOURCE,
+		updatedAt: CATALOG_UPDATED_AT
+	});
+}
+
+/** Immutable first-party DeepSeek USD rule catalog (prices per 1M tokens). */
+export const DEEPSEEK_PRICING_RULES = Object.freeze([
+	flatRule({
+		id: "deepseek-v4-flash-usd-flat-before-2026-08-16",
+		model: "deepseek-v4-flash",
+		effectiveTo: TIME_BAND_V1_FROM,
+		prices: { cacheRead: 0.0028, input: 0.14, output: 0.28 }
+	}),
+	flatRule({
+		id: "deepseek-v4-pro-usd-flat-before-2026-08-16",
+		model: "deepseek-v4-pro",
+		effectiveTo: TIME_BAND_V1_FROM,
+		prices: { cacheRead: 0.003625, input: 0.435, output: 0.87 }
+	}),
+	timeBandRule({
+		id: "deepseek-v4-flash-usd-time-band-v1",
+		model: "deepseek-v4-flash",
+		effectiveFrom: TIME_BAND_V1_FROM,
+		effectiveTo: WEEKDAY_SCHEDULE_FROM,
+		peakDays: [0, 1, 2, 3, 4, 5, 6],
+		offPeak: { cacheRead: 0.007, input: 0.22, output: 0.66 },
+		peak: { cacheRead: 0.014, input: 0.44, output: 1.32 }
+	}),
+	timeBandRule({
+		id: "deepseek-v4-pro-usd-time-band-v1",
+		model: "deepseek-v4-pro",
+		effectiveFrom: TIME_BAND_V1_FROM,
+		effectiveTo: WEEKDAY_SCHEDULE_FROM,
+		peakDays: [0, 1, 2, 3, 4, 5, 6],
+		offPeak: { cacheRead: 0.022, input: 0.66, output: 1.98 },
+		peak: { cacheRead: 0.044, input: 1.32, output: 3.96 }
+	}),
+	timeBandRule({
+		id: "deepseek-v4-flash-usd-weekday-schedule",
+		model: "deepseek-v4-flash",
+		effectiveFrom: WEEKDAY_SCHEDULE_FROM,
+		peakDays: [1, 2, 3, 4, 5],
+		offPeak: { cacheRead: 0.007, input: 0.22, output: 0.66 },
+		peak: { cacheRead: 0.014, input: 0.44, output: 1.32 }
+	}),
+	timeBandRule({
+		id: "deepseek-v4-pro-usd-weekday-schedule",
+		model: "deepseek-v4-pro",
+		effectiveFrom: WEEKDAY_SCHEDULE_FROM,
+		peakDays: [1, 2, 3, 4, 5],
+		offPeak: { cacheRead: 0.022, input: 0.66, output: 1.98 },
+		peak: { cacheRead: 0.044, input: 1.32, output: 3.96 }
+	})
+]);
+
+/** Alias reserved for future additive provider catalogs. */
+export const PRICING_RULES = DEEPSEEK_PRICING_RULES;
+
+function nonEmptyString(value) {
+	return typeof value === "string" && value.trim() !== "" ? value.trim() : null;
+}
+
+function timestampOf(value) {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (value instanceof Date) {
+		const timestamp = value.getTime();
+		return Number.isFinite(timestamp) ? timestamp : null;
+	}
+	if (typeof value === "string" && value.trim() !== "") {
+		const normalized = value.trim();
+		// Date.parse() interprets offset-less date-times in the machine's local
+		// timezone. Pricing timestamps must name an instant so recomputation is
+		// deterministic across hosts.
+		if (!/(?:Z|[+-]\d{2}:\d{2})$/i.test(normalized)) return null;
+		const timestamp = Date.parse(normalized);
+		return Number.isFinite(timestamp) ? timestamp : null;
+	}
+	return null;
+}
+
+function boundaryOf(value, fallback) {
+	if (value === null || value === void 0) return fallback;
+	const timestamp = timestampOf(value);
+	if (timestamp === null) throw new Error(`invalid pricing effective boundary: ${String(value)}`);
+	return timestamp;
+}
+
+function minuteOf(clock) {
+	const match = /^(\d{2}):(\d{2})$/.exec(clock);
+	if (match === null) return null;
+	const hour = Number(match[1]);
+	const minute = Number(match[2]);
+	if (!Number.isInteger(hour) || hour < 0 || hour > 23 || !Number.isInteger(minute) || minute < 0 || minute > 59) return null;
+	return hour * 60 + minute;
+}
+
+function validateUnitPrices(prices, label) {
+	if (prices === null || typeof prices !== "object" || Array.isArray(prices)) throw new Error(`${label} must be an object`);
+	for (const component of ["input", "cacheRead", "cacheWrite", "output"]) {
+		if (!Object.hasOwn(prices, component)) throw new Error(`${label}.${component} is required`);
+		const value = prices[component];
+		if (value !== null && (typeof value !== "number" || !Number.isFinite(value) || value < 0)) {
+			throw new Error(`${label}.${component} must be a non-negative number or null`);
+		}
+	}
+}
+
+function validateSchedule(schedule, label) {
+	if (schedule === null || typeof schedule !== "object" || Array.isArray(schedule)) throw new Error(`${label} must be an object`);
+	if (nonEmptyString(schedule.timezone) === null) throw new Error(`${label}.timezone is required`);
+	try {
+		new Intl.DateTimeFormat("en-US", { timeZone: schedule.timezone }).format(0);
+	} catch {
+		throw new Error(`${label}.timezone is invalid`);
+	}
+	if (!Array.isArray(schedule.peakDays) || schedule.peakDays.length === 0) throw new Error(`${label}.peakDays must be non-empty`);
+	const days = new Set();
+	for (const day of schedule.peakDays) {
+		if (!Number.isInteger(day) || day < 0 || day > 6 || days.has(day)) throw new Error(`${label}.peakDays must contain unique integers from 0 to 6`);
+		days.add(day);
+	}
+	if (!Array.isArray(schedule.peakWindows) || schedule.peakWindows.length === 0) throw new Error(`${label}.peakWindows must be non-empty`);
+	for (const [index, window] of schedule.peakWindows.entries()) {
+		if (!Array.isArray(window) || window.length !== 2) throw new Error(`${label}.peakWindows[${index}] must be [start, end]`);
+		const start = minuteOf(window[0]);
+		const end = minuteOf(window[1]);
+		if (start === null || end === null || start >= end) throw new Error(`${label}.peakWindows[${index}] must be a non-empty same-day half-open interval`);
+	}
+	if (schedule.otherwise !== "offPeak") throw new Error(`${label}.otherwise must be offPeak`);
+}
+
+function pricingKey(rule) {
+	return JSON.stringify([rule.providerFamily, rule.pricingFamily, rule.modelMatcher.model, rule.currency]);
+}
+
+/**
+ * Validate rule shape and reject overlapping effective windows for one exact
+ * provider/pricing/model/currency key. Invalid catalogs are programmer errors.
+ */
+export function validatePricingRules(rules) {
+	if (!Array.isArray(rules) || rules.length === 0) throw new Error("pricing rules must be a non-empty array");
+	const ids = new Set();
+	const intervals = new Map();
+	for (const [index, rule] of rules.entries()) {
+		const label = `pricingRules[${index}]`;
+		if (rule === null || typeof rule !== "object" || Array.isArray(rule)) throw new Error(`${label} must be an object`);
+		if (nonEmptyString(rule.id) === null || ids.has(rule.id)) throw new Error(`${label}.id must be unique and non-empty`);
+		ids.add(rule.id);
+		if (nonEmptyString(rule.providerFamily) === null || nonEmptyString(rule.pricingFamily) === null) throw new Error(`${label} provider/pricing family is required`);
+		if (rule.modelMatcher?.type !== "exact" || nonEmptyString(rule.modelMatcher?.model) === null) throw new Error(`${label}.modelMatcher must be an exact model identity`);
+		if (typeof rule.currency !== "string" || !/^[A-Z]{3}$/.test(rule.currency)) throw new Error(`${label}.currency must be an uppercase ISO-style code`);
+		const from = boundaryOf(rule.effectiveFrom, -Infinity);
+		const to = boundaryOf(rule.effectiveTo, Infinity);
+		if (from >= to) throw new Error(`${label} effectiveFrom must be earlier than effectiveTo`);
+		if (timestampOf(rule.updatedAt) === null) throw new Error(`${label}.updatedAt must be a timestamp`);
+		if (rule.source?.kind !== "official" || nonEmptyString(rule.source?.provider) === null) throw new Error(`${label}.source must identify an official provider`);
+		try {
+			const sourceURL = new URL(rule.source.url);
+			if (sourceURL.protocol !== "https:") throw new Error("not HTTPS");
+		} catch {
+			throw new Error(`${label}.source.url must be HTTPS`);
+		}
+		const pricingKeys = Object.keys(rule.pricing ?? {}).sort();
+		if (rule.schedule === null) {
+			if (pricingKeys.join(",") !== "flat") throw new Error(`${label}.pricing must contain only flat without a schedule`);
+			validateUnitPrices(rule.pricing.flat, `${label}.pricing.flat`);
+		} else {
+			validateSchedule(rule.schedule, `${label}.schedule`);
+			if (pricingKeys.join(",") !== "offPeak,peak") throw new Error(`${label}.pricing must contain peak and offPeak with a schedule`);
+			validateUnitPrices(rule.pricing.peak, `${label}.pricing.peak`);
+			validateUnitPrices(rule.pricing.offPeak, `${label}.pricing.offPeak`);
+		}
+		const key = pricingKey(rule);
+		const previous = intervals.get(key) ?? [];
+		for (const interval of previous) {
+			if (Math.max(from, interval.from) < Math.min(to, interval.to)) {
+				throw new Error(`overlapping pricing rules for ${key}: ${interval.id} and ${rule.id}`);
+			}
+		}
+		previous.push({ id: rule.id, from, to });
+		intervals.set(key, previous);
+	}
+	return rules;
+}
+
+function ensureValidatedRules(rules) {
+	// The immutable built-in catalog is validated once at module load. Custom
+	// catalogs stay fail-fast without imposing repeated schema work on PR5's
+	// future per-sample estimation path.
+	if (rules !== PRICING_RULES) validatePricingRules(rules);
+}
+
+function isEffective(rule, timestamp) {
+	return timestamp >= boundaryOf(rule.effectiveFrom, -Infinity)
+		&& timestamp < boundaryOf(rule.effectiveTo, Infinity);
+}
+
+function hostnameOf(baseURL) {
+	if (nonEmptyString(baseURL) === null) return null;
+	try {
+		return new URL(baseURL).hostname.toLowerCase().replace(/\.$/, "");
+	} catch {
+		return null;
+	}
+}
+
+function isOfficialDeepSeekIdentity(identity) {
+	if (identity?.providerFamily !== "deepseek" || identity?.pricingFamily !== "deepseek") return false;
+	// An exact official billing host remains authoritative even when an explicit
+	// account monitor caused the shared resolver's confidence to be `explicit`.
+	if (hostnameOf(identity.baseURL) === "api.deepseek.com") return true;
+	if (identity.confidence === "canonical-id" && (identity.routeId === "deepseek" || identity.routeId === "deepseek-official")) return true;
+	return false;
+}
+
+function isEligibleIdentity(identity, rule) {
+	if (identity?.providerFamily !== rule.providerFamily || identity?.pricingFamily !== rule.pricingFamily) return false;
+	if (rule.providerFamily === "deepseek" && rule.pricingFamily === "deepseek") return isOfficialDeepSeekIdentity(identity);
+	return false;
+}
+
+/** Match one exact historical rule, or null when the route/model/currency is unpriced. */
+export function matchPricingRule({ identity, model, timestamp, currency }, rules = PRICING_RULES) {
+	ensureValidatedRules(rules);
+	const at = timestampOf(timestamp);
+	if (at === null || nonEmptyString(model) === null || typeof currency !== "string") return null;
+	const matches = rules.filter((rule) => (
+		isEligibleIdentity(identity, rule)
+		&& rule.modelMatcher.model === model
+		&& rule.currency === currency
+		&& isEffective(rule, at)
+	));
+	if (matches.length > 1) throw new Error(`ambiguous pricing rules at ${new Date(at).toISOString()}: ${matches.map((rule) => rule.id).join(", ")}`);
+	return matches[0] ?? null;
+}
+
+function zonedClock(timestamp, timezone) {
+	const parts = Object.fromEntries(new Intl.DateTimeFormat("en-US", {
+		timeZone: timezone,
+		weekday: "short",
+		hour: "2-digit",
+		minute: "2-digit",
+		hourCycle: "h23"
+	}).formatToParts(new Date(timestamp)).filter((part) => part.type !== "literal").map((part) => [part.type, part.value]));
+	return {
+		weekday: WEEKDAY_NUMBER[parts.weekday],
+		minute: Number(parts.hour) * 60 + Number(parts.minute)
+	};
+}
+
+function tariffForSchedule(schedule, timestamp) {
+	const clock = zonedClock(timestamp, schedule.timezone);
+	if (!schedule.peakDays.includes(clock.weekday)) return schedule.otherwise;
+	return schedule.peakWindows.some(([start, end]) => clock.minute >= minuteOf(start) && clock.minute < minuteOf(end))
+		? "peak"
+		: schedule.otherwise;
+}
+
+function resolveUnitPricingUnchecked(rule, timestamp) {
+	if (!isEffective(rule, timestamp)) return null;
+	const tariff = rule.schedule === null ? "flat" : tariffForSchedule(rule.schedule, timestamp);
+	return { tariff, unitPricing: { ...rule.pricing[tariff] } };
+}
+
+/** Resolve the applicable tariff and per-million unit prices for one rule. */
+export function resolveUnitPricing(rule, timestamp) {
+	validatePricingRules([rule]);
+	const at = timestampOf(timestamp);
+	return at === null ? null : resolveUnitPricingUnchecked(rule, at);
+}
+
+function normalizedBuckets(buckets) {
+	if (buckets === null || typeof buckets !== "object" || Array.isArray(buckets)) return null;
+	const normalized = {};
+	for (const [bucket] of BUCKET_COMPONENTS) {
+		const value = buckets[bucket];
+		if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null;
+		normalized[bucket] = value;
+	}
+	return normalized;
+}
+
+/**
+ * Estimate cost without rounding. Unknown route/model/currency or a positive
+ * bucket with no reliable unit price makes the whole estimate unknown (null).
+ */
+export function estimateTokenCost(input, rules = PRICING_RULES) {
+	if (input === null || typeof input !== "object") return null;
+	const at = timestampOf(input.timestamp);
+	const buckets = normalizedBuckets(input.buckets);
+	if (at === null || buckets === null) return null;
+	const rule = matchPricingRule(input, rules);
+	if (rule === null) return null;
+	const resolved = resolveUnitPricingUnchecked(rule, at);
+	if (resolved === null) return null;
+	const components = {};
+	for (const [bucket, component] of BUCKET_COMPONENTS) {
+		const tokens = buckets[bucket];
+		const price = resolved.unitPricing[component];
+		if (tokens > 0 && price === null) return null;
+		components[component] = tokens === 0 ? 0 : tokens / TOKENS_PER_MILLION * price;
+	}
+	return {
+		amount: components.input + components.cacheRead + components.cacheWrite + components.output,
+		currency: rule.currency,
+		components,
+		tariff: resolved.tariff,
+		ruleId: rule.id,
+		source: { ...rule.source },
+		updatedAt: rule.updatedAt
+	};
+}
+
+validatePricingRules(PRICING_RULES);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "exports": {
     ".": "./lib/index.js",
     "./client": "./lib/client.js",
+    "./pricing": "./lib/pricing.js",
     "./usage": "./lib/usage.js",
     "./package.json": "./package.json"
   },
@@ -48,14 +49,15 @@
     }
   },
   "scripts": {
-    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/network.js && node --check lib/provider-identity.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/accounts.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-overlay-layering.mjs && node --check scripts/test-bundle.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-provider-identity.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/test-accounts.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
-    "test": "npm run test:bundle && npm run test:client && npm run test:overlay && npm run test:server && npm run test:provider-identity && npm run test:balance && npm run test:subscriptions && npm run test:accounts && npm run test:install",
+    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/pricing.js && node --check lib/network.js && node --check lib/provider-identity.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/accounts.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-overlay-layering.mjs && node --check scripts/test-bundle.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-provider-identity.mjs && node --check scripts/test-pricing.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/test-accounts.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
+    "test": "npm run test:bundle && npm run test:client && npm run test:overlay && npm run test:server && npm run test:provider-identity && npm run test:pricing && npm run test:balance && npm run test:subscriptions && npm run test:accounts && npm run test:install",
     "test:bundle": "node scripts/test-bundle.mjs",
     "test:client": "node scripts/smoke-client.mjs",
     "test:overlay": "node scripts/test-overlay-layering.mjs",
     "test:install": "node scripts/test-install.mjs",
     "test:server": "node scripts/test-server.mjs",
     "test:provider-identity": "node scripts/test-provider-identity.mjs",
+    "test:pricing": "node scripts/test-pricing.mjs",
     "test:balance": "node scripts/test-balance.mjs",
     "test:subscriptions": "node scripts/test-subscriptions.mjs",
     "test:accounts": "node scripts/test-accounts.mjs",

--- a/scripts/test-pricing.mjs
+++ b/scripts/test-pricing.mjs
@@ -24,7 +24,13 @@ function tokenBuckets(overrides = {}) {
 }
 
 const official = resolveProviderIdentity(provider("deepseek-official", "https://api.deepseek.com"));
-const canonical = resolveProviderIdentity(provider("deepseek", "https://relay.invalid/v1"));
+const canonicalOfficialHost = resolveProviderIdentity(provider("deepseek", "https://api.deepseek.com"));
+const officialPath = resolveProviderIdentity(provider("deepseek-official", "https://api.deepseek.com/anthropic"));
+const canonicalCustomRelay = resolveProviderIdentity(provider("deepseek", "https://relay.invalid/v1"));
+const officialCustomRelay = resolveProviderIdentity(provider("deepseek-official", "https://relay.invalid/v1"));
+const malformedCanonical = resolveProviderIdentity(provider("deepseek", "not-a-url"));
+const canonicalWithoutBaseURL = resolveProviderIdentity(provider("deepseek"));
+const arbitraryWithoutBaseURL = resolveProviderIdentity(provider("arbitrary-route"));
 const officialHost = resolveProviderIdentity(provider("direct-deepseek", "https://api.deepseek.com/v1"));
 const openrouter = resolveProviderIdentity(provider("openrouter", "https://openrouter.ai/api/v1"));
 const customRelay = resolveProviderIdentity(provider("relay-a", "https://relay.example.com/v1", "DeepSeek"));
@@ -143,7 +149,13 @@ console.log("DeepSeek pricing catalog validates ok");
 
 {
 	assert.notEqual(estimate({ identity: official, model: "deepseek-v4-pro" }), null, "official DeepSeek route is priced");
-	assert.notEqual(estimate({ identity: canonical, model: "deepseek-v4-pro" }), null, "canonical DeepSeek route id is priced");
+	assert.notEqual(estimate({ identity: canonicalOfficialHost, model: "deepseek-v4-pro" }), null, "canonical DeepSeek id on api.deepseek.com is priced");
+	assert.notEqual(estimate({ identity: officialPath, model: "deepseek-v4-pro" }), null, "official DeepSeek path on api.deepseek.com is priced");
+	assert.equal(estimate({ identity: canonicalCustomRelay, model: "deepseek-v4-pro" }), null, "canonical DeepSeek id must not override a custom relay");
+	assert.equal(estimate({ identity: officialCustomRelay, model: "deepseek-v4-pro" }), null, "deepseek-official id must not override a custom relay");
+	assert.equal(estimate({ identity: malformedCanonical, model: "deepseek-v4-pro" }), null, "canonical DeepSeek id with a malformed explicit baseURL is unpriced");
+	assert.notEqual(estimate({ identity: canonicalWithoutBaseURL, model: "deepseek-v4-pro" }), null, "canonical DeepSeek id without a baseURL remains priced");
+	assert.equal(estimate({ identity: arbitraryWithoutBaseURL, model: "deepseek-v4-pro" }), null, "arbitrary route without a baseURL is unpriced");
 	assert.notEqual(estimate({ identity: officialHost, model: "deepseek-v4-pro" }), null, "resolver-confirmed api.deepseek.com route is priced");
 	const explicitOfficialHost = resolveProviderIdentity(provider("deepseek-official", "https://api.deepseek.com"), {
 		monitors: { "deepseek-official": { adapter: "deepseek-balance" } }

--- a/scripts/test-pricing.mjs
+++ b/scripts/test-pricing.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+
+import { resolveProviderIdentity } from "../lib/provider-identity.js";
+import {
+	DEEPSEEK_PRICING_RULES,
+	estimateTokenCost,
+	matchPricingRule,
+	resolveUnitPricing,
+	validatePricingRules
+} from "../lib/pricing.js";
+
+function provider(id, baseURL, displayName = id) {
+	return { id, displayName, ...(baseURL === void 0 ? {} : { baseURL }) };
+}
+
+function tokenBuckets(overrides = {}) {
+	return {
+		inputTokens: 0,
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+		outputTokens: 0,
+		...overrides
+	};
+}
+
+const official = resolveProviderIdentity(provider("deepseek-official", "https://api.deepseek.com"));
+const canonical = resolveProviderIdentity(provider("deepseek", "https://relay.invalid/v1"));
+const officialHost = resolveProviderIdentity(provider("direct-deepseek", "https://api.deepseek.com/v1"));
+const openrouter = resolveProviderIdentity(provider("openrouter", "https://openrouter.ai/api/v1"));
+const customRelay = resolveProviderIdentity(provider("relay-a", "https://relay.example.com/v1", "DeepSeek"));
+
+function estimate({
+	identity = official,
+	model = "deepseek-v4-flash",
+	timestamp = "2026-08-15T00:00:00.000Z",
+	currency = "USD",
+	buckets = tokenBuckets({ inputTokens: 1_000_000 })
+} = {}, rules = DEEPSEEK_PRICING_RULES) {
+	return estimateTokenCost({ identity, model, timestamp, currency, buckets }, rules);
+}
+
+function tariff(timestamp, model = "deepseek-v4-flash") {
+	return estimate({ timestamp, model }).tariff;
+}
+
+function closeTo(actual, expected, label) {
+	assert.ok(Math.abs(actual - expected) < 1e-12, `${label}: expected ${expected}, got ${actual}`);
+}
+
+assert.equal(validatePricingRules(DEEPSEEK_PRICING_RULES), DEEPSEEK_PRICING_RULES);
+assert.equal(DEEPSEEK_PRICING_RULES.length, 6, "two exact models × three historical phases");
+console.log("DeepSeek pricing catalog validates ok");
+
+{
+	const flash = estimate({ model: "deepseek-v4-flash", timestamp: "2026-08-16T15:59:59.999Z" });
+	const pro = estimate({ model: "deepseek-v4-pro", timestamp: "2026-08-16T15:59:59.999Z" });
+	assert.equal(flash.tariff, "flat");
+	assert.equal(flash.ruleId, "deepseek-v4-flash-usd-flat-before-2026-08-16");
+	assert.equal(flash.amount, 0.14);
+	assert.equal(pro.tariff, "flat");
+	assert.equal(pro.ruleId, "deepseek-v4-pro-usd-flat-before-2026-08-16");
+	assert.equal(pro.amount, 0.435);
+	assert.deepEqual(flash.source, {
+		kind: "official",
+		provider: "deepseek",
+		url: "https://api-docs.deepseek.com/quick_start/pricing/"
+	});
+	assert.equal(flash.updatedAt, "2026-08-23T00:00:00.000Z");
+	console.log("old flat Flash/Pro rules and source metadata ok");
+}
+
+{
+	const before = matchPricingRule({ identity: official, model: "deepseek-v4-flash", timestamp: "2026-08-16T15:59:59.999Z", currency: "USD" });
+	const at = matchPricingRule({ identity: official, model: "deepseek-v4-flash", timestamp: "2026-08-16T16:00:00.000Z", currency: "USD" });
+	assert.equal(before.id, "deepseek-v4-flash-usd-flat-before-2026-08-16");
+	assert.equal(at.id, "deepseek-v4-flash-usd-time-band-v1");
+	assert.equal(tariff("2026-08-17T01:00:00.000Z"), "peak", "Rule B weekday 09:00 Shanghai");
+	assert.equal(tariff("2026-08-17T04:00:00.000Z"), "offPeak", "Rule B weekday 12:00 Shanghai");
+	assert.equal(tariff("2026-08-22T01:00:00.000Z"), "peak", "Rule B weekend peak-clock remains peak");
+	console.log("Rule A/B boundary and time-band-v1 weekend behavior ok");
+}
+
+{
+	const before = matchPricingRule({ identity: official, model: "deepseek-v4-pro", timestamp: "2026-08-22T15:59:59.999Z", currency: "USD" });
+	const at = matchPricingRule({ identity: official, model: "deepseek-v4-pro", timestamp: "2026-08-22T16:00:00.000Z", currency: "USD" });
+	assert.equal(before.id, "deepseek-v4-pro-usd-time-band-v1");
+	assert.equal(at.id, "deepseek-v4-pro-usd-weekday-schedule");
+	assert.equal(tariff("2026-08-24T01:00:00.000Z", "deepseek-v4-pro"), "peak");
+	assert.equal(tariff("2026-08-24T04:00:00.000Z", "deepseek-v4-pro"), "offPeak");
+	assert.equal(tariff("2026-08-29T01:00:00.000Z", "deepseek-v4-pro"), "offPeak", "Rule C Saturday is all off-peak");
+	assert.equal(tariff("2026-08-30T01:00:00.000Z", "deepseek-v4-pro"), "offPeak", "Rule C Sunday is all off-peak");
+	console.log("Rule B/C boundary and weekday-only schedule ok");
+}
+
+{
+	const cases = [
+		["2026-08-24T00:59:59.000Z", "offPeak", "08:59:59"],
+		["2026-08-24T01:00:00.000Z", "peak", "09:00:00"],
+		["2026-08-24T03:59:59.000Z", "peak", "11:59:59"],
+		["2026-08-24T04:00:00.000Z", "offPeak", "12:00:00"],
+		["2026-08-24T05:59:59.000Z", "offPeak", "13:59:59"],
+		["2026-08-24T06:00:00.000Z", "peak", "14:00:00"],
+		["2026-08-24T09:59:59.000Z", "peak", "17:59:59"],
+		["2026-08-24T10:00:00.000Z", "offPeak", "18:00:00"]
+	];
+	for (const [timestamp, expected, clock] of cases) assert.equal(tariff(timestamp), expected, `${clock} Shanghai boundary`);
+	console.log("half-open 09/12/14/18 Shanghai clock boundaries ok");
+}
+
+{
+	const template = DEEPSEEK_PRICING_RULES.find((rule) => rule.id === "deepseek-v4-flash-usd-weekday-schedule");
+	const midnightRule = (peakDays) => ({
+		...template,
+		id: `timezone-regression-${peakDays.join("-")}`,
+		effectiveFrom: null,
+		schedule: {
+			...template.schedule,
+			peakDays,
+			peakWindows: [["00:00", "01:00"]]
+		}
+	});
+	assert.equal(resolveUnitPricing(midnightRule([6]), "2026-08-28T16:30:00.000Z").tariff, "peak", "UTC Friday is Shanghai Saturday");
+	assert.equal(resolveUnitPricing(midnightRule([1]), "2026-08-30T16:30:00.000Z").tariff, "peak", "UTC Sunday is Shanghai Monday");
+	console.log("Asia/Shanghai weekday derivation is independent of UTC/local timezone ok");
+}
+
+{
+	const input = estimate({ buckets: tokenBuckets({ inputTokens: 1_000_000 }) });
+	const cacheRead = estimate({ buckets: tokenBuckets({ cacheReadTokens: 1_000_000 }) });
+	const output = estimate({ buckets: tokenBuckets({ outputTokens: 1_000_000 }) });
+	const combined = estimate({ buckets: tokenBuckets({ inputTokens: 2_000_000, cacheReadTokens: 3_000_000, outputTokens: 500_000 }) });
+	assert.deepEqual(input.components, { input: 0.14, cacheRead: 0, cacheWrite: 0, output: 0 });
+	assert.deepEqual(cacheRead.components, { input: 0, cacheRead: 0.0028, cacheWrite: 0, output: 0 });
+	assert.deepEqual(output.components, { input: 0, cacheRead: 0, cacheWrite: 0, output: 0.28 });
+	closeTo(combined.components.input, 0.28, "combined input");
+	closeTo(combined.components.cacheRead, 0.0084, "combined cache read");
+	closeTo(combined.components.output, 0.14, "combined output");
+	closeTo(combined.amount, 0.4284, "combined amount");
+	assert.equal(estimate({ buckets: tokenBuckets({ cacheWriteTokens: 1 }) }), null, "positive cacheWrite with unknown price invalidates whole estimate");
+	assert.equal(estimate({ buckets: tokenBuckets() }).amount, 0, "a matched rule with zero usage has a known zero amount");
+	console.log("input/cacheRead/output components and cacheWrite fail-closed policy ok");
+}
+
+{
+	assert.notEqual(estimate({ identity: official, model: "deepseek-v4-pro" }), null, "official DeepSeek route is priced");
+	assert.notEqual(estimate({ identity: canonical, model: "deepseek-v4-pro" }), null, "canonical DeepSeek route id is priced");
+	assert.notEqual(estimate({ identity: officialHost, model: "deepseek-v4-pro" }), null, "resolver-confirmed api.deepseek.com route is priced");
+	const explicitOfficialHost = resolveProviderIdentity(provider("deepseek-official", "https://api.deepseek.com"), {
+		monitors: { "deepseek-official": { adapter: "deepseek-balance" } }
+	});
+	assert.notEqual(estimate({ identity: explicitOfficialHost, model: "deepseek-v4-pro" }), null, "an explicit official adapter on api.deepseek.com remains eligible");
+	assert.equal(estimate({ identity: openrouter, model: "deepseek-v4-pro" }), null, "OpenRouter must not inherit DeepSeek official pricing");
+	assert.equal(estimate({ identity: customRelay, model: "deepseek-v4-pro" }), null, "custom relay must remain unpriced");
+	const explicitGateway = resolveProviderIdentity(provider("deepseek-official", "https://api.deepseek.com"), {
+		monitors: { "deepseek-official": { adapter: "new-api" } }
+	});
+	assert.equal(estimate({ identity: explicitGateway, model: "deepseek-v4-pro" }), null, "explicit gateway identity must override canonical id pricing");
+	console.log("official-route eligibility and cross-provider isolation ok");
+}
+
+{
+	for (const model of [
+		"unknown-model",
+		"deepseek-v4-flash-anything",
+		"deepseek-v4-flash-vision-exp",
+		"z-ai/glm-5",
+		"z-ai/glm-5.2"
+	]) assert.equal(estimate({ model }), null, `${model} must remain unpriced without an exact rule`);
+	assert.equal(estimate({ currency: "CNY" }), null);
+	assert.equal(estimate({ currency: "usd" }), null);
+	assert.equal(estimate({ timestamp: "not-a-date" }), null);
+	assert.equal(estimate({ timestamp: "2026-08-24T09:00:00" }), null, "offset-less timestamps must not depend on the machine timezone");
+	assert.equal(estimate({ buckets: { inputTokens: 1, outputTokens: 0, cacheReadTokens: 0 } }), null, "missing bucket data must not be undercounted");
+	console.log("unknown model/currency/timestamp/buckets fail closed to null ok");
+}
+
+{
+	const template = DEEPSEEK_PRICING_RULES[0];
+	const exactRule = { ...template, id: "exact-zai-model", modelMatcher: { type: "exact", model: "z-ai/glm-5" } };
+	assert.notEqual(matchPricingRule({ identity: official, model: "z-ai/glm-5", timestamp: "2026-08-01T00:00:00Z", currency: "USD" }, [exactRule]), null);
+	assert.equal(matchPricingRule({ identity: official, model: "z-ai/glm-5.2", timestamp: "2026-08-01T00:00:00Z", currency: "USD" }, [exactRule]), null);
+	assert.throws(() => validatePricingRules([{ ...exactRule, modelMatcher: { type: "prefix", model: "z-ai/glm-5" } }]), /exact model identity/);
+	assert.throws(() => validatePricingRules([template, { ...template, id: "overlapping-rule" }]), /overlapping pricing rules/);
+	assert.throws(() => validatePricingRules([{ ...template, effectiveFrom: "2026-08-01T00:00:00" }]), /invalid pricing effective boundary/);
+	console.log("exact matcher and ambiguous-rule validation ok");
+}
+
+{
+	const template = DEEPSEEK_PRICING_RULES[0];
+	const freeRule = {
+		...template,
+		id: "explicit-free-rule",
+		pricing: { flat: { input: 0, cacheRead: 0, cacheWrite: 0, output: 0 } }
+	};
+	assert.equal(estimate({ buckets: tokenBuckets({ inputTokens: 123, cacheWriteTokens: 456 }) }, [freeRule]).amount, 0, "an explicit zero price may produce zero cost");
+	const first = estimate({ model: "deepseek-v4-pro", timestamp: "2026-08-24T01:30:00Z", buckets: tokenBuckets({ inputTokens: 123456, cacheReadTokens: 654321, outputTokens: 111111 }) });
+	const second = estimate({ model: "deepseek-v4-pro", timestamp: "2026-08-24T01:30:00Z", buckets: tokenBuckets({ inputTokens: 123456, cacheReadTokens: 654321, outputTokens: 111111 }) });
+	assert.deepEqual(second, first, "historical recomputation must be deterministic");
+	console.log("explicit free pricing and deterministic recomputation ok");
+}
+
+console.log("PRICING ENGINE TESTS PASSED");


### PR DESCRIPTION
Closes #62
Reference #65

Depends on:
#60 / #66
#18 / #68
#61 / #69

## Summary

- Add a pure, deterministic, provider-aware historical pricing engine.
- Ship exact DeepSeek official USD rules for the old-flat, time-band v1, and weekday-schedule phases.
- Enforce exact model matching, official-route eligibility, explicit currency, provenance, and fail-closed unknown pricing.
- Cover effective boundaries, Asia/Shanghai peak windows, provider isolation, cacheWrite safety, and deterministic recomputation.

## Scope

Pricing is derived data.
No cost UI.
No budget.
No token ledger.
No pricing network fetch.
No version bump.

## Validation

- npm run check
- npm test
- npm pack --json
- pricing suite under TZ=UTC and TZ=America/Los_Angeles

This PR intentionally remains Draft.