### PR TITLE
fix: make account refresh controls effective

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Provider balances, subscription quotas, and token-usage analytics for the DeepSe
 | --- | --- | --- |
 | 💳 | 统一账户卡片 | API 供应商显示余额，Token Plan 显示分窗口额度；面板一次只呈现当前供应商 |
 | 📊 | Token 用量分析 | 今日、本月、累计、缓存命中率、月历热图，以及按日期/供应商/模型下钻 |
-| 🔄 | 后台监测 | 服务端启动即刷新，之后每五分钟更新全部已配置账户与本地 Token 聚合 |
+| 🔄 | 后台监测 | 账户按 active/detail/background 自适应刷新；间隔可配置或完全关闭，本地 Token 聚合保持独立运行 |
 | 🧩 | 可扩展适配器 | 支持 New API、Sub2API、通用余额模板，以及声明式 JSON Pointer 自定义查询 |
 | 🔒 | 本机安全边界 | 五个端点仅接受回环 GET；凭据只在服务端解析并发往校验后的供应商地址 |
 
-界面支持中文和英文。浏览器只请求当前选择的 provider；后台刷新与面板是否打开无关。手动刷新会更新用量、供应商列表，并强制刷新当前账户，不会批量强制请求其他供应商。
+界面支持中文和英文。浏览器只请求当前选择的 provider；账户自动刷新由服务端统一调度。手动刷新会更新用量、供应商列表，并强制刷新当前账户，不会批量强制请求其他供应商。
 
 ## 快速安装 / Quick start
 
@@ -109,6 +109,27 @@ npx --yes github:Ychris12138/dsh-usage-stats --no-enable
 ## 凭据与供应商配置 / Configuration
 
 凭据由 Harness 从 `~/.dsh/.credentials.yaml` 解析。安装器不会读取、创建或修改该文件。不要把真实 Key、Cookie 或管理令牌提交到 Git、公开 issue，或粘贴给编码 Agent。
+
+### 账户刷新 / Account refresh
+
+默认刷新间隔是 active 1 分钟、detail 2 分钟、background 15 分钟。严格限流的 New API 或公司中转可以调整全局策略，或完全关闭账户自动刷新：
+
+```yaml
+# ~/.dsh/profiles/web/cordis.patch.yml
+- insert:
+    - id: usage-stats
+      name: "@ychris12138/dsh-usage-stats"
+      config:
+        refresh:
+          enabled: false
+          activeMs: 60000
+          detailMs: 120000
+          backgroundMs: 900000
+```
+
+三个间隔必须是 `60000` 至 `86400000` 毫秒之间的整数。需要停止时使用 `refresh.enabled: false`，不要填写超大的 timeout。关闭后，每个相同 provider 配置仍允许首次查询；之后普通面板读取只返回缓存，不会因缓存过期访问上游。账户端点的 `refresh=1`（Retry）仍可显式刷新，provider/monitor 配置变化后也会为新配置重新查询一次。
+
+旧配置 `disableBackgroundRefresh: true` 继续等价于 `refresh.enabled: false`；两者同时存在时，显式的 `refresh.enabled` 优先。该开关只关闭账户上游自动刷新，不会关闭本地 Token 用量聚合。
 
 ### 余额型供应商
 

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -22,10 +22,17 @@ export { isPrivateAddress } from "./network.js";
 
 const DEFAULT_TIMEOUT_MS = 15000;
 const DEFAULT_REFRESH_MS = 300000;
