### PR TITLE
fix: respect New API balance currency

### DIFF
--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -758,17 +758,56 @@ async function queryGeneral(spec, credential, deps, now) {
 	return { ...baseSnapshot(spec, "ok", now), balance, alert: balanceAlert(balance, spec.monitor.warning) };
 }
 
-async function quotaPerUnit(spec, deps) {
+const LEGACY_NEW_API_QUOTA_PER_UNIT = 500000;
+
+function legacyNewApiQuotaStatus() {
+	return {
+		quotaPerUnit: LEGACY_NEW_API_QUOTA_PER_UNIT,
+		quotaUnitFallback: true,
+		displayType: "USD",
+		usdExchangeRate: 1
+	};
+}
+
+function normalizeNewApiQuotaStatus(body) {
+	const rawUnit = numberOrNull(body?.data?.quota_per_unit);
+	const quotaUnitFallback = rawUnit === null || rawUnit <= 0;
+	const quotaPerUnit = quotaUnitFallback ? LEGACY_NEW_API_QUOTA_PER_UNIT : rawUnit;
+	const rawDisplayType = body?.data?.quota_display_type;
+	let displayType = "USD";
+	if (rawDisplayType !== void 0 && rawDisplayType !== null && rawDisplayType !== "") {
+		const normalized = nonEmptyString(rawDisplayType);
+		if (normalized === null) throw statusError("invalid-response", "New API quota display type is invalid");
+		displayType = normalized.toUpperCase();
+	}
+	if (displayType === "USD") {
+		return { quotaPerUnit, quotaUnitFallback, displayType, usdExchangeRate: 1 };
+	}
+	if (displayType === "CNY") {
+		const usdExchangeRate = numberOrNull(body?.data?.usd_exchange_rate);
+		if (usdExchangeRate === null || usdExchangeRate <= 0) {
+			throw statusError("invalid-response", "New API CNY display requires a positive USD exchange rate");
+		}
+		return { quotaPerUnit, quotaUnitFallback, displayType, usdExchangeRate };
+	}
+	throw statusError("unsupported", "New API quota display type is unsupported");
+}
+
+async function queryNewApiQuotaStatus(spec, deps) {
 	try {
 		const body = await requestJson(new URL("/api/status", spec.baseURL).href, { headers: { accept: "application/json" } }, deps);
-		const value = numberOrNull(body?.data?.quota_per_unit);
-		if (value !== null && value > 0) return { value, fallback: false };
-		// Old status schemas did not expose quota_per_unit.
-		return { value: 500000, fallback: true };
+		return normalizeNewApiQuotaStatus(body);
 	} catch (error) {
-		if (error?.httpStatus === 404 || error?.httpStatus === 405) return { value: 500000, fallback: true };
+		if (error?.httpStatus === 404 || error?.httpStatus === 405) return legacyNewApiQuotaStatus();
 		throw error;
 	}
+}
+
+function newApiQuotaAmount(value, quotaStatus) {
+	const rawQuota = numberOrNull(value);
+	// New API raw quota first converts to USD, then to the configured display
+	// currency. Both account paths share this exact factor for every component.
+	return rawQuota === null ? null : rawQuota / quotaStatus.quotaPerUnit * quotaStatus.usdExchangeRate;
 }
 
 async function queryNewApiFallback(spec, credentials, deps, now) {
@@ -778,19 +817,20 @@ async function queryNewApiFallback(spec, credentials, deps, now) {
 	const headers = { authorization: `Bearer ${token}`, accept: "application/json" };
 	const userId = await resolveCredential(credentials, spec.monitor.fallbackUserIdRef);
 	if (userId !== "") headers["new-api-user"] = userId;
-	const [body, quotaUnit] = await Promise.all([
+	const [body, quotaStatus] = await Promise.all([
 		requestJson(new URL("/api/user/self", spec.baseURL).href, { headers }, deps),
-		quotaPerUnit(spec, deps)
+		queryNewApiQuotaStatus(spec, deps)
 	]);
-	const unit = quotaUnit.value;
 	if (body?.success === false || body?.data === null || typeof body?.data !== "object") throw statusError("invalid-response", "New API user response is invalid");
 	const remainingQuota = numberOrNull(body.data.quota);
 	const usedQuota = numberOrNull(body.data.used_quota);
-	if (remainingQuota === null) throw statusError("invalid-response", "New API user response is missing quota");
+	const remaining = newApiQuotaAmount(remainingQuota, quotaStatus);
+	const used = newApiQuotaAmount(usedQuota, quotaStatus);
+	if (remaining === null) throw statusError("invalid-response", "New API user response is missing quota");
 	const balance = {
-		remaining: remainingQuota / unit,
-		...(usedQuota === null ? {} : { used: usedQuota / unit, total: (remainingQuota + usedQuota) / unit }),
-		currency: "USD",
+		remaining,
+		...(used === null ? {} : { used, total: newApiQuotaAmount(remainingQuota + usedQuota, quotaStatus) }),
+		currency: quotaStatus.displayType,
 		unlimited: false,
 		expiresAt: null
 	};
@@ -800,8 +840,8 @@ async function queryNewApiFallback(spec, credentials, deps, now) {
 		balance,
 		alert: balanceAlert(balance, spec.monitor.warning),
 		source: "management-fallback",
-		quotaUnit: unit,
-		quotaUnitFallback: quotaUnit.fallback
+		quotaUnit: quotaStatus.quotaPerUnit,
+		quotaUnitFallback: quotaStatus.quotaUnitFallback
 	};
 }
 
@@ -819,15 +859,14 @@ async function queryNewApi(spec, credentials, credential, deps, now) {
 	const granted = numberOrNull(body.data.total_granted);
 	const used = numberOrNull(body.data.total_used);
 	const available = numberOrNull(body.data.total_available);
-	const quotaUnit = await quotaPerUnit(spec, deps);
-	const unit = quotaUnit.value;
+	const quotaStatus = await queryNewApiQuotaStatus(spec, deps);
 	const unlimited = booleanOrNull(body.data.unlimited_quota) === true;
 	if (!unlimited && available === null) throw statusError("invalid-response", "New API token response is missing total_available");
 	const balance = {
-		remaining: available === null ? null : available / unit,
-		...(used === null ? {} : { used: used / unit }),
-		...(granted === null ? {} : { total: granted / unit }),
-		currency: "USD",
+		remaining: newApiQuotaAmount(available, quotaStatus),
+		...(used === null ? {} : { used: newApiQuotaAmount(used, quotaStatus) }),
+		...(granted === null ? {} : { total: newApiQuotaAmount(granted, quotaStatus) }),
+		currency: quotaStatus.displayType,
 		unlimited,
 		expiresAt: numberOrNull(body.data.expires_at) > 0 ? toIso(body.data.expires_at) : null
 	};
@@ -837,8 +876,8 @@ async function queryNewApi(spec, credentials, credential, deps, now) {
 		balance,
 		alert: unlimited ? { level: "normal", metric: "remaining-percent", value: 100 } : balanceAlert(balance, spec.monitor.warning),
 		source: "token",
-		quotaUnit: unit,
-		quotaUnitFallback: quotaUnit.fallback
+		quotaUnit: quotaStatus.quotaPerUnit,
+		quotaUnitFallback: quotaStatus.quotaUnitFallback
 	};
 }
 

--- a/scripts/test-accounts.mjs
+++ b/scripts/test-accounts.mjs
@@ -26,6 +26,10 @@ function jsonResponse(value, status = 200, headers = {}) {
 	});
 }
 
+function closeTo(actual, expected, label) {
+	assert.ok(Math.abs(actual - expected) < 1e-12, `${label}: expected ${expected}, got ${actual}`);
+}
+
 /** Build a fake provider-status error the way lib/accounts.js statusError() does. */
 function statusErrorFromTest(status, message) {
 	const error = new Error(message);
@@ -189,7 +193,7 @@ console.log("IPv4/IPv6 private-address classification ok");
 		now: () => now,
 		fetch: async (url, init) => {
 			calls.push({ url: String(url), init });
-			if (String(url).endsWith("/api/status")) return jsonResponse({ data: { quota_per_unit: 500000 } });
+			if (String(url).endsWith("/api/status")) return jsonResponse({ data: { quota_per_unit: 500000, quota_display_type: "USD", usd_exchange_rate: 6.73 } });
 			return jsonResponse({ code: true, data: {
 				total_granted: 1500000,
 				total_used: 500000,
@@ -212,6 +216,111 @@ console.log("IPv4/IPv6 private-address classification ok");
 	assert.equal(calls[0].init.headers.authorization, "Bearer sk-relay");
 	assert.equal(JSON.stringify(account).includes("sk-relay"), false);
 	console.log("New API token-scoped normalization ok");
+}
+
+{
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "new-api" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async (url) => String(url).endsWith("/api/status")
+			? jsonResponse({ data: { quota_per_unit: 500000, quota_display_type: "CNY", usd_exchange_rate: 7 } })
+			: jsonResponse({ code: true, data: {
+				total_granted: 7500000,
+				total_used: 2500000,
+				total_available: 5000000,
+				unlimited_quota: false
+			} })
+	});
+	assert.deepEqual(account.balance, {
+		remaining: 70,
+		used: 35,
+		total: 105,
+		currency: "CNY",
+		unlimited: false,
+		expiresAt: null
+	});
+	console.log("New API token route converts every CNY balance component ok");
+}
+
+{
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "new-api" }
+	} }));
+	for (const statusCode of [404, 405]) {
+		const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+			now: () => now,
+			fetch: async (url) => String(url).endsWith("/api/status")
+				? jsonResponse({}, statusCode)
+				: jsonResponse({ code: true, data: { total_granted: 5000000, total_used: 0, total_available: 5000000 } })
+		});
+		assert.deepEqual({ remaining: account.balance.remaining, currency: account.balance.currency }, { remaining: 10, currency: "USD" });
+		assert.equal(account.quotaUnit, 500000);
+		assert.equal(account.quotaUnitFallback, true);
+	}
+	const missingStatusFields = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async (url) => String(url).endsWith("/api/status")
+			? jsonResponse({ data: {} })
+			: jsonResponse({ code: true, data: { total_granted: 5000000, total_used: 0, total_available: 5000000 } })
+	});
+	assert.deepEqual({ remaining: missingStatusFields.balance.remaining, currency: missingStatusFields.balance.currency }, { remaining: 10, currency: "USD" });
+	assert.equal(missingStatusFields.quotaUnitFallback, true);
+	console.log("New API legacy status schema and 404/405 retain USD fallback ok");
+}
+
+{
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "new-api" }
+	} }));
+	for (const usdExchangeRate of [void 0, 0, -1, "invalid", Infinity]) {
+		const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+			now: () => now,
+			fetch: async (url) => {
+				if (!String(url).endsWith("/api/status")) return jsonResponse({ code: true, data: { total_granted: 5000000, total_used: 0, total_available: 5000000 } });
+				const statusBody = { data: { quota_per_unit: 500000, quota_display_type: "CNY", usd_exchange_rate: usdExchangeRate } };
+				if (usdExchangeRate !== Infinity) return jsonResponse(statusBody);
+				return { ok: true, status: 200, headers: { get: () => "application/json" }, json: async () => statusBody };
+			}
+		});
+		assert.equal(account.status, "invalid-response", `CNY rate ${String(usdExchangeRate)} must fail closed`);
+		assert.equal(account.balance, null);
+	}
+	console.log("New API explicit CNY with an invalid exchange rate fails closed ok");
+}
+
+{
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "new-api" }
+	} }));
+	for (const quotaDisplayType of ["TOKENS", "CUSTOM"]) {
+		const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+			now: () => now,
+			fetch: async (url) => String(url).endsWith("/api/status")
+				? jsonResponse({ data: { quota_per_unit: 500000, quota_display_type: quotaDisplayType } })
+				: jsonResponse({ code: true, data: { total_granted: 5000000, total_used: 0, total_available: 5000000 } })
+		});
+		assert.equal(account.status, "unsupported");
+		assert.equal(account.balance, null, `${quotaDisplayType} must not enter the ISO currency field`);
+	}
+	console.log("New API TOKENS/CUSTOM display types remain unsupported ok");
+}
+
+{
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": { adapter: "new-api" }
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "sk-relay" }), {
+		now: () => now,
+		fetch: async (url) => String(url).endsWith("/api/status")
+			? jsonResponse({ data: { quota_per_unit: 500000, quota_display_type: "USD" } })
+			: jsonResponse({ code: true, data: { total_granted: 0, total_used: 0, total_available: null, unlimited_quota: true } })
+	});
+	assert.equal(account.status, "ok");
+	assert.deepEqual(account.balance, { remaining: null, used: 0, total: 0, currency: "USD", unlimited: true, expiresAt: null });
+	assert.deepEqual(account.alert, { level: "normal", metric: "remaining-percent", value: 100 });
+	console.log("New API unlimited quota behavior remains intact ok");
 }
 
 {
@@ -423,15 +532,37 @@ console.log("IPv4/IPv6 private-address classification ok");
 		fetch: async (url, init) => {
 			calls.push({ url: String(url), authorization: init.headers.authorization });
 			if (String(url).endsWith("/api/usage/token/")) return jsonResponse({}, 404);
-			if (String(url).endsWith("/api/status")) return jsonResponse({ data: { quota_per_unit: 1000 } });
-			return jsonResponse({ success: true, data: { group: "pro", quota: 8000, used_quota: 2000 } });
+			if (String(url).endsWith("/api/status")) return jsonResponse({ data: { quota_per_unit: 500000, quota_display_type: "CNY", usd_exchange_rate: 6.73 } });
+			return jsonResponse({ success: true, data: { group: "pro", quota: 5000000, used_quota: 2500000 } });
 		}
 	});
 	assert.equal(account.status, "ok");
 	assert.equal(account.plan, "pro");