-const DEFAULT_REFRESH_POLICY = Object.freeze({
+const MAX_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_REFRESH_CONFIG = Object.freeze({
+	enabled: true,
 	activeMs: 60000,
 	detailMs: 120000,
-	backgroundMs: 900000,
+	backgroundMs: 900000
+});
+const DEFAULT_REFRESH_POLICY = Object.freeze({
+	activeMs: DEFAULT_REFRESH_CONFIG.activeMs,
+	detailMs: DEFAULT_REFRESH_CONFIG.detailMs,
+	backgroundMs: DEFAULT_REFRESH_CONFIG.backgroundMs,
 	rateLimitBaseMs: 300000,
 	rateLimitMaxMs: 3600000
 });
@@ -166,10 +173,12 @@ export function refreshPolicy(state, now = Date.now(), overrides = {}) {
 		: null;
 	const priority = activity === "active" ? 3 : activity === "detail" ? 2 : 1;
 	if (lastAttemptAt === null) return { activity, priority, delayMs: 0, nextRefreshAt: now };
-	let delayMs = activity === "active" ? intervals.activeMs : activity === "detail" ? intervals.detailMs : intervals.backgroundMs;
+	const normalDelayMs = activity === "active" ? intervals.activeMs : activity === "detail" ? intervals.detailMs : intervals.backgroundMs;
+	let delayMs = normalDelayMs;
 	if ((Number(state?.rateLimitFailures) || 0) > 0) {
 		const failures = Math.max(1, Math.floor(Number(state.rateLimitFailures) || 1));
-		delayMs = Math.min(intervals.rateLimitMaxMs, intervals.rateLimitBaseMs * 2 ** Math.min(20, failures - 1));
+		const backoffDelayMs = Math.min(intervals.rateLimitMaxMs, intervals.rateLimitBaseMs * 2 ** Math.min(20, failures - 1));
+		delayMs = Math.max(normalDelayMs, backoffDelayMs);
 	}
 	return { activity, priority, delayMs, nextRefreshAt: lastAttemptAt + delayMs };
 }
@@ -338,9 +347,34 @@ function validateDeclarative(monitor, label) {
 	if (monitor.extract.divisor !== void 0 && (numberOrNull(monitor.extract.divisor) === null || Number(monitor.extract.divisor) === 0)) throw new Error(`${label}.extract.divisor must be a non-zero number`);
 }
 
+function validateRefreshInterval(value, label, fallback) {
+	if (value === void 0) return fallback;
+	if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value)
+		|| value < 60000 || value > MAX_REFRESH_INTERVAL_MS) {
+		throw new Error(`${label} must be an integer from 60000 to ${MAX_REFRESH_INTERVAL_MS} ms`);
+	}
+	return value;
+}
+
+function validateRefreshConfig(raw, disableBackgroundRefresh) {
+	if (raw === void 0) raw = {};
+	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) throw new Error("refresh must be an object");
+	if (disableBackgroundRefresh !== void 0 && typeof disableBackgroundRefresh !== "boolean") {
+		throw new Error("disableBackgroundRefresh must be a boolean");
+	}
+	if (raw.enabled !== void 0 && typeof raw.enabled !== "boolean") throw new Error("refresh.enabled must be a boolean");
+	return {
+		enabled: raw.enabled ?? (disableBackgroundRefresh === true ? false : DEFAULT_REFRESH_CONFIG.enabled),
+		activeMs: validateRefreshInterval(raw.activeMs, "refresh.activeMs", DEFAULT_REFRESH_CONFIG.activeMs),
+		detailMs: validateRefreshInterval(raw.detailMs, "refresh.detailMs", DEFAULT_REFRESH_CONFIG.detailMs),
+		backgroundMs: validateRefreshInterval(raw.backgroundMs, "refresh.backgroundMs", DEFAULT_REFRESH_CONFIG.backgroundMs)
+	};
+}
+
 /** Validate and freeze the non-secret account-monitor configuration shape. */
 export function validateAccountConfig(raw = {}) {
 	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) throw new Error("account config must be an object");
+	const refresh = validateRefreshConfig(raw.refresh, raw.disableBackgroundRefresh);
 	const monitors = raw.monitors ?? {};
 	if (monitors === null || typeof monitors !== "object" || Array.isArray(monitors)) throw new Error("monitors must be an object keyed by provider id");
 	const normalized = {};
@@ -360,7 +394,7 @@ export function validateAccountConfig(raw = {}) {
 		if (adapter === "declarative") validateDeclarative(value, label);
 		normalized[providerId] = { ...value, providerId, adapter };
 	}
-	return { monitors: normalized };
+	return { monitors: normalized, refresh };
 }
 
 /** Bind one configured Harness provider to its explicit or built-in adapter. */
@@ -1224,7 +1258,12 @@ export function createAccountService({ credentials, getProviders, config = { mon
 	const inflight = new Map();
 	const refreshGenerations = new Map();
 	const now = deps.now ?? Date.now;
+	const refreshConfig = { ...DEFAULT_REFRESH_CONFIG, ...(config.refresh ?? {}) };
+	const autoRefreshEnabled = refreshConfig.enabled !== false;
 	const policyOverrides = {
+		activeMs: refreshConfig.activeMs,
+		detailMs: refreshConfig.detailMs,
+		backgroundMs: refreshConfig.backgroundMs,
 		...(deps.refreshMs === void 0 ? {} : { backgroundMs: deps.refreshMs }),
 		...(deps.refreshPolicy ?? {})
 	};
@@ -1363,7 +1402,8 @@ export function createAccountService({ credentials, getProviders, config = { mon
 		if (activity !== null) touch(providerId, activity);
 		const hit = cache.get(providerId);
 		const at = now();
-		if (!force && hit?.configKey === spec.configKey && policyOf(spec, at).nextRefreshAt > at) return withHealthAge(hit.account, at);
+		if (!force && hit?.configKey === spec.configKey
+			&& (!autoRefreshEnabled || policyOf(spec, at).nextRefreshAt > at)) return withHealthAge(hit.account, at);
 		return refresh(spec);
 	}
 
@@ -1386,6 +1426,7 @@ export function createAccountService({ credentials, getProviders, config = { mon
 	}
 
 	async function refreshDue({ force = false } = {}) {
+		if (!autoRefreshEnabled && !force) return [];
 		const at = now();
 		const all = await refreshableSpecs();
 		const due = force ? all : all.filter((spec) => policyOf(spec, at).nextRefreshAt <= at);
@@ -1393,6 +1434,7 @@ export function createAccountService({ credentials, getProviders, config = { mon
 	}
 
 	async function nextRefreshAt() {
+		if (!autoRefreshEnabled) return null;
 		const at = now();
 		const all = await refreshableSpecs();
 		if (all.length === 0) return null;

--- a/lib/index.js
+++ b/lib/index.js
@@ -620,7 +620,7 @@ async function handleSubscriptions(ctx, accounts, req, res) {
 	}
 }
 
-/** One adaptive account scheduler plus the existing five-minute usage fold. */
+/** Existing five-minute usage fold plus an optional adaptive account scheduler. */
 export function startBackgroundRefresh(ctx, accounts, deps = {}) {
 	let running = false;
 	let stopped = false;
@@ -633,6 +633,7 @@ export function startBackgroundRefresh(ctx, accounts, deps = {}) {
 	const setTimer = deps.setTimeout ?? setTimeout;
 	const clearTimer = deps.clearTimeout ?? clearTimeout;
 	const config = deps.config ?? { monitors: {} };
+	const accountRefreshEnabled = deps.accountRefreshEnabled !== false;
 
 	const clearScheduled = () => {
 		if (timer === null) return;
@@ -645,10 +646,12 @@ export function startBackgroundRefresh(ctx, accounts, deps = {}) {
 		const generation = ++scheduleGeneration;
 		clearScheduled();
 		let accountNext = null;
-		try {
-			accountNext = await accounts.nextRefreshAt();
-		} catch (error) {
-			ctx.logger.warn(`usage-stats: refresh scheduling failed: ${String(error)}`);
+		if (accountRefreshEnabled) {
+			try {
+				accountNext = await accounts.nextRefreshAt();
+			} catch (error) {
+				ctx.logger.warn(`usage-stats: refresh scheduling failed: ${String(error)}`);
+			}
 		}
 		if (stopped || generation !== scheduleGeneration) return;
 		const target = Math.min(accountNext ?? Infinity, nextUsageAt);
@@ -672,16 +675,19 @@ export function startBackgroundRefresh(ctx, accounts, deps = {}) {
 			const at = now();
 			if (force || at >= nextUsageAt) {
 				try {
-					accounts.setActiveProviders(await collectActiveAccountIds(ctx, config));
+					if (accountRefreshEnabled) accounts.setActiveProviders(await collectActiveAccountIds(ctx, config));
+					else await collectUsage(ctx);
 				} catch (error) {
 					ctx.logger.warn(`usage-stats: background usage refresh failed: ${String(error)}`);
 				}
 				nextUsageAt = now() + usageIntervalMs;
 			}
-			try {
-				await accounts.refreshDue({ force });
-			} catch (error) {
-				ctx.logger.warn(`usage-stats: background account refresh failed: ${String(error)}`);
+			if (accountRefreshEnabled) {
+				try {
+					await accounts.refreshDue({ force });
+				} catch (error) {
+					ctx.logger.warn(`usage-stats: background account refresh failed: ${String(error)}`);
+				}
 			}
 		})().finally(() => {
 			running = false;
@@ -689,11 +695,14 @@ export function startBackgroundRefresh(ctx, accounts, deps = {}) {
 		await active;
 		await schedule();
 	};
-	const unsubscribePolicyChanges = accounts.subscribePolicyChanges?.(() => {
-		// Activity changes only rearm this one central timer. The service remains
-		// responsible for deciding whether an upstream refresh is actually due.
-		if (!stopped && !running) void schedule();
-	}) ?? (() => {});
+	let unsubscribePolicyChanges = () => {};
+	if (accountRefreshEnabled) {
+		unsubscribePolicyChanges = accounts.subscribePolicyChanges?.(() => {
+			// Activity changes only rearm this one central timer. The service remains
+			// responsible for deciding whether an upstream refresh is actually due.
+			if (!stopped && !running) void schedule();
+		}) ?? unsubscribePolicyChanges;
+	}
 	const ready = run();
 	const stop = async () => {
 		stopped = true;
@@ -766,7 +775,10 @@ async function apply(ctx, rawConfig = {}, deps = {}) {
 		path: SESSION_CONTEXT_PATH,
 		handler: (req, res) => handleSessionContext(ctx, config, accounts, req, res)
 	}), "usage-stats: session context route");
-	if (deps.disableBackgroundRefresh !== true) ctx.effect(() => startBackgroundRefresh(ctx, accounts, { config }), "usage-stats: background account refresh");
+	if (deps.disableBackgroundRefresh !== true) ctx.effect(() => startBackgroundRefresh(ctx, accounts, {
+		config,
+		accountRefreshEnabled: config.refresh.enabled
+	}), "usage-stats: background usage/account refresh");
 }
 
 export { apply, Config, inject, name, USAGE_PATH, PROVIDERS_PATH, BALANCE_PATH, SUBSCRIPTIONS_PATH, ACCOUNT_PATH, SESSION_CONTEXT_PATH, configuredProviders, totalTokens, zeroBuckets };

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -80,21 +80,59 @@ const deepseek = {
 }
 
 {
+	assert.deepEqual(validateAccountConfig().refresh, {
+		enabled: true,
+		activeMs: 60000,
+		detailMs: 120000,
+		backgroundMs: 900000
+	});
+	assert.equal(validateAccountConfig({ disableBackgroundRefresh: true }).refresh.enabled, false, "the legacy disable alias must remain effective");
+	assert.equal(validateAccountConfig({ disableBackgroundRefresh: true, refresh: { enabled: true } }).refresh.enabled, true, "explicit refresh.enabled must override the legacy alias");
+	assert.deepEqual(validateAccountConfig({ refresh: { activeMs: 120000, detailMs: 180000, backgroundMs: 240000 } }).refresh, {
+		enabled: true,
+		activeMs: 120000,
+		detailMs: 180000,
+		backgroundMs: 240000
+	});
+	for (const invalid of [
+		{ refresh: null },
+		{ refresh: { enabled: "false" } },
+		{ refresh: { activeMs: 59999 } },
+		{ refresh: { detailMs: 60000.5 } },
+		{ refresh: { backgroundMs: Infinity } },
+		{ refresh: { backgroundMs: 86400001 } },
+		{ disableBackgroundRefresh: "true" }
+	]) assert.throws(() => validateAccountConfig(invalid), /refresh|disableBackgroundRefresh/);
+	console.log("public refresh config defaults, precedence, and bounds ok");
+}
+
+{
 	const active = refreshPolicy({ activity: "active", status: "ok", rateLimitFailures: 0, lastAttemptAt: now }, now);
 	const detail = refreshPolicy({ activity: "detail", status: "ok", rateLimitFailures: 0, lastAttemptAt: now }, now);
 	const background = refreshPolicy({ activity: "background", status: "ok", rateLimitFailures: 0, lastAttemptAt: now }, now);
-	assert.ok(active.nextRefreshAt < background.nextRefreshAt, "active providers must refresh sooner than background providers");
-	assert.ok(detail.nextRefreshAt < background.nextRefreshAt, "detail providers must refresh sooner than background providers");
+	assert.equal(active.delayMs, 60000);
+	assert.equal(detail.delayMs, 120000);
+	assert.equal(background.delayMs, 900000);
 	const first429 = refreshPolicy({ activity: "active", status: "rate-limited", rateLimitFailures: 1, lastAttemptAt: now }, now);
 	const second429 = refreshPolicy({ activity: "active", status: "rate-limited", rateLimitFailures: 2, lastAttemptAt: now }, now);
+	const third429 = refreshPolicy({ activity: "active", status: "rate-limited", rateLimitFailures: 3, lastAttemptAt: now }, now);
+	const fourth429 = refreshPolicy({ activity: "active", status: "rate-limited", rateLimitFailures: 4, lastAttemptAt: now }, now);
+	const fifth429 = refreshPolicy({ activity: "active", status: "rate-limited", rateLimitFailures: 5, lastAttemptAt: now }, now);
 	const failedRetry = refreshPolicy({ activity: "active", status: "unavailable", rateLimitFailures: 2, lastAttemptAt: now }, now);
 	const bounded429 = refreshPolicy({ activity: "active", status: "rate-limited", rateLimitFailures: 99, lastAttemptAt: now }, now);
-	assert.ok(first429.nextRefreshAt > active.nextRefreshAt, "429 must override the fast activity interval");
-	assert.ok(second429.nextRefreshAt > first429.nextRefreshAt, "consecutive 429 responses must increase backoff");
+	assert.equal(first429.delayMs, 300000);
+	assert.equal(second429.delayMs, 600000);
+	assert.equal(third429.delayMs, 1200000);
+	assert.equal(fourth429.delayMs, 2400000);
+	assert.equal(fifth429.delayMs, 3600000);
 	assert.equal(failedRetry.nextRefreshAt, second429.nextRefreshAt, "a non-success retry must preserve the existing rate-limit backoff");
-	assert.ok(bounded429.nextRefreshAt - now <= 3600000, "429 backoff must remain bounded");
+	assert.equal(bounded429.delayMs, 3600000, "429 backoff must remain bounded");
+	assert.equal(refreshPolicy({ activity: "detail", rateLimitFailures: 1, lastAttemptAt: now }, now).delayMs, 300000);
+	assert.equal(refreshPolicy({ activity: "background", rateLimitFailures: 1, lastAttemptAt: now }, now).delayMs, 900000, "429 must not shorten the normal background interval");
+	assert.equal(refreshPolicy({ activity: "active", rateLimitFailures: 1, lastAttemptAt: now }, now, { activeMs: 1800000 }).delayMs, 1800000, "429 must not shorten a custom normal interval");
+	assert.equal(refreshPolicy({ activity: "active", rateLimitFailures: 0, lastAttemptAt: now }, now).delayMs, 60000, "success/reset state must restore the normal interval");
 	assert.equal(refreshPolicy({ activity: "background", status: "pending", rateLimitFailures: 0, lastAttemptAt: null }, now).nextRefreshAt, now);
-	console.log("adaptive refresh policy and bounded 429 backoff ok");
+	console.log("adaptive refresh defaults and monotonic 429 backoff ok");
 }
 
 {
@@ -1024,6 +1062,106 @@ console.log("IPv4/IPv6 private-address classification ok");
 }
 
 {
+	let calls = 0;
+	const service = createAccountService({
+		credentials: credentials({ RELAY_A_KEY: "sk-relay" }),
+		getProviders: async () => [relay],
+		config: validateAccountConfig({
+			refresh: { activeMs: 120000, detailMs: 180000, backgroundMs: 240000 },
+			monitors: { "relay-a": { adapter: "general" } }
+		}),
+		deps: {
+			includeLegacyProviders: false,
+			now: () => now,
+			fetch: async () => {
+				calls += 1;
+				return jsonResponse({ balance: 42, currency: "USD" });
+			}
+		}
+	});
+	await service.get("relay-a");
+	assert.equal(await service.nextRefreshAt(), now + 240000, "production config must override the background interval");
+	service.touch("relay-a", "detail");
+	assert.equal(await service.nextRefreshAt(), now + 180000, "production config must override the detail interval");
+	service.touch("relay-a", "active");
+	assert.equal(await service.nextRefreshAt(), now + 120000, "production config must override the active interval");
+	assert.equal(calls, 1);
+	console.log("normalized refresh intervals reach AccountService policy ok");
+}
+
+{
+	let clock = now;
+	let calls = 0;
+	let provider = { ...relay };
+	const requested = [];
+	const service = createAccountService({
+		credentials: credentials({ RELAY_A_KEY: "sk-relay" }),
+		getProviders: async () => [provider],
+		config: validateAccountConfig({
+			refresh: { enabled: false },
+			monitors: { "relay-a": { adapter: "general" } }
+		}),
+		deps: {
+			includeLegacyProviders: false,
+			now: () => clock,
+			fetch: async (url) => {
+				calls += 1;
+				requested.push(String(url));
+				return jsonResponse({ balance: calls, currency: "USD" });
+			}
+		}
+	});
+	const first = await service.get("relay-a");
+	assert.equal(first.balance.remaining, 1, "disabled mode must allow one initial fetch when no cache exists");
+	clock += 7 * 86400000;
+	const cached = await service.get("relay-a");
+	assert.equal(cached.balance.remaining, 1);
+	assert.equal(calls, 1, "disabled mode must keep returning the same-config cache regardless of age");
+	assert.deepEqual(await service.refreshDue(), [], "disabled mode must not perform non-force due refreshes");
+	assert.equal(await service.nextRefreshAt(), null, "disabled mode has no adaptive account-refresh deadline");
+	const forced = await service.get("relay-a", { force: true });
+	assert.equal(forced.balance.remaining, 2, "force=true must remain an explicit refresh escape hatch");
+	provider = { ...provider, baseURL: "https://replacement.example.com/v1" };
+	const rebound = await service.get("relay-a");
+	assert.equal(rebound.balance.remaining, 3, "a changed configKey must fetch once instead of reusing disabled-mode cache");
+	await service.get("relay-a");
+	assert.equal(calls, 3, "the replacement config must then become the stable disabled-mode cache");
+	assert.deepEqual(requested, [
+		"https://relay.example.com/user/balance",
+		"https://relay.example.com/user/balance",
+		"https://replacement.example.com/user/balance"
+	]);
+	console.log("disabled refresh first-fetch, cache, force, and config-change semantics ok");
+}
+
+{
+	let clock = now;
+	let calls = 0;
+	const service = createAccountService({
+		credentials: credentials({ RELAY_A_KEY: "sk-relay" }),
+		getProviders: async () => [relay],
+		config: validateAccountConfig({
+			refresh: { backgroundMs: 60000 },
+			monitors: { "relay-a": { adapter: "general" } }
+		}),
+		deps: {
+			includeLegacyProviders: false,
+			now: () => clock,
+			fetch: async () => {
+				calls += 1;
+				return jsonResponse({ balance: calls, currency: "USD" });
+			}
+		}
+	});
+	await service.get("relay-a");
+	clock += 60000;
+	const refreshed = await service.get("relay-a");
+	assert.equal(refreshed.balance.remaining, 2);
+	assert.equal(calls, 2, "enabled mode must preserve automatic cache-expiry refreshes");
+	console.log("enabled refresh cache expiry behavior ok");
+}
+
+{
 	let phase = "ok";
 	let clock = now;
 	const service = createAccountService({
@@ -1084,17 +1222,17 @@ console.log("IPv4/IPv6 private-address classification ok");
 	assert.equal(limited.balance.remaining, 8);
 	assert.equal(limited.lastSuccessAt, successfulAt);
 	assert.equal(limited.reason, "rate-limited");
-	assert.equal(await service.nextRefreshAt(), clock + 300000, "the first 429 must schedule bounded backoff");
+	assert.equal(await service.nextRefreshAt(), clock + 900000, "the first 429 must not shorten the normal background interval");
 	clock += 300000;
 	const limitedAgain = await service.get("relay-a", { force: true });
 	assert.equal(limitedAgain.status, "rate-limited");
-	assert.equal(await service.nextRefreshAt(), clock + 600000, "consecutive 429 responses must increase backoff per provider");
+	assert.equal(await service.nextRefreshAt(), clock + 900000, "backoff below the normal interval must retain the normal background delay");
 	phase = "transient";
 	clock += 1000;
 	const failedRetry = await service.get("relay-a", { force: true });
 	assert.equal(failedRetry.status, "unavailable");
 	assert.equal(failedRetry.stale, true);
-	assert.equal(await service.nextRefreshAt(), clock + 600000, "a failed retry must not clear rate-limit backoff before recovery");
+	assert.equal(await service.nextRefreshAt(), clock + 900000, "a failed retry must not clear rate-limit backoff before recovery");
 	phase = "auth";
 	clock += 1000;
 	const unauthorized = await service.get("relay-a", { force: true });

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -235,7 +235,14 @@ async function testV3CacheUpgradeRefoldsCurrentRoute(root) {
 
 async function testConfigValidation(root) {
 	const plugin = await freshModule("config", join(root, "config"));
-	assert.deepEqual(plugin.Config["~standard"].validate({ monitors: {} }).issues, void 0);
+	const validated = plugin.Config["~standard"].validate({
+		refresh: { enabled: false, activeMs: 120000, detailMs: 180000, backgroundMs: 240000 },
+		monitors: {}
+	});
+	assert.deepEqual(validated.issues, void 0);
+	assert.deepEqual(validated.value.refresh, { enabled: false, activeMs: 120000, detailMs: 180000, backgroundMs: 240000 });
+	assert.equal(plugin.Config["~standard"].validate({ disableBackgroundRefresh: true }).value.refresh.enabled, false);
+	assert.match(plugin.Config["~standard"].validate({ refresh: { activeMs: 1 } }).issues[0].message, /refresh\.activeMs/);
 	assert.match(plugin.Config["~standard"].validate({ monitors: { relay: { adapter: "missing" } } }).issues[0].message, /adapter is unsupported/);
 	const routes = new Map();
 	const context = makeContext({
@@ -340,6 +347,43 @@ async function testBackgroundRefresh(root) {
 	assert.equal(unsubscribed, true, "scheduler cleanup must unsubscribe from AccountService policy changes");
 }
 
+async function testDisabledAccountRefresh(root) {
+	const home = join(root, "refresh-disabled");
+	const plugin = await freshModule("refresh-disabled", home);
+	const routes = new Map();
+	let adaptiveCalls = 0;
+	const accounts = {
+		validate: async () => {},
+		nextRefreshAt: async () => { adaptiveCalls += 1; throw new Error("disabled account scheduler must not request a deadline"); },
+		refreshDue: async () => { adaptiveCalls += 1; throw new Error("disabled account scheduler must not refresh accounts"); },
+		setActiveProviders: () => { adaptiveCalls += 1; },
+		subscribePolicyChanges: () => { adaptiveCalls += 1; return () => {}; },
+		providerViews: async () => [],
+		get: async () => null,
+		subscriptionAccounts: async () => []
+	};
+	const cleanups = [];
+	const ctx = makeContext({
+		sessions: { list: () => [] },
+		persistence: { listSnapshots: async () => [], list: async () => [] },
+		routes,
+		settings: { get: () => void 0 }
+	});
+	ctx.effect = (register) => {
+		const cleanup = register();
+		if (typeof cleanup === "function") cleanups.push(cleanup);
+		return cleanup;
+	};
+	await plugin.apply(ctx, { refresh: { enabled: false } }, { accounts });
+	const schedulerCleanup = cleanups.find((cleanup) => cleanup.ready instanceof Promise);
+	assert.notEqual(schedulerCleanup, void 0, "usage aggregation lifecycle must remain registered when account refresh is disabled");
+	await schedulerCleanup.ready;
+	assert.equal(adaptiveCalls, 0, "disabled mode must not start the adaptive account scheduler");
+	const cache = JSON.parse(await readFile(join(home, "storages", "usage-stats-cache.json"), "utf8"));
+	assert.equal(cache.version, 4, "the surviving usage lifecycle must still fold and persist usage");
+	await schedulerCleanup();
+}
+
 async function testPersistedToLive(root) {
 	const plugin = await freshModule("transition", join(root, "transition"));
 	const id = "transition-session";
@@ -430,6 +474,7 @@ try {
 	await testConfigValidation(root);
 	await testLegacyZaiSubscriptionId(root);
 	await testBackgroundRefresh(root);
+	await testDisabledAccountRefresh(root);
 	await testPersistedToLive(root);
 	await testRevisionRewrite(root);
 	await testLiveLogShrink(root);


### PR DESCRIPTION
Closes #72
Reference #65

Follow-up to #61 / #69.

## Summary

- Normalize public account refresh controls with safe defaults and bounded intervals.
- Make refresh.enabled=false stop automatic upstream account requests while preserving usage aggregation and explicit Retry.
- Ensure production AccountService uses configured active/detail/background intervals.
- Make 429 backoff monotonic with the normal refresh interval.

## Scope

No pricing changes.
No cost/budget work.
No per-provider refresh overrides.
No version bump.

## Validation

- npm run check
- npm test
- npm pack --json
- Standards review: PASS
- Spec review: PASS

This PR intentionally remains Draft.