-	assert.deepEqual(account.balance, { remaining: 8, used: 2, total: 10, currency: "USD", unlimited: false, expiresAt: null });
+	assert.deepEqual({ currency: account.balance.currency, unlimited: account.balance.unlimited, expiresAt: account.balance.expiresAt }, { currency: "CNY", unlimited: false, expiresAt: null });
+	closeTo(account.balance.remaining, 67.3, "management fallback CNY remaining");
+	closeTo(account.balance.used, 33.65, "management fallback CNY used");
+	closeTo(account.balance.total, 100.95, "management fallback CNY total");
 	assert.ok(calls.some((call) => call.url.endsWith("/api/user/self") && call.authorization === "Bearer management-pat"));
-	console.log("New API explicit management fallback ok");
+	console.log("New API management fallback shares non-hardcoded CNY conversion ok");
+}
+
+{
+	const spec = resolveAccountSpec(relay, validateAccountConfig({ monitors: {
+		"relay-a": {
+			adapter: "new-api",
+			fallbackCredentialRef: "RELAY_A_PAT"
+		}
+	} }));
+	const account = await queryAccount(spec, credentials({ RELAY_A_KEY: "inference-key", RELAY_A_PAT: "management-pat" }), {
+		now: () => now,
+		fetch: async (url) => {
+			if (String(url).endsWith("/api/usage/token/") || String(url).endsWith("/api/status")) return jsonResponse({}, 404);
+			return jsonResponse({ success: true, data: { quota: 5000000, used_quota: 0 } });
+		}
+	});
+	assert.deepEqual(account.balance, { remaining: 10, used: 0, total: 10, currency: "USD", unlimited: false, expiresAt: null });
+	assert.equal(account.quotaUnitFallback, true);
+	console.log("New API management fallback retains legacy USD behavior when status is unavailable ok");
 }
 
 {


### PR DESCRIPTION
Closes #71
Reference #65

Follow-up correctness fix for the New API account adapter.

## Summary

- Normalize quota_per_unit, quota_display_type, and usd_exchange_rate from /api/status.
- Apply one shared USD/CNY conversion to remaining, used, and total on both New API account paths.
- Preserve legacy 500000 + USD behavior and fail closed for invalid or unsupported display currencies.

## Scope

No session cost or budget work.
No pricing engine changes.
No FX or currency UI.
No refresh-policy changes.
No version bump.

## Validation

- npm run check
- npm test
- npm pack --json
- Standards review: PASS
- Spec review: PASS

This PR intentionally remains Draft.