### PR TITLE
feat: add current-session billing and budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Provider balances, subscription quotas, and token-usage analytics for the DeepSe
 | --- | --- | --- |
 | 💳 | 统一账户卡片 | API 供应商显示余额，Token Plan 显示分窗口额度；面板一次只呈现当前供应商 |
 | 📊 | Token 用量分析 | 今日、本月、累计、缓存命中率、月历热图，以及按日期/供应商/模型下钻 |
+| 💰 | 估算费用与预算 | 按事件时间匹配历史价格，提供当前会话、日/月与 session 维度费用；可选日/月预算预警 |
 | 🔄 | 后台监测 | 账户按 active/detail/background 自适应刷新；间隔可配置或完全关闭，本地 Token 聚合保持独立运行 |
 | 🧩 | 可扩展适配器 | 支持 New API、Sub2API、通用余额模板，以及声明式 JSON Pointer 自定义查询 |
-| 🔒 | 本机安全边界 | 五个端点仅接受回环 GET；凭据只在服务端解析并发往校验后的供应商地址 |
+| 🔒 | 本机安全边界 | 六个端点仅接受回环 GET；凭据只在服务端解析并发往校验后的供应商地址 |
 
 界面支持中文和英文。浏览器只请求当前选择的 provider；账户自动刷新由服务端统一调度。手动刷新会更新用量、供应商列表，并强制刷新当前账户，不会批量强制请求其他供应商。
 
@@ -130,6 +131,24 @@ npx --yes github:Ychris12138/dsh-usage-stats --no-enable
 三个间隔必须是 `60000` 至 `86400000` 毫秒之间的整数。需要停止时使用 `refresh.enabled: false`，不要填写超大的 timeout。关闭后，每个相同 provider 配置仍允许首次查询；之后普通面板读取只返回缓存，不会因缓存过期访问上游。账户端点的 `refresh=1`（Retry）仍可显式刷新，provider/monitor 配置变化后也会为新配置重新查询一次。
 
 旧配置 `disableBackgroundRefresh: true` 继续等价于 `refresh.enabled: false`；两者同时存在时，显式的 `refresh.enabled` 优先。该开关只关闭账户上游自动刷新，不会关闭本地 Token 用量聚合。
+
+### 估算费用与预算 / Estimated cost and budgets
+
+预算是可选的非敏感配置，默认关闭。金额只在 provider、model、事件时间与货币均能由内置价格规则可靠确定时计算；未知中转、订阅路线、无价格的 cache write 或混合币种会整体显示 `—`，不会展示部分费用或进行汇率换算。
+
+```yaml
+# ~/.dsh/profiles/web/cordis.patch.yml
+- insert:
+    - id: usage-stats
+      name: "@ychris12138/dsh-usage-stats"
+      config:
+        budgets:
+          currency: USD
+          daily: 5
+          monthly: 100
+```
+
+预算使用本机日历日/月边界：低于 80% 为正常，达到 80% 为 warning，达到 100% 为 critical。`daily` / `monthly` 必须是正数或 `null`；当前版本不做 FX 换算，因此预算货币与可靠价格货币不兼容时状态保持 unknown。
 
 ### 余额型供应商
 
@@ -343,14 +362,16 @@ npx --yes github:Ychris12138/dsh-usage-stats --check
 - 自定义 monitor 默认要求 HTTPS、同源相对路径、手动 redirect 和 JSON 响应，body 上限为 1 MiB。
 - 发凭据前会筛选域名的 IPv4/IPv6 解析结果并固定一个允许的连接地址，优先使用公网地址；HTTPS 域名解析到 `198.18.0.0/15` 时可作为 Clash/Mihomo 等代理的 synthetic fake-IP 使用。字面量 `198.18/15`、其他私网/特殊地址仍默认拒绝，防止 DNS rebinding 绕过私网限制。
 - `usageBaseURL` 禁止内嵌 username/password；`Authorization`、`X-API-Key`、`API-Key` 等 header 必须由 credential ref 注入。
-- 五个端点仅接受 GET，并同时校验 peer socket 与 Host；支持 IPv4、IPv4-mapped IPv6 和 `[::1]:port`。
+- 六个端点仅接受 GET，并同时校验 peer socket 与 Host；支持 IPv4、IPv4-mapped IPv6 和 `[::1]:port`。
 - 用量缓存 `~/.dsh/storages/usage-stats-cache.json` 只保存聚合 Token、会话 id、不透明 revision 与折叠游标，不保存提示词、回复或文件路径。
 
 本机反向代理会让插件看到代理自身的回环地址。请勿把端点经反向代理暴露到局域网或公网；确需代理时必须在代理层增加可靠认证与访问控制。安全问题请按 [SECURITY.md](SECURITY.md) 私下报告。
 
 ## 正确性与数据口径 / Correctness
 
-统计值来自 `assistant/chunk` 或 `assistant/message` 中 provider-reported `usage`，不是本地估算。相同 turn/step 的后续样本会替换旧样本，并按 `provider/model` 归集。
+Token 统计值来自 `assistant/chunk` 或 `assistant/message` 中 provider-reported `usage`，不是本地估算。相同 turn/step 的后续样本会替换旧样本，并按 `provider/model` 归集。
+
+费用是明确标注的估算派生值：每个 usage 样本使用自己的事件时间、原始 provider/model 与四类 token bucket 匹配 `lib/pricing.js`；替换样本会先减去旧费用，再加入新费用。绝不会用“当前价格 × 历史累计 Token”。Current Session Pill 使用 DSH 原生 `tokenUsage` projection 触发重读，并只在 projection 与服务端 session buckets 完全一致时显示服务端事件级估算。
 
 - 活跃会话只处理新追加事件。
 - 持久化会话使用不透明 revision；未变化时不重复读取日志。
@@ -362,11 +383,12 @@ npx --yes github:Ychris12138/dsh-usage-stats --check
 
 | Method | Path | Response |
 | --- | --- | --- |
-| `GET` | `/api/usage-stats/usage` | 按日期/provider/model 聚合的 Token 与缓存命中率 |
+| `GET` | `/api/usage-stats/usage` | 按日期/provider/model 聚合的 Token、派生费用、session 明细与日/月预算状态 |
 | `GET` | `/api/usage-stats/providers` | provider 列表、account mode、adapter、状态与预警摘要 |
 | `GET` | `/api/usage-stats/account?provider=<id>` | 当前 provider 的统一余额或 Token Plan 快照；`refresh=1` 强制刷新 |
 | `GET` | `/api/usage-stats/balance?provider=<id>` | `0.1.x` 余额兼容路由 |
 | `GET` | `/api/usage-stats/subscriptions` | `0.1.x` Token Plan 兼容路由 |
+| `GET` | `/api/usage-stats/session-context?session=<id>` | 当前 live session 的 route/model/account 与同一增量 fold 的 session 费用快照 |
 
 非 GET 返回 `405`，非回环请求返回 `403`；所有响应均为 JSON 并带 `Cache-Control: no-cache`。
 

--- a/lib/billing.js
+++ b/lib/billing.js
@@ -39,9 +39,76 @@ export function validateBudgetConfig(raw = {}) {
 	};
 }
 
-/** Exact pricing catalog + identity-policy fingerprint for cached costs. */
-export function pricingFingerprint(rules = PRICING_RULES) {
-	return JSON.stringify({ providerIdentityPolicy: PROVIDER_IDENTITY_POLICY_VERSION, rules });
+function safeBaseURLState(baseURL) {
+	if (typeof baseURL !== "string" || baseURL.trim() === "") return { state: "absent" };
+	try {
+		const hostname = new URL(baseURL).hostname.toLowerCase().replace(/\.$/, "");
+		return hostname === "" ? { state: "malformed" } : { state: "hostname", hostname };
+	} catch {
+		return { state: "malformed" };
+	}
+}
+
+function compareProjection(left, right) {
+	const a = JSON.stringify(left);
+	const b = JSON.stringify(right);
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Secret-free provider facts that can change pricing eligibility. */
+export function providerPricingIdentityProjection(providers = [], config = { monitors: {} }) {
+	return (Array.isArray(providers) ? providers : []).map((provider) => {
+		const identity = resolveProviderIdentity(provider, config);
+		return {
+			routeId: identity.routeId,
+			providerFamily: identity.providerFamily,
+			pricingFamily: identity.pricingFamily,
+			confidence: identity.confidence,
+			baseURL: safeBaseURLState(identity.baseURL)
+		};
+	}).sort(compareProjection);
+}
+
+/** Exact pricing catalog + runtime provider-identity fingerprint for cached costs. */
+export function pricingFingerprint({ providers = [], config = { monitors: {} }, rules = PRICING_RULES } = {}) {
+	return JSON.stringify({
+		schemaVersion: 1,
+		providerIdentityPolicy: PROVIDER_IDENTITY_POLICY_VERSION,
+		providerPricingIdentities: providerPricingIdentityProjection(providers, config),
+		pricingCatalog: rules
+	});
+}
+
+function providerProjectionByRoute(fingerprint) {
+	try {
+		const parsed = JSON.parse(fingerprint);
+		if (parsed?.schemaVersion !== 1 || !Array.isArray(parsed.providerPricingIdentities)) return null;
+		const byRoute = new Map();
+		for (const projection of parsed.providerPricingIdentities) {
+			if (projection === null || typeof projection !== "object" || typeof projection.routeId !== "string") return null;
+			const entries = byRoute.get(projection.routeId) ?? [];
+			entries.push(projection);
+			byRoute.set(projection.routeId, entries);
+		}
+		for (const entries of byRoute.values()) entries.sort(compareProjection);
+		return byRoute;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Changed route ids, or null when an old fingerprint cannot prove its provider
+ * identity. Callers must treat null as a global fail-closed transition.
+ */
+export function changedProviderPricingRoutes(previousFingerprint, nextFingerprint) {
+	const previous = providerProjectionByRoute(previousFingerprint);
+	const next = providerProjectionByRoute(nextFingerprint);
+	if (previous === null || next === null) return null;
+	const routeIds = new Set([...previous.keys(), ...next.keys()]);
+	return [...routeIds].filter((routeId) => (
+		JSON.stringify(previous.get(routeId) ?? []) !== JSON.stringify(next.get(routeId) ?? [])
+	)).sort();
 }
 
 /** Empty additive monetary accumulator. */

--- a/lib/billing.js
+++ b/lib/billing.js
@@ -1,0 +1,252 @@
+/**
+ * Pure billing derivation over provider-reported usage samples.
+ *
+ * Token accounting remains owned by usage.js/DSH. This module only carries
+ * monetary contributions produced by pricing.js, their provenance, and
+ * fail-closed budget state.
+ *
+ * @module dsh-usage-stats/billing
+ */
+
+import { estimateTokenCost, PRICING_RULES } from "./pricing.js";
+import { PROVIDER_IDENTITY_POLICY_VERSION, resolveProviderIdentity } from "./provider-identity.js";
+
+const ISO_CURRENCY = /^[A-Z]{3}$/;
+
+export const DEFAULT_BUDGET_CONFIG = Object.freeze({
+	currency: "USD",
+	daily: null,
+	monthly: null
+});
+
+function optionalLimit(value, label) {
+	if (value === void 0 || value === null) return null;
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+		throw new Error(`${label} must be a positive finite number or null`);
+	}
+	return value;
+}
+
+/** Validate the public, secret-free daily/monthly budget configuration. */
+export function validateBudgetConfig(raw = {}) {
+	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) throw new Error("budgets must be an object");
+	const currency = raw.currency ?? DEFAULT_BUDGET_CONFIG.currency;
+	if (typeof currency !== "string" || !ISO_CURRENCY.test(currency)) throw new Error("budgets.currency must be an uppercase three-letter currency code");
+	return {
+		currency,
+		daily: optionalLimit(raw.daily, "budgets.daily"),
+		monthly: optionalLimit(raw.monthly, "budgets.monthly")
+	};
+}
+
+/** Exact pricing catalog + identity-policy fingerprint for cached costs. */
+export function pricingFingerprint(rules = PRICING_RULES) {
+	return JSON.stringify({ providerIdentityPolicy: PROVIDER_IDENTITY_POLICY_VERSION, rules });
+}
+
+/** Empty additive monetary accumulator. */
+export function createCostAccumulator() {
+	return {
+		pricedSamples: 0,
+		incompleteSamples: 0,
+		currencies: new Map(),
+		rules: new Map()
+	};
+}
+
+function tokenCount(buckets) {
+	if (buckets === null || typeof buckets !== "object") return 0;
+	return ["inputTokens", "outputTokens", "cacheReadTokens", "cacheWriteTokens"]
+		.reduce((sum, key) => sum + (typeof buckets[key] === "number" && Number.isFinite(buckets[key]) && buckets[key] > 0 ? buckets[key] : 0), 0);
+}
+
+function safeSource(source) {
+	if (source === null || typeof source !== "object" || Array.isArray(source)) return null;
+	const kind = typeof source.kind === "string" ? source.kind : null;
+	const provider = typeof source.provider === "string" ? source.provider : null;
+	const url = typeof source.url === "string" ? source.url : null;
+	return kind === null || provider === null || url === null ? null : { kind, provider, url };
+}
+
+/**
+ * Convert one pricing result into an additive contribution. Positive token
+ * usage with no trustworthy estimate is explicitly incomplete.
+ */
+export function costSampleOf(estimate, buckets) {
+	if (tokenCount(buckets) === 0) return { counted: false };
+	if (estimate === null || typeof estimate !== "object"
+		|| typeof estimate.amount !== "number" || !Number.isFinite(estimate.amount) || estimate.amount < 0
+		|| typeof estimate.currency !== "string" || !ISO_CURRENCY.test(estimate.currency)) {
+		return { counted: true, complete: false };
+	}
+	return {
+		counted: true,
+		complete: true,
+		amount: estimate.amount,
+		currency: estimate.currency,
+		ruleId: typeof estimate.ruleId === "string" && estimate.ruleId !== "" ? estimate.ruleId : null,
+		source: safeSource(estimate.source),
+		updatedAt: typeof estimate.updatedAt === "string" ? estimate.updatedAt : null
+	};
+}
+
+function adjustCount(map, key, amount, countDelta) {
+	const previous = map.get(key) ?? { amount: 0, count: 0 };
+	const next = { amount: previous.amount + amount, count: previous.count + countDelta };
+	if (next.count <= 0) map.delete(key);
+	else map.set(key, next);
+}
+
+/** Add (`direction=1`) or subtract (`direction=-1`) one cost contribution. */
+export function applyCostSample(target, sample, direction = 1) {
+	if (sample?.counted !== true) return target;
+	if (direction !== 1 && direction !== -1) throw new Error("cost sample direction must be 1 or -1");
+	if (sample.complete !== true) {
+		target.incompleteSamples = Math.max(0, target.incompleteSamples + direction);
+		return target;
+	}
+	target.pricedSamples = Math.max(0, target.pricedSamples + direction);
+	adjustCount(target.currencies, sample.currency, direction * sample.amount, direction);
+	if (sample.ruleId !== null) {
+		const previous = target.rules.get(sample.ruleId) ?? { count: 0, source: sample.source, updatedAt: sample.updatedAt };
+		const count = previous.count + direction;
+		if (count <= 0) target.rules.delete(sample.ruleId);
+		else target.rules.set(sample.ruleId, {
+			count,
+			source: previous.source ?? sample.source,
+			updatedAt: previous.updatedAt ?? sample.updatedAt
+		});
+	}
+	return target;
+}
+
+/** Merge one complete accumulator into another. */
+export function mergeCostAccumulator(target, source) {
+	target.pricedSamples += source.pricedSamples;
+	target.incompleteSamples += source.incompleteSamples;
+	for (const [currency, entry] of source.currencies) adjustCount(target.currencies, currency, entry.amount, entry.count);
+	for (const [ruleId, entry] of source.rules) {
+		const previous = target.rules.get(ruleId);
+		target.rules.set(ruleId, previous === void 0 ? { ...entry } : {
+			count: previous.count + entry.count,
+			source: previous.source ?? entry.source,
+			updatedAt: previous.updatedAt ?? entry.updatedAt
+		});
+	}
+	return target;
+}
+
+function provenanceOf(accumulator) {
+	const entries = [...accumulator.rules.entries()].filter(([, entry]) => entry.count > 0).sort(([a], [b]) => a.localeCompare(b));
+	const sources = new Map();
+	let updatedAt = null;
+	for (const [, entry] of entries) {
+		if (entry.source !== null) sources.set(JSON.stringify(entry.source), entry.source);
+		if (typeof entry.updatedAt === "string" && (updatedAt === null || entry.updatedAt > updatedAt)) updatedAt = entry.updatedAt;
+	}
+	return {
+		ruleIds: entries.map(([ruleId]) => ruleId),
+		source: sources.size === 1 ? [...sources.values()][0] : null,
+		updatedAt
+	};
+}
+
+/** Render an accumulator; any unpriced sample or mixed currency fails closed. */
+export function renderCost(accumulator) {
+	const sampleCount = accumulator.pricedSamples + accumulator.incompleteSamples;
+	const complete = sampleCount > 0 && accumulator.incompleteSamples === 0 && accumulator.currencies.size === 1;
+	const [currency, currencyEntry] = complete ? [...accumulator.currencies.entries()][0] : [null, null];
+	return {
+		estimatedCost: complete ? currencyEntry.amount : null,
+		currency,
+		costComplete: complete,
+		pricing: provenanceOf(accumulator)
+	};
+}
+
+/** JSON-safe cost accumulator for the incremental cache. */
+export function serializeCostAccumulator(accumulator) {
+	return {
+		pricedSamples: accumulator.pricedSamples,
+		incompleteSamples: accumulator.incompleteSamples,
+		currencies: Object.fromEntries([...accumulator.currencies].map(([currency, entry]) => [currency, { ...entry }])),
+		rules: Object.fromEntries([...accumulator.rules].map(([ruleId, entry]) => [ruleId, { ...entry }]))
+	};
+}
+
+/** Lenient cache restore; invalid fields degrade to an empty/incomplete-safe state. */
+export function parseCostAccumulator(raw) {
+	const accumulator = createCostAccumulator();
+	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return accumulator;
+	accumulator.pricedSamples = Number.isSafeInteger(raw.pricedSamples) && raw.pricedSamples >= 0 ? raw.pricedSamples : 0;
+	accumulator.incompleteSamples = Number.isSafeInteger(raw.incompleteSamples) && raw.incompleteSamples >= 0 ? raw.incompleteSamples : 0;
+	for (const [currency, entry] of Object.entries(raw.currencies ?? {})) {
+		if (!ISO_CURRENCY.test(currency) || entry === null || typeof entry !== "object"
+			|| typeof entry.amount !== "number" || !Number.isFinite(entry.amount)
+			|| !Number.isSafeInteger(entry.count) || entry.count <= 0) continue;
+		accumulator.currencies.set(currency, { amount: entry.amount, count: entry.count });
+	}
+	for (const [ruleId, entry] of Object.entries(raw.rules ?? {})) {
+		if (ruleId === "" || entry === null || typeof entry !== "object" || !Number.isSafeInteger(entry.count) || entry.count <= 0) continue;
+		accumulator.rules.set(ruleId, {
+			count: entry.count,
+			source: safeSource(entry.source),
+			updatedAt: typeof entry.updatedAt === "string" ? entry.updatedAt : null
+		});
+	}
+	return accumulator;
+}
+
+/** Build the only provider-aware bridge from session route identity to pricing.js. */
+export function createUsageCostEstimator(providers, config = { monitors: {} }, currency = "USD", rules = PRICING_RULES) {
+	const byId = new Map((Array.isArray(providers) ? providers : []).map((provider) => [provider.id, provider]));
+	return ({ providerId, model, timestamp, buckets }) => {
+		const provider = byId.get(providerId) ?? { id: providerId, displayName: providerId };
+		const identity = resolveProviderIdentity(provider, config);
+		return estimateTokenCost({ identity, model, timestamp, currency, buckets }, rules);
+	};
+}
+
+/** Budget threshold policy: 80% warns, 100% is critical. */
+export function budgetLevel(percent) {
+	if (typeof percent !== "number" || !Number.isFinite(percent) || percent < 0) return "unknown";
+	if (percent >= 100) return "critical";
+	if (percent >= 80) return "warning";
+	return "normal";
+}
+
+function budgetWindow(limit, currency, accumulator) {
+	const sampleCount = accumulator.pricedSamples + accumulator.incompleteSamples;
+	const rendered = renderCost(accumulator);
+	const knownEmpty = sampleCount === 0;
+	const compatible = knownEmpty || rendered.costComplete && rendered.currency === currency;
+	const estimatedSpend = compatible ? (knownEmpty ? 0 : rendered.estimatedCost) : null;
+	const percent = limit === null || estimatedSpend === null ? null : estimatedSpend / limit * 100;
+	return {
+		limit,
+		currency,
+		estimatedSpend,
+		percent,
+		costComplete: compatible,
+		level: limit === null ? "disabled" : budgetLevel(percent)
+	};
+}
+
+function localDayKey(timeMs) {
+	const date = new Date(timeMs);
+	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+/** Render current local-day and local-month budget state from day costs. */
+export function renderBudgetSummary(dayCosts, config = DEFAULT_BUDGET_CONFIG, now = Date.now()) {
+	const day = localDayKey(now);
+	const month = day.slice(0, 7);
+	const daily = dayCosts.get(day)?.total ?? createCostAccumulator();
+	const monthly = createCostAccumulator();
+	for (const [date, entry] of dayCosts) if (date.startsWith(month)) mergeCostAccumulator(monthly, entry.total);
+	return {
+		currency: config.currency,
+		daily: budgetWindow(config.daily, config.currency, daily),
+		monthly: budgetWindow(config.monthly, config.currency, monthly)
+	};
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -318,6 +318,21 @@ window.__ModuleLoader__.load({
 			}
 		}
 
+		function budgetWindowText(period, window, translate) {
+			if (window === null || typeof window !== "object" || window.limit === null || window.limit === void 0) return null;
+			const spent = window.costComplete === true ? fmtCurrency(window.estimatedSpend, window.currency) : "—";
+			const limit = fmtCurrency(window.limit, window.currency);
+			const level = ["normal", "warning", "critical"].includes(window.level)
+				? translate(`budget.level.${window.level}`)
+				: translate("budget.level.unknown");
+			return translate("budget.summary", {
+				period: translate(`budget.period.${period}`),
+				spent,
+				limit,
+				level
+			});
+		}
+
 		/**
 		 * Collapsed-badge account value, derived from the unified v0.2.0 account
 		 * snapshot. Balance providers show a real-currency amount; subscription /
@@ -468,6 +483,47 @@ window.__ModuleLoader__.load({
 			return JSON.stringify([provider, model]);
 		}
 
+		/** Stable signature for DSH's native cumulative tokenUsage projection. */
+		function tokenUsageSignalOf(projection) {
+			return JSON.stringify([
+				projection?.uncachedInputTokens,
+				projection?.outputTokens,
+				projection?.cacheReadTokens,
+				projection?.cacheWriteTokens
+			]);
+		}
+
+		function projectionBucketsOf(projection) {
+			const pairs = [
+				["inputTokens", projection?.uncachedInputTokens],
+				["outputTokens", projection?.outputTokens],
+				["cacheReadTokens", projection?.cacheReadTokens],
+				["cacheWriteTokens", projection?.cacheWriteTokens]
+			];
+			const buckets = {};
+			for (const [key, value] of pairs) {
+				if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null;
+				buckets[key] = value;
+			}
+			return buckets;
+		}
+
+		/**
+		 * The browser never prices cumulative tokens. It displays the server's
+		 * event-time estimate only when its folded buckets exactly match DSH's
+		 * native current-session projection.
+		 */
+		function currentSessionCostLabel(session, projection) {
+			const buckets = projectionBucketsOf(projection);
+			if (session === null || typeof session !== "object" || buckets === null) return "—";
+			for (const key of ["inputTokens", "outputTokens", "cacheReadTokens", "cacheWriteTokens"]) {
+				if (session[key] !== buckets[key]) return "—";
+			}
+			if (session.costComplete !== true || typeof session.estimatedCost !== "number" || !Number.isFinite(session.estimatedCost)
+				|| typeof session.currency !== "string" || session.currency === "") return "—";
+			return `≈${fmtCurrency(session.estimatedCost, session.currency)}`;
+		}
+
 		/**
 		 * Resolve one explicit DSH session through the server-owned identity and
 		 * account protocols. The account endpoint reads AccountService's existing
@@ -517,11 +573,13 @@ window.__ModuleLoader__.load({
 				? account.displayName
 				: typeof snapshot.context.providerId === "string" && snapshot.context.providerId !== "" ? snapshot.context.providerId : providerId;
 			let status = typeof account?.status === "string" ? account.status : typeof snapshot.status === "string" ? snapshot.status : "unavailable";
+			const costLabel = currentSessionCostLabel(snapshot.context.session, snapshot.tokenUsage);
 			if (account?.stale === true && status === "ok") status = "unavailable";
 			if (status !== "ok") {
-				const value = status === "unsupported"
+				const accountValue = status === "unsupported"
 					? translate("sessionPill.status.unsupported")
 					: subscriptionStatusLabel(status, translate);
+				const value = `${accountValue} · ${costLabel}`;
 				return {
 					providerId,
 					providerLabel,
@@ -551,17 +609,19 @@ window.__ModuleLoader__.load({
 
 			if (value === null) {
 				const invalid = translate("account.status.invalidResponse");
+				const invalidValue = `${invalid} · ${costLabel}`;
 				return {
 					providerId,
 					providerLabel,
 					status: "invalid-response",
-					value: invalid,
+					value: invalidValue,
 					tone: "neutral",
-					ariaLabel: translate("sessionPill.aria", { provider: providerLabel, value: invalid })
+					ariaLabel: translate("sessionPill.aria", { provider: providerLabel, value: invalidValue })
 				};
 			}
 			const alertLevel = account?.alert?.level;
 			const tone = alertLevel === "normal" || alertLevel === "warning" || alertLevel === "critical" ? alertLevel : "neutral";
+			value = `${value} · ${costLabel}`;
 			const accessibleValue = auxiliaryLabel === "" ? value : `${value} · ${auxiliaryLabel}`;
 			return {
 				providerId,
@@ -609,12 +669,14 @@ window.__ModuleLoader__.load({
 		}
 
 		/** Formal `conversation.input.right` slot occupant. */
-		function CurrentSessionPill({ sessionId, session, modelDirectory, request = fetchJson, t }) {
+		function CurrentSessionPill({ sessionId, session, modelDirectory, useProjection = () => void 0, request = fetchJson, t }) {
 			const translate = (key, params) => interpolate(t !== void 0 ? t(key) : key, params);
 			const [loaded, setLoaded] = react.useState({ key: null, snapshot: null });
 			const loaderRef = react.useRef(null);
 			if (loaderRef.current === null) loaderRef.current = createLoader();
 			const signal = sessionContextSignalOf(session);
+			const tokenUsage = useProjection("tokenUsage");
+			const tokenSignal = tokenUsageSignalOf(tokenUsage);
 			const subscribeModelSelection = react.useCallback((notify) => typeof modelDirectory?.subscribe === "function"
 				? modelDirectory.subscribe(notify)
 				: () => {}, [modelDirectory]);
@@ -622,7 +684,7 @@ window.__ModuleLoader__.load({
 				typeof modelDirectory?.getSnapshot === "function" ? modelDirectory.getSnapshot() : null
 			), [modelDirectory]);
 			const modelSignal = react.useSyncExternalStore(subscribeModelSelection, getModelSelectionSignal, getModelSelectionSignal);
-			const requestKey = JSON.stringify([sessionId, signal, modelSignal]);
+			const requestKey = JSON.stringify([sessionId, signal, modelSignal, tokenSignal]);
 			const [selectedProvider, selectedModel] = JSON.parse(modelSignal);
 			const selectedRoute = selectedProvider !== "" && selectedModel !== ""
 				? { provider: selectedProvider, model: selectedModel }
@@ -639,9 +701,9 @@ window.__ModuleLoader__.load({
 				return () => {
 					mounted = false;
 				};
-			}, [sessionId, signal, modelSignal, request, requestKey, selectedRoute?.provider, selectedRoute?.model]);
+			}, [sessionId, signal, modelSignal, tokenSignal, request, requestKey, selectedRoute?.provider, selectedRoute?.model]);
 			return react_jsx_runtime.jsx(CurrentSessionPillView, {
-				snapshot: loaded.key === requestKey ? loaded.snapshot : null,
+				snapshot: loaded.key === requestKey && loaded.snapshot !== null ? { ...loaded.snapshot, tokenUsage } : null,
 				translate
 			});
 		}
@@ -947,6 +1009,10 @@ window.__ModuleLoader__.load({
 
 			const selectedEntry = selectedDay !== null ? dayMap.get(selectedDay) ?? null : null;
 			const badgeCount = stats !== null ? fmtCompact(stats.dayTokens) : null;
+			const budgetRows = usage?.budgets === null || usage?.budgets === void 0 ? [] : [
+				["daily", usage.budgets.daily],
+				["monthly", usage.budgets.monthly]
+			].map(([period, window]) => ({ period, window, text: budgetWindowText(period, window, translate) })).filter((entry) => entry.text !== null);
 
 			// Collapsed-badge account value, derived from the unified v0.2.0
 			// account snapshot. Balance providers show a real-currency amount;
@@ -1082,9 +1148,9 @@ window.__ModuleLoader__.load({
 													react_jsx_runtime.jsxs("div", {
 														className: S.statsRow,
 														children: [
-															react_jsx_runtime.jsx("div", { className: S.stat, children: [react_jsx_runtime.jsx("span", { className: S.statValue, children: fmt(stats.dayTokens) }), react_jsx_runtime.jsx("span", { className: S.statLabel, children: translate("usage.today") })] }),
-															react_jsx_runtime.jsx("div", { className: S.stat, children: [react_jsx_runtime.jsx("span", { className: S.statValue, children: fmt(stats.monthTokens) }), react_jsx_runtime.jsx("span", { className: S.statLabel, children: translate("usage.month") })] }),
-															react_jsx_runtime.jsx("div", { className: S.stat, children: [react_jsx_runtime.jsx("span", { className: S.statValue, children: fmt(stats.total) }), react_jsx_runtime.jsx("span", { className: S.statLabel, children: translate("usage.total") })] })
+													react_jsx_runtime.jsxs("div", { className: S.stat, children: [react_jsx_runtime.jsx("span", { className: S.statValue, children: fmt(stats.dayTokens) }), react_jsx_runtime.jsx("span", { className: S.statLabel, children: translate("usage.today") })] }),
+													react_jsx_runtime.jsxs("div", { className: S.stat, children: [react_jsx_runtime.jsx("span", { className: S.statValue, children: fmt(stats.monthTokens) }), react_jsx_runtime.jsx("span", { className: S.statLabel, children: translate("usage.month") })] }),
+													react_jsx_runtime.jsxs("div", { className: S.stat, children: [react_jsx_runtime.jsx("span", { className: S.statValue, children: fmt(stats.total) }), react_jsx_runtime.jsx("span", { className: S.statLabel, children: translate("usage.total") })] })
 														]
 													}),
 													react_jsx_runtime.jsx("p", {
@@ -1094,10 +1160,16 @@ window.__ModuleLoader__.load({
 																translate("usage.hit.today"),
 																": ",
 																react_jsx_runtime.jsx("b", { children: fmtHit(stats.todayHit) })
-															]
-														})
+														]
 													})
-												]
+												}),
+												...budgetRows.map((entry) => react_jsx_runtime.jsx("p", {
+													className: S.hitCaption,
+													"data-budget-period": entry.period,
+													"data-budget-level": entry.window.level,
+													children: entry.text
+												}, entry.period))
+											]
 											}),
 											usage !== null && usageError === null && react_jsx_runtime.jsxs("section", {
 												className: S.section,
@@ -1717,6 +1789,13 @@ window.__ModuleLoader__.load({
 			"usage.cacheRead": "缓存读",
 			"usage.unknownModel": "未知模型",
 			"usage.noModels": "这一天没有分模型数据。",
+			"budget.period.daily": "今日估算",
+			"budget.period.monthly": "本月估算",
+			"budget.level.normal": "正常",
+			"budget.level.warning": "接近预算",
+			"budget.level.critical": "已超预算",
+			"budget.level.unknown": "费用不完整",
+			"budget.summary": "{period}：{spent} / {limit} · {level}",
 			"month.year": "{year}年{month}",
 			"action.refresh": "刷新",
 			"action.retry": "重试",
@@ -1830,6 +1909,13 @@ window.__ModuleLoader__.load({
 			"usage.cacheRead": "Cache read",
 			"usage.unknownModel": "Unknown model",
 			"usage.noModels": "No per-model data for this day.",
+			"budget.period.daily": "Today estimated",
+			"budget.period.monthly": "This month estimated",
+			"budget.level.normal": "Normal",
+			"budget.level.warning": "Near budget",
+			"budget.level.critical": "Over budget",
+			"budget.level.unknown": "Incomplete cost",
+			"budget.summary": "{period}: {spent} / {limit} · {level}",
 			"month.year": "{month} {year}",
 			"action.refresh": "Refresh",
 			"action.retry": "Retry",
@@ -1896,6 +1982,7 @@ window.__ModuleLoader__.load({
 		exports.modelLabelOf = modelLabelOf;
 		exports.fmt = fmt;
 		exports.fmtCurrency = fmtCurrency;
+		exports.budgetWindowText = budgetWindowText;
 		exports.badgeAccountValue = badgeAccountValue;
 		exports.badgeWarnOf = badgeWarnOf;
 		exports.shouldDismissPanel = shouldDismissPanel;
@@ -1903,6 +1990,8 @@ window.__ModuleLoader__.load({
 		exports.formatResetCountdown = formatResetCountdown;
 		exports.loadSessionPillSnapshot = loadSessionPillSnapshot;
 		exports.modelSelectionSignalOf = modelSelectionSignalOf;
+		exports.tokenUsageSignalOf = tokenUsageSignalOf;
+		exports.currentSessionCostLabel = currentSessionCostLabel;
 		exports.requestUsageStatsPanel = requestUsageStatsPanel;
 		exports.sessionContextSignalOf = sessionContextSignalOf;
 		exports.sessionPillViewOf = sessionPillViewOf;

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ import { join, dirname } from "node:path";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { applyUsageDelta, createUsageState, currentSessionContext, mergeBillingInto, mergeInto, renderSessionUsage, renderUsage, resetUsageState, totalTokens, zeroBuckets } from "./usage.js";
 import { ACCOUNT_REFRESH_MS, createAccountService, validateAccountConfig } from "./accounts.js";
-import { createUsageCostEstimator, parseCostAccumulator, pricingFingerprint, renderBudgetSummary, serializeCostAccumulator, validateBudgetConfig } from "./billing.js";
+import { changedProviderPricingRoutes, createUsageCostEstimator, parseCostAccumulator, pricingFingerprint, renderBudgetSummary, serializeCostAccumulator, validateBudgetConfig } from "./billing.js";
 
 /** Stable Cordis plugin name. */
 const name = "usage-stats";
@@ -52,7 +52,6 @@ const ACCOUNT_PATH = "/api/usage-stats/account";
 const SESSION_CONTEXT_PATH = "/api/usage-stats/session-context";
 const UPSTREAM_TIMEOUT_MS = 15000;
 const CACHE_VERSION = 5;
-const PRICING_FINGERPRINT = pricingFingerprint();
 
 /** Default DeepSeek connection facts when the settings namespace is absent. */
 const DEEPSEEK_DEFAULTS = {
@@ -256,22 +255,69 @@ function parseSession(raw) {
 	return state;
 }
 
-/** Load the cache once per process; any corruption degrades to a fresh cache. */
-async function loadCache() {
-	if (loadedCache !== null) return loadedCache;
+function parsePricingIdentityCutoffs(raw) {
+	const cutoffs = Object.create(null);
+	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return cutoffs;
+	for (const [routeId, cutoff] of Object.entries(raw)) {
+		if (routeId !== "" && Number.isFinite(cutoff) && cutoff >= 0) cutoffs[routeId] = cutoff;
+	}
+	return cutoffs;
+}
+
+function freshCache(pricingFingerprintValue, previous = null, transitionAt = Date.now()) {
+	const pricingIdentityCutoffs = parsePricingIdentityCutoffs(previous?.pricingIdentityCutoffs);
+	let pricingIdentityCutoffAll = Number.isFinite(previous?.pricingIdentityCutoffAll) && previous.pricingIdentityCutoffAll >= 0
+		? previous.pricingIdentityCutoffAll
+		: null;
+	if (previous !== null && previous.pricingFingerprint !== pricingFingerprintValue) {
+		const changedRoutes = changedProviderPricingRoutes(previous.pricingFingerprint, pricingFingerprintValue);
+		if (changedRoutes === null) pricingIdentityCutoffAll = Math.max(pricingIdentityCutoffAll ?? 0, transitionAt);
+		else for (const routeId of changedRoutes) pricingIdentityCutoffs[routeId] = Math.max(pricingIdentityCutoffs[routeId] ?? 0, transitionAt);
+	}
+	return {
+		version: CACHE_VERSION,
+		pricingFingerprint: pricingFingerprintValue,
+		pricingIdentityCutoffAll,
+		pricingIdentityCutoffs,
+		sessions: {}
+	};
+}
+
+function restoredCache(parsed, pricingFingerprintValue) {
+	const sessions = {};
+	for (const [id, entry] of Object.entries(parsed.sessions)) {
+		if (typeof id === "string" && id.length > 0) sessions[id] = parseSession(entry);
+	}
+	return {
+		version: CACHE_VERSION,
+		pricingFingerprint: pricingFingerprintValue,
+		pricingIdentityCutoffAll: Number.isFinite(parsed.pricingIdentityCutoffAll) && parsed.pricingIdentityCutoffAll >= 0
+			? parsed.pricingIdentityCutoffAll
+			: null,
+		pricingIdentityCutoffs: parsePricingIdentityCutoffs(parsed.pricingIdentityCutoffs),
+		sessions
+	};
+}
+
+/** Load against the current runtime provider/pricing fingerprint. */
+async function loadCache(pricingFingerprintValue) {
+	if (loadedCache !== null) {
+		if (loadedCache.pricingFingerprint !== pricingFingerprintValue) {
+			loadedCache = freshCache(pricingFingerprintValue, loadedCache);
+			loadPromise = Promise.resolve(loadedCache);
+		}
+		return loadedCache;
+	}
 	loadPromise ??= (async () => {
-		const fresh = { version: CACHE_VERSION, pricingFingerprint: PRICING_FINGERPRINT, sessions: {} };
+		const fresh = freshCache(pricingFingerprintValue);
 		try {
 			const raw = await readFile(cachePath(), "utf8");
 			const parsed = JSON.parse(raw);
 			if (parsed !== null && typeof parsed === "object" && parsed.version === CACHE_VERSION
-				&& parsed.pricingFingerprint === PRICING_FINGERPRINT
+				&& typeof parsed.pricingFingerprint === "string"
 				&& parsed.sessions !== null && typeof parsed.sessions === "object") {
-				const sessions = {};
-				for (const [id, entry] of Object.entries(parsed.sessions)) {
-					if (typeof id === "string" && id.length > 0) sessions[id] = parseSession(entry);
-				}
-				return { version: CACHE_VERSION, pricingFingerprint: PRICING_FINGERPRINT, sessions };
+				if (parsed.pricingFingerprint === pricingFingerprintValue) return restoredCache(parsed, pricingFingerprintValue);
+				return freshCache(pricingFingerprintValue, parsed);
 			}
 		} catch {
 			/* first run or corrupt cache */
@@ -287,7 +333,13 @@ async function saveCache(ctx, cache) {
 	try {
 		const path = cachePath();
 		await mkdir(dirname(path), { recursive: true });
-		const serialized = { version: CACHE_VERSION, pricingFingerprint: PRICING_FINGERPRINT, sessions: {} };
+		const serialized = {
+			version: CACHE_VERSION,
+			pricingFingerprint: cache.pricingFingerprint,
+			pricingIdentityCutoffAll: cache.pricingIdentityCutoffAll,
+			pricingIdentityCutoffs: cache.pricingIdentityCutoffs,
+			sessions: {}
+		};
 		for (const [id, state] of Object.entries(cache.sessions)) serialized.sessions[id] = serializeSession(state);
 		const tmp = `${path}.tmp`;
 		await writeFile(tmp, JSON.stringify(serialized), "utf8");
@@ -324,9 +376,18 @@ function withLock(run) {
  */
 export async function collectUsage(ctx, config = { monitors: {}, budgets: validateBudgetConfig() }) {
 	return withLock(async () => {
-		const cache = await loadCache();
 		const providers = await configuredProviders(ctx);
-		const estimateCost = createUsageCostEstimator(providers, config);
+		const runtimePricingFingerprint = pricingFingerprint({ providers, config });
+		const cache = await loadCache(runtimePricingFingerprint);
+		const estimateCurrentCost = createUsageCostEstimator(providers, config);
+		const estimateCost = (input) => {
+			const routeCutoff = Object.hasOwn(cache.pricingIdentityCutoffs, input.providerId)
+				? cache.pricingIdentityCutoffs[input.providerId]
+				: null;
+			const cutoff = Math.max(cache.pricingIdentityCutoffAll ?? 0, routeCutoff ?? 0);
+			if (cutoff > 0 && (!Number.isFinite(input.timestamp) || input.timestamp <= cutoff)) return null;
+			return estimateCurrentCost(input);
+		};
 		const live = ctx.get("sessions");
 		const attached = new Set();
 		if (live !== void 0) {
@@ -493,7 +554,8 @@ export async function collectSessionContext(ctx, sessionId, config = { monitors:
 	const sessions = ctx.get("sessions");
 	const live = sessions?.get?.(sessionId) ?? sessions?.list?.().find((session) => session.id === sessionId);
 	if (live === void 0) return null;
-	const cache = await loadCache();
+	const cache = loadedCache;
+	if (cache === null) return null;
 	const state = cache.sessions[sessionId];
 	if (state?.kind !== "live") return null;
 	const currentRoute = selectedRoute ?? state.currentRoute;
@@ -511,7 +573,8 @@ export async function collectSessionContext(ctx, sessionId, config = { monitors:
 export async function collectActiveAccountIds(ctx, config = { monitors: {} }) {
 	await collectUsage(ctx, config);
 	const sessions = ctx.get("sessions")?.list?.() ?? [];
-	const cache = await loadCache();
+	const cache = loadedCache;
+	if (cache === null) return [];
 	const providers = await configuredProviders(ctx);
 	const byId = new Map(providers.map((provider) => [provider.id, provider]));
 	const accountIds = new Set();

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,8 +34,9 @@
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { applyUsageDelta, createUsageState, currentSessionContext, mergeInto, renderUsage, resetUsageState, totalTokens, zeroBuckets } from "./usage.js";
+import { applyUsageDelta, createUsageState, currentSessionContext, mergeBillingInto, mergeInto, renderSessionUsage, renderUsage, resetUsageState, totalTokens, zeroBuckets } from "./usage.js";
 import { ACCOUNT_REFRESH_MS, createAccountService, validateAccountConfig } from "./accounts.js";
+import { createUsageCostEstimator, parseCostAccumulator, pricingFingerprint, renderBudgetSummary, serializeCostAccumulator, validateBudgetConfig } from "./billing.js";
 
 /** Stable Cordis plugin name. */
 const name = "usage-stats";
@@ -50,7 +51,8 @@ const SUBSCRIPTIONS_PATH = "/api/usage-stats/subscriptions";
 const ACCOUNT_PATH = "/api/usage-stats/account";
 const SESSION_CONTEXT_PATH = "/api/usage-stats/session-context";
 const UPSTREAM_TIMEOUT_MS = 15000;
-const CACHE_VERSION = 4;
+const CACHE_VERSION = 5;
+const PRICING_FINGERPRINT = pricingFingerprint();
 
 /** Default DeepSeek connection facts when the settings namespace is absent. */
 const DEEPSEEK_DEFAULTS = {
@@ -141,6 +143,7 @@ function serializeSession(state) {
 	}
 	return {
 		kind: state.kind ?? "persisted",
+		title: typeof state.title === "string" ? state.title : null,
 		consumed: state.consumed ?? 0,
 		...(state.revision === void 0 ? {} : { revision: state.revision }),
 		days,
@@ -148,7 +151,23 @@ function serializeSession(state) {
 			key: state.lastSample.key,
 			day: state.lastSample.day,
 			model: state.lastSample.model,
+			providerId: state.lastSample.providerId,
+			time: state.lastSample.time,
+			cost: state.lastSample.cost,
 			buckets: { ...state.lastSample.buckets }
+		},
+		billing: {
+			total: serializeCostAccumulator(state.billing.total),
+			days: Object.fromEntries([...state.billing.days].map(([date, entry]) => [date, {
+				total: serializeCostAccumulator(entry.total),
+				models: Object.fromEntries([...entry.models].map(([model, accumulator]) => [model, serializeCostAccumulator(accumulator)]))
+			}])),
+			providers: Object.fromEntries(state.billing.providers),
+			models: Object.fromEntries(state.billing.models),
+			sampleCount: state.billing.sampleCount,
+			firstAt: state.billing.firstAt,
+			lastAt: state.billing.lastAt,
+			penultimateAt: state.billing.penultimateAt
 		},
 		currentModel: state.currentModel,
 		currentRoute: state.currentRoute === null || state.currentRoute === void 0 ? null : {
@@ -164,6 +183,7 @@ function parseSession(raw) {
 	const state = createUsageState();
 	if (raw === null || typeof raw !== "object") return state;
 	state.kind = typeof raw.kind === "string" ? raw.kind : "persisted";
+	state.title = typeof raw.title === "string" ? raw.title : null;
 	state.consumed = Number.isSafeInteger(raw.consumed) ? raw.consumed : 0;
 	if (typeof raw.revision === "string") state.revision = raw.revision;
 	if (raw.days !== null && typeof raw.days === "object") {
@@ -197,6 +217,9 @@ function parseSession(raw) {
 			key: raw.lastSample.key,
 			day: raw.lastSample.day,
 			model: typeof raw.lastSample.model === "string" ? raw.lastSample.model : "unknown",
+			providerId: typeof raw.lastSample.providerId === "string" ? raw.lastSample.providerId : "unknown",
+			time: Number.isFinite(raw.lastSample.time) ? raw.lastSample.time : null,
+			cost: raw.lastSample.cost !== null && typeof raw.lastSample.cost === "object" ? { ...raw.lastSample.cost } : { counted: true, complete: false },
 			buckets: {
 				inputTokens: Number.isFinite(buckets.inputTokens) ? buckets.inputTokens : 0,
 				outputTokens: Number.isFinite(buckets.outputTokens) ? buckets.outputTokens : 0,
@@ -204,6 +227,21 @@ function parseSession(raw) {
 				cacheWriteTokens: Number.isFinite(buckets.cacheWriteTokens) ? buckets.cacheWriteTokens : 0
 			}
 		};
+	}
+	if (raw.billing !== null && typeof raw.billing === "object" && !Array.isArray(raw.billing)) {
+		state.billing.total = parseCostAccumulator(raw.billing.total);
+		for (const [date, entry] of Object.entries(raw.billing.days ?? {})) {
+			if (entry === null || typeof entry !== "object" || Array.isArray(entry)) continue;
+			const restored = { total: parseCostAccumulator(entry.total), models: new Map() };
+			for (const [model, accumulator] of Object.entries(entry.models ?? {})) restored.models.set(model, parseCostAccumulator(accumulator));
+			state.billing.days.set(date, restored);
+		}
+		for (const [providerId, count] of Object.entries(raw.billing.providers ?? {})) if (Number.isSafeInteger(count) && count > 0) state.billing.providers.set(providerId, count);
+		for (const [model, count] of Object.entries(raw.billing.models ?? {})) if (Number.isSafeInteger(count) && count > 0) state.billing.models.set(model, count);
+		state.billing.sampleCount = Number.isSafeInteger(raw.billing.sampleCount) && raw.billing.sampleCount >= 0 ? raw.billing.sampleCount : 0;
+		state.billing.firstAt = Number.isFinite(raw.billing.firstAt) ? raw.billing.firstAt : null;
+		state.billing.lastAt = Number.isFinite(raw.billing.lastAt) ? raw.billing.lastAt : null;
+		state.billing.penultimateAt = Number.isFinite(raw.billing.penultimateAt) ? raw.billing.penultimateAt : null;
 	}
 	if (typeof raw.currentModel === "string") state.currentModel = raw.currentModel;
 	if (raw.currentRoute !== null && typeof raw.currentRoute === "object"
@@ -222,16 +260,18 @@ function parseSession(raw) {
 async function loadCache() {
 	if (loadedCache !== null) return loadedCache;
 	loadPromise ??= (async () => {
-		const fresh = { version: CACHE_VERSION, sessions: {} };
+		const fresh = { version: CACHE_VERSION, pricingFingerprint: PRICING_FINGERPRINT, sessions: {} };
 		try {
 			const raw = await readFile(cachePath(), "utf8");
 			const parsed = JSON.parse(raw);
-			if (parsed !== null && typeof parsed === "object" && parsed.version === CACHE_VERSION && parsed.sessions !== null && typeof parsed.sessions === "object") {
+			if (parsed !== null && typeof parsed === "object" && parsed.version === CACHE_VERSION
+				&& parsed.pricingFingerprint === PRICING_FINGERPRINT
+				&& parsed.sessions !== null && typeof parsed.sessions === "object") {
 				const sessions = {};
 				for (const [id, entry] of Object.entries(parsed.sessions)) {
 					if (typeof id === "string" && id.length > 0) sessions[id] = parseSession(entry);
 				}
-				return { version: CACHE_VERSION, sessions };
+				return { version: CACHE_VERSION, pricingFingerprint: PRICING_FINGERPRINT, sessions };
 			}
 		} catch {
 			/* first run or corrupt cache */
@@ -247,7 +287,7 @@ async function saveCache(ctx, cache) {
 	try {
 		const path = cachePath();
 		await mkdir(dirname(path), { recursive: true });
-		const serialized = { version: CACHE_VERSION, sessions: {} };
+		const serialized = { version: CACHE_VERSION, pricingFingerprint: PRICING_FINGERPRINT, sessions: {} };
 		for (const [id, state] of Object.entries(cache.sessions)) serialized.sessions[id] = serializeSession(state);
 		const tmp = `${path}.tmp`;
 		await writeFile(tmp, JSON.stringify(serialized), "utf8");
@@ -282,15 +322,18 @@ function withLock(run) {
  * Sessions that vanished are dropped, and a session switching between
  * live/persisted is refolded from scratch to stay exact.
  */
-export async function collectUsage(ctx) {
+export async function collectUsage(ctx, config = { monitors: {}, budgets: validateBudgetConfig() }) {
 	return withLock(async () => {
 		const cache = await loadCache();
+		const providers = await configuredProviders(ctx);
+		const estimateCost = createUsageCostEstimator(providers, config);
 		const live = ctx.get("sessions");
 		const attached = new Set();
 		if (live !== void 0) {
 			for (const session of live.list()) {
 				attached.add(session.id);
 				const state = cache.sessions[session.id] ?? createUsageState();
+				if (typeof session.title === "string") state.title = session.title;
 				if (state.kind !== "live") {
 					// Live/persisted transition: refold the whole in-memory log.
 					resetUsageState(state);
@@ -306,7 +349,7 @@ export async function collectUsage(ctx) {
 					resetUsageState(state);
 				}
 				if ((state.consumed ?? 0) < count) {
-					applyUsageDelta(state, session.events.slice(state.consumed ?? 0));
+					applyUsageDelta(state, session.events.slice(state.consumed ?? 0), { estimateCost });
 					state.consumed = count;
 				}
 				state.kind = "live";
@@ -333,6 +376,7 @@ export async function collectUsage(ctx) {
 				persistedIds.add(meta.id);
 				if (attached.has(meta.id)) continue;
 				const state = cache.sessions[meta.id] ?? createUsageState();
+				if (typeof meta.title === "string") state.title = meta.title;
 				const revision = revisionOf.get(meta.id);
 				const changed = state.kind !== "persisted" || (revision !== void 0 && revision !== state.revision) || revision === void 0;
 				if (changed) {
@@ -349,10 +393,10 @@ export async function collectUsage(ctx) {
 							// Log truncated or rewritten: refold the whole log.
 							resetUsageState(state);
 							const { events: allEvents } = await persistence.readFrom(meta.id, 0);
-							applyUsageDelta(state, allEvents);
+							applyUsageDelta(state, allEvents, { estimateCost });
 							state.consumed = allEvents.length > 0 ? allEvents[allEvents.length - 1].seq : 0;
 						} else if (fresh.length > 0) {
-							applyUsageDelta(state, fresh);
+							applyUsageDelta(state, fresh, { estimateCost });
 							state.consumed = fresh[fresh.length - 1].seq;
 						}
 						state.kind = "persisted";
@@ -368,18 +412,28 @@ export async function collectUsage(ctx) {
 			if (!attached.has(id) && !persistedIds.has(id)) delete cache.sessions[id];
 		}
 		const byDay = new Map();
-		for (const state of Object.values(cache.sessions)) mergeInto(byDay, state.days);
+		const billingByDay = new Map();
+		for (const state of Object.values(cache.sessions)) {
+			mergeInto(byDay, state.days);
+			mergeBillingInto(billingByDay, state.billing.days);
+		}
 		// Keep the atomic cache write inside the single-flight section. Otherwise
 		// overlapping saves can race on the same temporary file.
 		await saveCache(ctx, cache);
-		return renderUsage(byDay, Date.now());
+		const updatedAt = Date.now();
+		const rendered = renderUsage(byDay, updatedAt, billingByDay);
+		return {
+			...rendered,
+			sessions: Object.entries(cache.sessions).map(([sessionId, state]) => renderSessionUsage(sessionId, state)).filter((session) => session.tokens > 0),
+			budgets: renderBudgetSummary(billingByDay, config.budgets ?? validateBudgetConfig(), updatedAt)
+		};
 	});
 }
 
-async function handleUsage(ctx, req, res) {
+async function handleUsage(ctx, config, req, res) {
 	if (rejectForeignCaller(req, res)) return;
 	try {
-		const result = await collectUsage(ctx);
+		const result = await collectUsage(ctx, config);
 		json(res, 200, { ok: true, ...result });
 	} catch (error) {
 		ctx.logger.warn(`usage-stats: usage aggregation failed: ${String(error)}`);
@@ -435,7 +489,7 @@ async function configuredProviders(ctx) {
  * events), and add no stream listener, provider request, cache, or usage ledger.
  */
 export async function collectSessionContext(ctx, sessionId, config = { monitors: {} }, selectedRoute = null) {
-	await collectUsage(ctx);
+	await collectUsage(ctx, config);
 	const sessions = ctx.get("sessions");
 	const live = sessions?.get?.(sessionId) ?? sessions?.list?.().find((session) => session.id === sessionId);
 	if (live === void 0) return null;
@@ -447,12 +501,15 @@ export async function collectSessionContext(ctx, sessionId, config = { monitors:
 	const providers = await configuredProviders(ctx);
 	const provider = providers.find((entry) => entry.id === currentRoute.providerId)
 		?? { id: currentRoute.providerId, displayName: currentRoute.providerId };
-	return currentSessionContext(sessionId, { ...state, currentRoute }, provider, config);
+	return {
+		...currentSessionContext(sessionId, { ...state, currentRoute }, provider, config),
+		session: renderSessionUsage(sessionId, state)
+	};
 }
 
 /** Resolve the current account ids for every live session without a new ledger or provider guess. */
 export async function collectActiveAccountIds(ctx, config = { monitors: {} }) {
-	await collectUsage(ctx);
+	await collectUsage(ctx, config);
 	const sessions = ctx.get("sessions")?.list?.() ?? [];
 	const cache = await loadCache();
 	const providers = await configuredProviders(ctx);
@@ -676,7 +733,7 @@ export function startBackgroundRefresh(ctx, accounts, deps = {}) {
 			if (force || at >= nextUsageAt) {
 				try {
 					if (accountRefreshEnabled) accounts.setActiveProviders(await collectActiveAccountIds(ctx, config));
-					else await collectUsage(ctx);
+					else await collectUsage(ctx, config);
 				} catch (error) {
 					ctx.logger.warn(`usage-stats: background usage refresh failed: ${String(error)}`);
 				}
@@ -717,7 +774,7 @@ export function startBackgroundRefresh(ctx, accounts, deps = {}) {
 }
 
 /**
- * Plugin body: register the five exact routes and start background refresh.
+ * Plugin body: register the six exact routes and start background refresh.
  * @param ctx - plugin context carrying webServer, credentials, sessions, sessionPersistence, settings, and llm.
  */
 const Config = {
@@ -726,7 +783,7 @@ const Config = {
 		vendor: "dsh-usage-stats",
 		validate(value) {
 			try {
-				return { value: validateAccountConfig(value ?? {}) };
+				return { value: validateConfig(value ?? {}) };
 			} catch (error) {
 				return { issues: [{ message: error instanceof Error ? error.message : String(error) }] };
 			}
@@ -734,8 +791,15 @@ const Config = {
 	}
 };
 
+function validateConfig(raw = {}) {
+	return {
+		...validateAccountConfig(raw),
+		budgets: validateBudgetConfig(raw.budgets)
+	};
+}
+
 async function apply(ctx, rawConfig = {}, deps = {}) {
-	const config = validateAccountConfig(rawConfig);
+	const config = validateConfig(rawConfig);
 	const accounts = deps.accounts ?? createAccountService({
 		credentials: ctx.get("credentials") ?? ctx.credentials,
 		getProviders: () => configuredProviders(ctx),
@@ -748,7 +812,7 @@ async function apply(ctx, rawConfig = {}, deps = {}) {
 	ctx.effect(() => ctx.webServer.register({
 		kind: "exact",
 		path: USAGE_PATH,
-		handler: (req, res) => handleUsage(ctx, req, res)
+		handler: (req, res) => handleUsage(ctx, config, req, res)
 	}), "usage-stats: usage route");
 	ctx.effect(() => ctx.webServer.register({
 		kind: "exact",
@@ -781,4 +845,4 @@ async function apply(ctx, rawConfig = {}, deps = {}) {
 	}), "usage-stats: background usage/account refresh");
 }
 
-export { apply, Config, inject, name, USAGE_PATH, PROVIDERS_PATH, BALANCE_PATH, SUBSCRIPTIONS_PATH, ACCOUNT_PATH, SESSION_CONTEXT_PATH, configuredProviders, totalTokens, zeroBuckets };
+export { apply, Config, inject, name, USAGE_PATH, PROVIDERS_PATH, BALANCE_PATH, SUBSCRIPTIONS_PATH, ACCOUNT_PATH, SESSION_CONTEXT_PATH, configuredProviders, totalTokens, validateConfig, zeroBuckets };

--- a/lib/provider-identity.js
+++ b/lib/provider-identity.js
@@ -12,6 +12,9 @@
 
 import { isPrivateHostname } from "./network.js";
 
+/** Bump whenever route classification can change pricing eligibility. */
+export const PROVIDER_IDENTITY_POLICY_VERSION = 1;
+
 const ADAPTER_IDENTITIES = Object.freeze({
 	"deepseek-balance": { providerFamily: "deepseek", pricingFamily: "deepseek" },
 	"openrouter-balance": { providerFamily: "openrouter", pricingFamily: "openrouter" },

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -18,6 +18,7 @@
  */
 
 import { resolveProviderIdentity } from "./provider-identity.js";
+import { applyCostSample, costSampleOf, createCostAccumulator, mergeCostAccumulator, renderCost } from "./billing.js";
 
 /** Local-calendar `YYYY-MM-DD` key for a millisecond epoch. */
 export function dayKey(timeMs) {
@@ -80,6 +81,77 @@ function subtractFrom(target, source) {
 	target.cacheReadTokens -= source.cacheReadTokens;
 	target.cacheWriteTokens -= source.cacheWriteTokens;
 	return target;
+}
+
+function billingEntryOf(byDay, day) {
+	let entry = byDay.get(day);
+	if (entry === void 0) {
+		entry = { total: createCostAccumulator(), models: new Map() };
+		byDay.set(day, entry);
+	}
+	return entry;
+}
+
+function modelCostOf(entry, model) {
+	let accumulator = entry.models.get(model);
+	if (accumulator === void 0) {
+		accumulator = createCostAccumulator();
+		entry.models.set(model, accumulator);
+	}
+	return accumulator;
+}
+
+function adjustIdentityCount(map, key, direction) {
+	const next = (map.get(key) ?? 0) + direction;
+	if (next <= 0) map.delete(key);
+	else map.set(key, next);
+}
+
+function createSessionBillingState() {
+	return {
+		total: createCostAccumulator(),
+		days: new Map(),
+		providers: new Map(),
+		models: new Map(),
+		sampleCount: 0,
+		firstAt: null,
+		lastAt: null,
+		penultimateAt: null
+	};
+}
+
+function applySessionCost(state, sample, direction) {
+	const billing = state.billing;
+	applyCostSample(billing.total, sample.cost, direction);
+	const dayEntry = billingEntryOf(billing.days, sample.day);
+	applyCostSample(dayEntry.total, sample.cost, direction);
+	applyCostSample(modelCostOf(dayEntry, sample.model), sample.cost, direction);
+	if (sample.cost.counted !== true) return;
+	adjustIdentityCount(billing.providers, sample.providerId, direction);
+	adjustIdentityCount(billing.models, sample.model, direction);
+	if (direction < 0) {
+		billing.sampleCount = Math.max(0, billing.sampleCount - 1);
+		if (billing.sampleCount === 0) {
+			billing.firstAt = null;
+			billing.lastAt = null;
+			billing.penultimateAt = null;
+		} else {
+			billing.lastAt = billing.penultimateAt;
+			billing.penultimateAt = null;
+		}
+		return;
+	}
+	if (billing.sampleCount === 0) billing.firstAt = sample.time;
+	billing.penultimateAt = billing.lastAt;
+	billing.lastAt = sample.time;
+	billing.sampleCount += 1;
+}
+
+function routeFromModelKey(key) {
+	if (typeof key !== "string") return { providerId: "unknown", model: "unknown" };
+	const slash = key.indexOf("/");
+	if (slash <= 0 || slash === key.length - 1) return { providerId: "unknown", model: "unknown" };
+	return { providerId: key.slice(0, slash), model: key.slice(slash + 1) };
 }
 
 /** Extract the usage sample an event carries, if any. */
@@ -158,6 +230,7 @@ export function createUsageState() {
 export function resetUsageState(state) {
 	return Object.assign(state, {
 		days: new Map(),
+		billing: createSessionBillingState(),
 		lastSample: null,
 		currentModel: null,
 		currentRoute: null,
@@ -196,10 +269,11 @@ export function currentSessionContext(sessionId, state, provider, config = { mon
  * @param state - session fold state (mutated in place).
  * @param events - the new events, in seq order, starting after the last fold.
  */
-export function applyUsageDelta(state, events) {
+export function applyUsageDelta(state, events, options = {}) {
 	let last = state.lastSample;
 	let currentModel = state.currentModel;
 	let currentRoute = state.currentRoute ?? null;
+	const estimateCost = typeof options.estimateCost === "function" ? options.estimateCost : null;
 	for (const event of events) {
 		if (event.type === "request/header" || event.type === "assistant/message") {
 			const route = routeModelOf(event);
@@ -219,6 +293,7 @@ export function applyUsageDelta(state, events) {
 		if (sample === void 0) continue;
 		const buckets = bucketsOf(sample.usage);
 		const model = modelOf(event) ?? currentModel ?? "unknown/unknown";
+		const route = routeModelOf(event) ?? routeFromModelKey(model);
 		const day = dayKey(event.time);
 		const entry = entryOf(state.days, day);
 		if (last !== null && last.key === sample.key) {
@@ -229,6 +304,7 @@ export function applyUsageDelta(state, events) {
 				const previousModel = previous.models.get(last.model);
 				if (previousModel !== void 0) subtractFrom(previousModel, last.buckets);
 			}
+			if (last.cost !== void 0) applySessionCost(state, last, -1);
 		}
 		addInto(entry.totals, buckets);
 		let modelBucket = entry.models.get(model);
@@ -237,7 +313,22 @@ export function applyUsageDelta(state, events) {
 			entry.models.set(model, modelBucket);
 		}
 		addInto(modelBucket, buckets);
-		last = { key: sample.key, day, model, buckets };
+		const estimate = estimateCost === null ? null : estimateCost({
+			providerId: route.providerId,
+			model: route.model,
+			timestamp: event.time,
+			buckets
+		});
+		last = {
+			key: sample.key,
+			day,
+			model,
+			providerId: route.providerId,
+			time: event.time,
+			buckets,
+			cost: costSampleOf(estimate, buckets)
+		};
+		applySessionCost(state, last, 1);
 	}
 	state.lastSample = last;
 	state.currentModel = currentModel;
@@ -276,6 +367,15 @@ export function mergeInto(byDay, sessionDays) {
 	}
 }
 
+/** Merge one session's monetary derivation into a global day map. */
+export function mergeBillingInto(byDay, sessionDays) {
+	for (const [day, entry] of sessionDays) {
+		const target = billingEntryOf(byDay, day);
+		mergeCostAccumulator(target.total, entry.total);
+		for (const [model, accumulator] of entry.models) mergeCostAccumulator(modelCostOf(target, model), accumulator);
+	}
+}
+
 /**
  * Merge one session fold into a global per-day map (convenience wrapper).
  * @param byDay - global map to mutate.
@@ -292,15 +392,17 @@ export function consumeEvents(byDay, events) {
  * @returns `{ days, total, updatedAt }` with `days` sorted ascending; each
  *   day carries `models` (descending by tokens) and a `cacheHitRate` percent.
  */
-export function renderUsage(byDay, updatedAt) {
+export function renderUsage(byDay, updatedAt, billingByDay = new Map()) {
 	const days = [...byDay.entries()]
 		.map(([date, entry]) => {
+			const billing = billingByDay.get(date);
 			const models = [...entry.models.entries()]
 				.map(([model, buckets]) => ({
 					model,
 					...buckets,
 					tokens: totalTokens(buckets),
-					cacheHitRate: cacheHitRate(buckets)
+					cacheHitRate: cacheHitRate(buckets),
+					...renderCost(billing?.models.get(model) ?? createCostAccumulator())
 				}))
 				// All-zero buckets come from warmup requests that report
 				// {input:0, output:0}; rendering them produces empty "0 tokens"
@@ -312,19 +414,40 @@ export function renderUsage(byDay, updatedAt) {
 				...entry.totals,
 				tokens: totalTokens(entry.totals),
 				cacheHitRate: cacheHitRate(entry.totals),
+				...renderCost(billing?.total ?? createCostAccumulator()),
 				models
 			};
 		})
 		.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
 	const total = zeroBuckets();
 	for (const [, entry] of byDay) addInto(total, entry.totals);
+	const totalCost = createCostAccumulator();
+	for (const [, entry] of billingByDay) mergeCostAccumulator(totalCost, entry.total);
 	return {
 		days,
 		total: {
 			...total,
 			tokens: totalTokens(total),
-			cacheHitRate: cacheHitRate(total)
+			cacheHitRate: cacheHitRate(total),
+			...renderCost(totalCost)
 		},
 		updatedAt
+	};
+}
+
+/** Render one cached session without maintaining a second token total. */
+export function renderSessionUsage(sessionId, state) {
+	const totals = zeroBuckets();
+	for (const [, entry] of state.days) addInto(totals, entry.totals);
+	return {
+		sessionId,
+		title: typeof state.title === "string" && state.title !== "" ? state.title : null,
+		providers: [...state.billing.providers.keys()].sort(),
+		models: [...state.billing.models.keys()].sort(),
+		...totals,
+		tokens: totalTokens(totals),
+		...renderCost(state.billing.total),
+		firstAt: Number.isFinite(state.billing.firstAt) ? new Date(state.billing.firstAt).toISOString() : null,
+		lastAt: Number.isFinite(state.billing.lastAt) ? new Date(state.billing.lastAt).toISOString() : null
 	};
 }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     }
   },
   "scripts": {
-    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/pricing.js && node --check lib/network.js && node --check lib/provider-identity.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/accounts.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-overlay-layering.mjs && node --check scripts/test-bundle.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-provider-identity.mjs && node --check scripts/test-pricing.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/test-accounts.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
-    "test": "npm run test:bundle && npm run test:client && npm run test:overlay && npm run test:server && npm run test:provider-identity && npm run test:pricing && npm run test:balance && npm run test:subscriptions && npm run test:accounts && npm run test:install",
+    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/billing.js && node --check lib/pricing.js && node --check lib/network.js && node --check lib/provider-identity.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/accounts.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-overlay-layering.mjs && node --check scripts/test-bundle.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-provider-identity.mjs && node --check scripts/test-pricing.mjs && node --check scripts/test-billing.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/test-accounts.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
+    "test": "npm run test:bundle && npm run test:client && npm run test:overlay && npm run test:server && npm run test:provider-identity && npm run test:pricing && npm run test:billing && npm run test:balance && npm run test:subscriptions && npm run test:accounts && npm run test:install",
     "test:bundle": "node scripts/test-bundle.mjs",
     "test:client": "node scripts/smoke-client.mjs",
     "test:overlay": "node scripts/test-overlay-layering.mjs",
@@ -58,6 +58,7 @@
     "test:server": "node scripts/test-server.mjs",
     "test:provider-identity": "node scripts/test-provider-identity.mjs",
     "test:pricing": "node scripts/test-pricing.mjs",
+    "test:billing": "node scripts/test-billing.mjs",
     "test:balance": "node scripts/test-balance.mjs",
     "test:subscriptions": "node scripts/test-subscriptions.mjs",
     "test:accounts": "node scripts/test-accounts.mjs",

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -325,7 +325,8 @@ console.log("unified single-provider account card ok, balance:", deepseekMarkup.
 // Race regression (P1): usage and account must each keep their OWN staleness
 // counter, so an account request issued right after a usage request must NOT
 // invalidate the in-flight usage response.
-const { createLoader, fmtCurrency } = exports_;
+const { budgetWindowText, createLoader, fmtCurrency } = exports_;
+if (typeof budgetWindowText !== "function") throw new Error("budget display helper missing");
 const usageLoader = createLoader();
 const accountLoader = createLoader();
 const usageId = usageLoader.start();
@@ -343,6 +344,17 @@ if (!cny.includes("36.44")) throw new Error(`unexpected CNY format: ${cny}`);
 if (fmtCurrency(void 0, "CNY") !== "—") throw new Error("missing amount must render em dash");
 if (fmtCurrency("9.9", "USD").includes("¥")) throw new Error("USD must not render as ¥");
 console.log("currency formatting ok:", cny);
+const budgetTranslate = (key, params) => {
+	if (key === "budget.period.daily") return "Today";
+	if (key === "budget.level.warning") return "Near";
+	if (key === "budget.level.unknown") return "Unknown";
+	if (key === "budget.summary") return `${params.period}: ${params.spent} / ${params.limit} · ${params.level}`;
+	return key;
+};
+const warningBudget = budgetWindowText("daily", { limit: 10, currency: "USD", estimatedSpend: 8, costComplete: true, level: "warning" }, budgetTranslate);
+if (!warningBudget.includes("8.00") || !warningBudget.includes("10.00") || !warningBudget.includes("Near")) throw new Error(`known budget state must be visible: ${warningBudget}`);
+const unknownBudget = budgetWindowText("daily", { limit: 10, currency: "USD", estimatedSpend: null, costComplete: false, level: "unknown" }, budgetTranslate);
+if (!unknownBudget.includes("—") || !unknownBudget.includes("Unknown")) throw new Error("incomplete budget cost must stay unknown");
 
 // Collapsed-badge account value + warning policy (v0.2.0 unified account model).
 const { badgeAccountValue, badgeWarnOf } = exports_;
@@ -383,15 +395,17 @@ console.log("collapsed-badge account value + warning policy ok");
 const {
 	CurrentSessionPill,
 	CurrentSessionPillView,
+	currentSessionCostLabel,
 	formatResetCountdown,
 	loadSessionPillSnapshot,
 	requestUsageStatsPanel,
 	sessionContextSignalOf,
 	sessionPillViewOf,
 	modelSelectionSignalOf,
+	tokenUsageSignalOf,
 	subscribeUsageStatsPanel
 } = exports_;
-if ([CurrentSessionPill, CurrentSessionPillView, formatResetCountdown, loadSessionPillSnapshot, requestUsageStatsPanel, sessionContextSignalOf, sessionPillViewOf, modelSelectionSignalOf, subscribeUsageStatsPanel].some((entry) => typeof entry !== "function")) {
+if ([CurrentSessionPill, CurrentSessionPillView, currentSessionCostLabel, formatResetCountdown, loadSessionPillSnapshot, requestUsageStatsPanel, sessionContextSignalOf, sessionPillViewOf, modelSelectionSignalOf, tokenUsageSignalOf, subscribeUsageStatsPanel].some((entry) => typeof entry !== "function")) {
 	throw new Error("current-session pill exports are incomplete");
 }
 const resetTranslate = (key, params) => {
@@ -445,7 +459,7 @@ const unlimitedPill = sessionPillViewOf({
 	context: pillContext,
 	account: { ...balancePillSnapshot.account, balance: { remaining: null, currency: "USD", unlimited: true } }
 }, pillTranslate);
-if (unlimitedPill.value !== "∞") throw new Error("unlimited balance pill must render infinity");
+if (unlimitedPill.value !== "∞ · —") throw new Error("unlimited balance pill must render infinity plus unknown session cost");
 
 const subscriptionPill = sessionPillViewOf({
 	context: { ...pillContext, providerId: "opencode-go", accountId: "opencode-go" },
@@ -487,6 +501,37 @@ if (subscriptionPillWithReset.value !== subscriptionPill.value) throw new Error(
 const warningPill = sessionPillViewOf({ ...balancePillSnapshot, account: { ...balancePillSnapshot.account, alert: { level: "warning" } } }, pillTranslate);
 if (warningPill.tone !== "warning") throw new Error("warning alert tone must be preserved");
 
+const nativeTokenUsage = { uncachedInputTokens: 1_000_000, outputTokens: 100_000, cacheReadTokens: 250_000, cacheWriteTokens: 0 };
+const billedSession = {
+	sessionId: "session/one",
+	inputTokens: 1_000_000,
+	outputTokens: 100_000,
+	cacheReadTokens: 250_000,
+	cacheWriteTokens: 0,
+	tokens: 1_350_000,
+	estimatedCost: 0.37,
+	currency: "USD",
+	costComplete: true
+};
+const billedPill = sessionPillViewOf({
+	...balancePillSnapshot,
+	context: { ...pillContext, session: billedSession },
+	tokenUsage: nativeTokenUsage
+}, pillTranslate);
+if (!billedPill.value.includes("≈") || !billedPill.value.includes("0.37") || billedPill.tone !== "normal") {
+	throw new Error(`matching native projection must expose the server event-time estimate without changing account tone: ${JSON.stringify(billedPill)}`);
+}
+if (currentSessionCostLabel(billedSession, { ...nativeTokenUsage, outputTokens: 100_001 }) !== "—") {
+	throw new Error("projection/server bucket mismatch must fail closed");
+}
+if (currentSessionCostLabel({ ...billedSession, estimatedCost: null, currency: null, costComplete: false }, nativeTokenUsage) !== "—") {
+	throw new Error("incomplete server billing must render an em dash");
+}
+if (tokenUsageSignalOf({ uncachedInputTokens: 1, outputTokens: 23, cacheReadTokens: 4, cacheWriteTokens: 5 })
+	=== tokenUsageSignalOf({ uncachedInputTokens: 12, outputTokens: 3, cacheReadTokens: 4, cacheWriteTokens: 5 })) {
+	throw new Error("tokenUsage refresh signatures must not collide");
+}
+
 const statusKeys = new Map([
 	["not-configured", "subscription.status.notConfigured"],
 	["unauthorized", "subscription.status.unauthorized"],
@@ -502,10 +547,10 @@ for (const [status, expected] of statusKeys) {
 		context: pillContext,
 		account: { ...balancePillSnapshot.account, status, alert: { level: "critical" } }
 	}, pillTranslate);
-	if (view.value !== expected || view.tone !== "neutral") throw new Error(`${status} pill must be a neutral status, got ${JSON.stringify(view)}`);
+	if (view.value !== `${expected} · —` || view.tone !== "neutral") throw new Error(`${status} pill must be a neutral status, got ${JSON.stringify(view)}`);
 }
 const unknownProviderPill = sessionPillViewOf({ context: { ...pillContext, providerId: "relay-a", accountId: "relay-a" }, account: null, status: "unsupported" }, pillTranslate);
-if (unknownProviderPill.providerLabel !== "relay-a" || unknownProviderPill.value !== "sessionPill.status.unsupported" || unknownProviderPill.tone !== "neutral") {
+if (unknownProviderPill.providerLabel !== "relay-a" || unknownProviderPill.value !== "sessionPill.status.unsupported · —" || unknownProviderPill.tone !== "neutral") {
 	throw new Error("unknown/no-adapter provider must remain a neutral server identity");
 }
 
@@ -593,11 +638,27 @@ let lifecycleProvider = "deepseek-official";
 let resolveSwitchedContext;
 let holdSwitchedContext = false;
 const lifecycleRequests = [];
+const projectionSubscribers = new Set();
+let lifecycleProjection = nativeTokenUsage;
+const useLifecycleProjection = () => react.useSyncExternalStore(
+	(notify) => { projectionSubscribers.add(notify); return () => projectionSubscribers.delete(notify); },
+	() => lifecycleProjection,
+	() => lifecycleProjection
+);
+const lifecycleSession = () => ({
+	...billedSession,
+	inputTokens: lifecycleProjection.uncachedInputTokens,
+	outputTokens: lifecycleProjection.outputTokens,
+	cacheReadTokens: lifecycleProjection.cacheReadTokens,
+	cacheWriteTokens: lifecycleProjection.cacheWriteTokens,
+	tokens: lifecycleProjection.uncachedInputTokens + lifecycleProjection.outputTokens + lifecycleProjection.cacheReadTokens + lifecycleProjection.cacheWriteTokens,
+	estimatedCost: lifecycleProjection.uncachedInputTokens / 1_000_000 * 0.37
+});
 const lifecycleRequest = async (path) => {
 	lifecycleRequests.push(path);
 	if (path.startsWith("/api/usage-stats/session-context")) {
 		if (holdSwitchedContext) return new Promise((resolve) => { resolveSwitchedContext = resolve; });
-		return { ok: true, context: { ...pillContext, providerId: lifecycleProvider, accountId: lifecycleProvider } };
+		return { ok: true, context: { ...pillContext, providerId: lifecycleProvider, accountId: lifecycleProvider, session: lifecycleSession() } };
 	}
 	return {
 		ok: true,
@@ -612,6 +673,7 @@ await act(async () => {
 		sessionId: "session-one",
 		session: baseSession,
 		modelDirectory,
+		useProjection: useLifecycleProjection,
 		request: lifecycleRequest,
 		t: (key) => key
 	}));
@@ -620,6 +682,19 @@ await act(async () => {
 });
 if (pillRenderer.root.findAllByProps({ "data-current-session-pill": true }).length !== 1) throw new Error("successful mount must create exactly one pill");
 if (pillRenderer.root.findByType("button").props["data-provider"] !== "deepseek-official") throw new Error("initial lifecycle provider missing");
+if (!JSON.stringify(pillRenderer.toJSON()).includes("0.37")) throw new Error("initial native projection must expose matching estimated cost");
+
+const beforeProjectionRefresh = lifecycleRequests.filter((path) => path.startsWith("/api/usage-stats/session-context")).length;
+await act(async () => {
+	lifecycleProjection = { ...nativeTokenUsage, uncachedInputTokens: 2_000_000 };
+	for (const subscriber of projectionSubscribers) subscriber();
+	await Promise.resolve();
+	await Promise.resolve();
+});
+if (lifecycleRequests.filter((path) => path.startsWith("/api/usage-stats/session-context")).length !== beforeProjectionRefresh + 1) {
+	throw new Error("native tokenUsage projection changes must trigger exactly one billing snapshot reload");
+}
+if (!JSON.stringify(pillRenderer.toJSON()).includes("0.74")) throw new Error("projection-driven reload must update the estimated cost");
 
 lifecycleProvider = "opencode-go";
 holdSwitchedContext = true;
@@ -631,7 +706,7 @@ await act(async () => {
 if (pillRenderer.toJSON() !== null) throw new Error("provider switch must not leave the previous session/account pill clickable while loading");
 holdSwitchedContext = false;
 await act(async () => {
-	resolveSwitchedContext({ ok: true, context: { ...pillContext, providerId: "opencode-go", accountId: "opencode-go" } });
+	resolveSwitchedContext({ ok: true, context: { ...pillContext, providerId: "opencode-go", accountId: "opencode-go", session: lifecycleSession() } });
 	await Promise.resolve();
 	await Promise.resolve();
 });
@@ -675,7 +750,15 @@ globalThis.fetch = async (path) => {
 				]
 			};
 			if (String(path).includes("/account")) return { ok: true, account: { id: "opencode-go", displayName: "OpenCode Go", mode: "subscription", status: "ok", windows: [{ kind: "weekly", remainingPercent: 18 }], alert: { level: "warning" } } };
-			return { ok: true, days: [], total: { tokens: 0 } };
+			return {
+				ok: true,
+				days: [],
+				total: { tokens: 0 },
+				budgets: {
+					daily: { limit: 10, currency: "USD", estimatedSpend: 8, costComplete: true, level: "warning" },
+					monthly: { limit: null, currency: "USD", estimatedSpend: 8, costComplete: true, level: "disabled" }
+				}
+			};
 		}
 	};
 };
@@ -699,6 +782,10 @@ if (integrationRenderer.root.findAllByProps({ "data-usage-stats-panel": true }).
 const selectedPicker = integrationRenderer.root.findByType("select");
 if (selectedPicker.props.value !== "opencode-go") throw new Error(`pill click must select its provider in the existing panel, got ${selectedPicker.props.value}`);
 if (!integrationRequests.some((path) => path.includes("/account?provider=opencode-go&activity=detail"))) throw new Error("the open detail panel must signal its provider to the central scheduler");
+if (integrationRenderer.root.findAllByProps({ "data-budget-period": "daily" }).length !== 1
+	|| integrationRenderer.root.findByProps({ "data-budget-period": "daily" }).props["data-budget-level"] !== "warning") {
+	throw new Error("configured budget state must integrate into the existing usage panel");
+}
 await act(async () => { integrationRenderer.unmount(); });
 globalThis.fetch = originalFetch;
 

--- a/scripts/test-billing.mjs
+++ b/scripts/test-billing.mjs
@@ -3,11 +3,13 @@ import assert from "node:assert/strict";
 import {
 	applyCostSample,
 	budgetLevel,
+	changedProviderPricingRoutes,
 	costSampleOf,
 	createCostAccumulator,
 	createUsageCostEstimator,
 	parseCostAccumulator,
 	pricingFingerprint,
+	providerPricingIdentityProjection,
 	renderBudgetSummary,
 	renderCost,
 	serializeCostAccumulator,
@@ -27,6 +29,33 @@ const openrouter = { id: "openrouter", displayName: "OpenRouter", baseURL: "http
 const customRelay = { id: "deepseek", displayName: "Corporate Relay", baseURL: "https://relay.invalid/v1" };
 const estimator = createUsageCostEstimator([official, openrouter, customRelay]);
 assert.match(pricingFingerprint(), /providerIdentityPolicy/, "derived-cost cache identity must include provider classification policy");
+
+{
+	const routeOfficial = { id: "route-a", displayName: "Route A", baseURL: "https://api.deepseek.com/v1" };
+	const routeCustom = { ...routeOfficial, baseURL: "https://relay.invalid/v1" };
+	const stableA = pricingFingerprint({ providers: [routeOfficial, openrouter] });
+	const stableB = pricingFingerprint({ providers: [openrouter, { ...routeOfficial }] });
+	const custom = pricingFingerprint({ providers: [routeCustom, openrouter] });
+	assert.equal(stableA, stableB, "provider pricing identity order and object identity must not affect the fingerprint");
+	assert.deepEqual(changedProviderPricingRoutes(stableA, stableB), []);
+	assert.deepEqual(changedProviderPricingRoutes(stableA, custom), ["route-a"], "official to custom must change the affected route identity");
+	assert.deepEqual(changedProviderPricingRoutes(custom, stableA), ["route-a"], "custom to official must change the affected route identity");
+	assert.equal(changedProviderPricingRoutes("legacy-catalog-only", stableA), null, "unprovable old identity must request a global fail-closed transition");
+	assert.deepEqual(providerPricingIdentityProjection([routeOfficial]), [{
+		routeId: "route-a",
+		providerFamily: "deepseek",
+		pricingFamily: "deepseek",
+		confidence: "canonical-host",
+		baseURL: { state: "hostname", hostname: "api.deepseek.com" }
+	}]);
+	assert.equal(providerPricingIdentityProjection([{ id: "deepseek" }])[0].baseURL.state, "absent");
+	assert.equal(providerPricingIdentityProjection([{ id: "deepseek", baseURL: "not a URL" }])[0].baseURL.state, "malformed");
+	const credentialURLFingerprint = pricingFingerprint({
+		providers: [{ ...routeOfficial, baseURL: "https://username:password@api.deepseek.com/v1?token=secret" }]
+	});
+	assert.doesNotMatch(credentialURLFingerprint, /username|password|token=|secret/i, "fingerprint must retain only the normalized hostname, never URL credentials/query data");
+	console.log("runtime provider pricing fingerprint is deterministic and secret-free");
+}
 
 const buckets = (inputTokens, outputTokens = 0, cacheReadTokens = 0, cacheWriteTokens = 0) => ({
 	inputTokens,

--- a/scripts/test-billing.mjs
+++ b/scripts/test-billing.mjs
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+
+import {
+	applyCostSample,
+	budgetLevel,
+	costSampleOf,
+	createCostAccumulator,
+	createUsageCostEstimator,
+	parseCostAccumulator,
+	pricingFingerprint,
+	renderBudgetSummary,
+	renderCost,
+	serializeCostAccumulator,
+	validateBudgetConfig
+} from "../lib/billing.js";
+import {
+	applyUsageDelta,
+	createUsageState,
+	mergeBillingInto,
+	mergeInto,
+	renderSessionUsage,
+	renderUsage
+} from "../lib/usage.js";
+
+const official = { id: "deepseek-official", displayName: "DeepSeek", baseURL: "https://api.deepseek.com" };
+const openrouter = { id: "openrouter", displayName: "OpenRouter", baseURL: "https://openrouter.ai/api/v1" };
+const customRelay = { id: "deepseek", displayName: "Corporate Relay", baseURL: "https://relay.invalid/v1" };
+const estimator = createUsageCostEstimator([official, openrouter, customRelay]);
+assert.match(pricingFingerprint(), /providerIdentityPolicy/, "derived-cost cache identity must include provider classification policy");
+
+const buckets = (inputTokens, outputTokens = 0, cacheReadTokens = 0, cacheWriteTokens = 0) => ({
+	inputTokens,
+	outputTokens,
+	cacheReadTokens,
+	cacheWriteTokens
+});
+
+function request(seq, time, providerId, model) {
+	return {
+		seq,
+		time,
+		type: "request/header",
+		data: { header: { config: { provider: providerId, model } } }
+	};
+}
+
+function usage(seq, time, turn, step, providerId, model, value, type = "assistant/message") {
+	if (type === "assistant/chunk") {
+		return {
+			seq,
+			time,
+			type,
+			data: { turn, step, chunk: { type: "usage", usage: value } }
+		};
+	}
+	return {
+		seq,
+		time,
+		type,
+		data: { turn, step, usage: value, message: { source: { provider: providerId, model } } }
+	};
+}
+
+const ruleA = Date.parse("2026-08-15T02:00:00Z");
+const ruleB = Date.parse("2026-08-20T02:00:00Z");
+const ruleC = Date.parse("2026-08-24T02:00:00Z");
+
+{
+	assert.notEqual(estimator({ providerId: "deepseek-official", model: "deepseek-v4-pro", timestamp: ruleC, buckets: buckets(1_000_000) }), null);
+	assert.equal(estimator({ providerId: "openrouter", model: "deepseek-v4-pro", timestamp: ruleC, buckets: buckets(1_000_000) }), null);
+	assert.equal(estimator({ providerId: "deepseek", model: "deepseek-v4-pro", timestamp: ruleC, buckets: buckets(1_000_000) }), null);
+	assert.equal(estimator({ providerId: "unknown", model: "deepseek-v4-pro", timestamp: ruleC, buckets: buckets(1_000_000) }), null);
+	assert.equal(estimator({ providerId: "deepseek-official", model: "unknown-model", timestamp: ruleC, buckets: buckets(1_000_000) }), null);
+	assert.equal(estimator({ providerId: "deepseek-official", model: "deepseek-v4-pro", timestamp: ruleC, buckets: buckets(0, 0, 0, 1) }), null);
+	console.log("official DeepSeek pricing and unpriced route/cache-write safety ok");
+}
+
+{
+	const state = createUsageState();
+	applyUsageDelta(state, [
+		request(0, ruleA, "deepseek-official", "deepseek-v4-pro"),
+		usage(1, ruleA, 1, 0, "deepseek-official", "deepseek-v4-pro", buckets(1_000_000)),
+		usage(2, ruleB, 2, 0, "deepseek-official", "deepseek-v4-pro", buckets(1_000_000)),
+		usage(3, ruleC, 3, 0, "deepseek-official", "deepseek-v4-pro", buckets(1_000_000))
+	], { estimateCost: estimator });
+	const rendered = renderSessionUsage("historical", state);
+	assert.deepEqual(rendered.pricing.ruleIds, [
+		"deepseek-v4-pro-usd-flat-before-2026-08-16",
+		"deepseek-v4-pro-usd-time-band-v1",
+		"deepseek-v4-pro-usd-weekday-schedule"
+	]);
+	assert.equal(rendered.costComplete, true);
+	console.log("Rule A/B/C event-time pricing provenance ok");
+}
+
+{
+	const peakAt = Date.parse("2026-08-24T02:00:00Z");
+	const offPeakAt = Date.parse("2026-08-24T05:00:00Z");
+	const state = createUsageState();
+	applyUsageDelta(state, [
+		usage(1, peakAt, 1, 0, "deepseek-official", "deepseek-v4-pro", buckets(1_000_000)),
+		usage(2, offPeakAt, 2, 0, "deepseek-official", "deepseek-v4-pro", buckets(1_000_000))
+	], { estimateCost: estimator });
+	const peak = estimator({ providerId: "deepseek-official", model: "deepseek-v4-pro", timestamp: peakAt, buckets: buckets(1_000_000) });
+	const offPeak = estimator({ providerId: "deepseek-official", model: "deepseek-v4-pro", timestamp: offPeakAt, buckets: buckets(1_000_000) });
+	assert.equal(peak.tariff, "peak");
+	assert.equal(offPeak.tariff, "offPeak");
+	assert.equal(renderSessionUsage("time-bands", state).estimatedCost, peak.amount + offPeak.amount,
+		"a session spanning price bands must add event-time estimates, not reprice cumulative tokens");
+	console.log("same-rule peak/offPeak session pricing ok");
+}
+
+{
+	const state = createUsageState();
+	const first = buckets(1_000_000);
+	const replacement = buckets(2_000_000, 100_000);
+	applyUsageDelta(state, [
+		request(0, ruleA, "deepseek-official", "deepseek-v4-pro"),
+		usage(1, ruleA, 1, 0, "deepseek-official", "deepseek-v4-pro", first, "assistant/chunk")
+	], { estimateCost: estimator });
+	const originalCost = renderSessionUsage("replace", state).estimatedCost;
+	applyUsageDelta(state, [
+		usage(2, ruleC, 1, 0, "deepseek-official", "deepseek-v4-pro", replacement)
+	], { estimateCost: estimator });
+	const rendered = renderSessionUsage("replace", state);
+	const expected = estimator({ providerId: "deepseek-official", model: "deepseek-v4-pro", timestamp: ruleC, buckets: replacement });
+	assert.notEqual(originalCost, expected.amount, "fixture must cross a historical/tariff boundary");
+	assert.equal(rendered.estimatedCost, expected.amount, "replacement must subtract the old monetary contribution before adding the new one");
+	assert.equal(rendered.tokens, 2_100_000);
+	assert.equal(rendered.firstAt, new Date(ruleC).toISOString(), "a sole sample replacement must move the session boundary time");
+	assert.deepEqual(rendered.pricing.ruleIds, [expected.ruleId]);
+	const byDay = new Map();
+	const billingByDay = new Map();
+	mergeInto(byDay, state.days);
+	mergeBillingInto(billingByDay, state.billing.days);
+	const days = renderUsage(byDay, ruleC + 1, billingByDay).days;
+	assert.equal(days.find((day) => day.date === "2026-08-15").tokens, 0);
+	assert.equal(days.find((day) => day.date === "2026-08-15").estimatedCost, null);
+	assert.equal(days.find((day) => day.date === "2026-08-24").estimatedCost, expected.amount);
+	console.log("cross-day/tariff replace-last-sample billing semantics ok");
+}
+
+{
+	const state = createUsageState();
+	applyUsageDelta(state, [
+		usage(1, ruleC, 1, 0, "deepseek-official", "deepseek-v4-pro", buckets(1_000_000)),
+		usage(2, ruleC + 1, 2, 0, "openrouter", "deepseek-v4-pro", buckets(1_000_000))
+	], { estimateCost: estimator });
+	const rendered = renderSessionUsage("partial", state);
+	assert.equal(rendered.tokens, 2_000_000);
+	assert.equal(rendered.estimatedCost, null);
+	assert.equal(rendered.currency, null);
+	assert.equal(rendered.costComplete, false, "one unpriced sample must invalidate the whole session estimate");
+	console.log("priced + unpriced session fails closed without partial cost");
+}
+
+{
+	const mixed = createUsageState();
+	const mixedEstimator = ({ providerId }) => ({
+		amount: 1,
+		currency: providerId === "usd" ? "USD" : "CNY",
+		ruleId: `rule-${providerId}`,
+		source: { kind: "official", provider: providerId, url: `https://${providerId}.invalid/pricing` },
+		updatedAt: "2026-08-25T00:00:00.000Z"
+	});
+	applyUsageDelta(mixed, [
+		usage(1, ruleC, 1, 0, "usd", "model", buckets(1)),
+		usage(2, ruleC + 1, 2, 0, "cny", "model", buckets(1))
+	], { estimateCost: mixedEstimator });
+	assert.deepEqual(renderSessionUsage("mixed", mixed), {
+		sessionId: "mixed",
+		title: null,
+		providers: ["cny", "usd"],
+		models: ["cny/model", "usd/model"],
+		inputTokens: 2,
+		outputTokens: 0,
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+		tokens: 2,
+		estimatedCost: null,
+		currency: null,
+		costComplete: false,
+		pricing: { ruleIds: ["rule-cny", "rule-usd"], source: null, updatedAt: "2026-08-25T00:00:00.000Z" },
+		firstAt: new Date(ruleC).toISOString(),
+		lastAt: new Date(ruleC + 1).toISOString()
+	});
+	console.log("mixed currencies are never silently summed");
+}
+
+{
+	assert.deepEqual(validateBudgetConfig(), { currency: "USD", daily: null, monthly: null });
+	assert.deepEqual(validateBudgetConfig({ currency: "CNY", daily: 5, monthly: 100 }), { currency: "CNY", daily: 5, monthly: 100 });
+	for (const invalid of [
+		{ currency: "usd" },
+		{ currency: "USDT" },
+		{ daily: 0 },
+		{ daily: -1 },
+		{ monthly: Infinity }
+	]) assert.throws(() => validateBudgetConfig(invalid), /budgets/);
+	assert.equal(budgetLevel(79.999), "normal");
+	assert.equal(budgetLevel(80), "warning");
+	assert.equal(budgetLevel(99.999), "warning");
+	assert.equal(budgetLevel(100), "critical");
+
+	const at = new Date(2026, 7, 25, 12).getTime();
+	const key = `${new Date(at).getFullYear()}-${String(new Date(at).getMonth() + 1).padStart(2, "0")}-${String(new Date(at).getDate()).padStart(2, "0")}`;
+	const dayCosts = new Map([[key, { total: createCostAccumulator(), models: new Map() }]]);
+	applyCostSample(dayCosts.get(key).total, costSampleOf({ amount: 8, currency: "USD", ruleId: "r", source: null, updatedAt: null }, buckets(1)));
+	const sameMonth = `${key.slice(0, 8)}01`;
+	const previousMonth = `${key.slice(0, 5)}${String(Number(key.slice(5, 7)) - 1).padStart(2, "0")}-28`;
+	dayCosts.set(sameMonth, { total: createCostAccumulator(), models: new Map() });
+	dayCosts.set(previousMonth, { total: createCostAccumulator(), models: new Map() });
+	applyCostSample(dayCosts.get(sameMonth).total, costSampleOf({ amount: 1, currency: "USD", ruleId: "r", source: null, updatedAt: null }, buckets(1)));
+	applyCostSample(dayCosts.get(previousMonth).total, costSampleOf({ amount: 100, currency: "USD", ruleId: "r", source: null, updatedAt: null }, buckets(1)));
+	let summary = renderBudgetSummary(dayCosts, validateBudgetConfig({ daily: 10, monthly: 10 }), at);
+	assert.equal(summary.daily.level, "warning");
+	assert.equal(summary.monthly.level, "warning");
+	assert.equal(summary.daily.estimatedSpend, 8);
+	assert.equal(summary.monthly.estimatedSpend, 9, "monthly spend must include the current month and exclude earlier months");
+	applyCostSample(dayCosts.get(key).total, costSampleOf({ amount: 2, currency: "USD", ruleId: "r", source: null, updatedAt: null }, buckets(1)));
+	summary = renderBudgetSummary(dayCosts, validateBudgetConfig({ daily: 10, monthly: 10 }), at);
+	assert.equal(summary.daily.level, "critical");
+	assert.equal(summary.monthly.level, "critical");
+	const incompatible = renderBudgetSummary(dayCosts, validateBudgetConfig({ currency: "CNY", daily: 10, monthly: 10 }), at);
+	assert.equal(incompatible.daily.level, "unknown");
+	assert.equal(incompatible.daily.estimatedSpend, null);
+	applyCostSample(dayCosts.get(key).total, costSampleOf(null, buckets(1)));
+	const incomplete = renderBudgetSummary(dayCosts, validateBudgetConfig({ daily: 10, monthly: 10 }), at);
+	assert.equal(incomplete.daily.level, "unknown");
+	assert.equal(incomplete.monthly.costComplete, false);
+	console.log("budget validation and 80/100 percent boundaries ok");
+}
+
+{
+	const states = [createUsageState(), createUsageState()];
+	let estimates = 0;
+	const countingEstimator = (input) => {
+		estimates += 1;
+		return estimator(input);
+	};
+	applyUsageDelta(states[0], [usage(1, ruleC, 1, 0, "deepseek-official", "deepseek-v4-pro", buckets(10, 2, 3))], { estimateCost: countingEstimator });
+	applyUsageDelta(states[1], [usage(1, ruleC + 1, 1, 0, "deepseek-official", "deepseek-v4-pro", buckets(20, 4, 6))], { estimateCost: countingEstimator });
+	applyUsageDelta(states[1], [], { estimateCost: countingEstimator });
+	assert.equal(estimates, 2, "steady state must price only new usage samples");
+	const byDay = new Map();
+	const billingByDay = new Map();
+	for (const state of states) {
+		mergeInto(byDay, state.days);
+		mergeBillingInto(billingByDay, state.billing.days);
+	}
+	const global = renderUsage(byDay, ruleC + 2, billingByDay);
+	const sessions = states.map((state, index) => renderSessionUsage(`s${index}`, state));
+	assert.equal(global.total.tokens, sessions.reduce((sum, session) => sum + session.tokens, 0));
+	assert.deepEqual({
+		inputTokens: global.total.inputTokens,
+		outputTokens: global.total.outputTokens,
+		cacheReadTokens: global.total.cacheReadTokens,
+		cacheWriteTokens: global.total.cacheWriteTokens,
+		tokens: global.total.tokens
+	}, { inputTokens: 30, outputTokens: 6, cacheReadTokens: 9, cacheWriteTokens: 0, tokens: 45 }, "billing derivation must not change legacy token totals");
+	assert.equal(global.days[0].models[0].tokens, 45);
+	const restored = parseCostAccumulator(serializeCostAccumulator(states[0].billing.total));
+	assert.deepEqual(renderCost(restored), renderCost(states[0].billing.total));
+	console.log("session/global reconciliation, unchanged token aggregation, O(new), and cache round-trip ok");
+}
+
+console.log("BILLING + BUDGET TESTS PASSED");

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { pricingFingerprint } from "../lib/billing.js";
 
 function usageEvent(seq, inputTokens) {
 	return {
@@ -270,9 +271,15 @@ async function testPricingFingerprintInvalidatesDerivedCosts(root) {
 	const storage = join(home, "storages");
 	await mkdir(storage, { recursive: true });
 	const sessionId = "fingerprint-session";
+	const oldFingerprint = JSON.parse(pricingFingerprint({ providers: [{
+		id: "deepseek-official",
+		displayName: "DeepSeek",
+		baseURL: "https://api.deepseek.com"
+	}] }));
+	oldFingerprint.pricingCatalog = [];
 	await writeFile(join(storage, "usage-stats-cache.json"), JSON.stringify({
 		version: 5,
-		pricingFingerprint: "stale-catalog",
+		pricingFingerprint: JSON.stringify(oldFingerprint),
 		sessions: {
 			[sessionId]: {
 				kind: "live",
@@ -291,10 +298,60 @@ async function testPricingFingerprintInvalidatesDerivedCosts(root) {
 		persistence: { listSnapshots: async () => [], list: async () => [] },
 		settings: { get: () => void 0 }
 	}));
-	assert.equal(usage.sessions[0].costComplete, true, "a stale pricing fingerprint must refold event-time costs");
+	assert.equal(usage.sessions[0].costComplete, true, "a catalog-only fingerprint change with unchanged provider identity may safely refold event-time costs");
 	assert.equal(usage.sessions[0].tokens, 1_000_000);
 	const rewritten = JSON.parse(await readFile(join(storage, "usage-stats-cache.json"), "utf8"));
-	assert.notEqual(rewritten.pricingFingerprint, "stale-catalog");
+	assert.notEqual(rewritten.pricingFingerprint, JSON.stringify(oldFingerprint));
+	assert.equal(rewritten.pricingIdentityCutoffAll, null, "catalog-only changes must not invent a provider identity cutoff");
+}
+
+async function testRuntimeProviderPricingIdentityChange(root) {
+	const home = join(root, "runtime-provider-pricing-identity");
+	const plugin = await freshModule("runtime-provider-pricing-identity", home);
+	const eventTime = Date.UTC(2026, 7, 24, 2, 0, 0);
+	const oldSession = { id: "old-route-session", events: [pricedUsageEvent(0, eventTime, "route-a", "deepseek-v4-pro", 1_000_000)] };
+	const liveSessions = [oldSession];
+	let baseURL = "https://api.deepseek.com/v1";
+	const settings = {
+		get: (name) => name === "llm-pi-ai" ? {
+			providers: { "route-a": { displayName: "Route A", baseURL } }
+		} : void 0
+	};
+	const context = makeContext({
+		sessions: { list: () => liveSessions },
+		persistence: { listSnapshots: async () => [], list: async () => [] },
+		settings
+	});
+
+	const official = await plugin.collectUsage(context);
+	assert.equal(official.sessions.find((session) => session.sessionId === oldSession.id).costComplete, true);
+	const officialCache = JSON.parse(await readFile(join(home, "storages", "usage-stats-cache.json"), "utf8"));
+
+	baseURL = "https://username:password@relay.invalid/v1?token=SECRET";
+	const custom = await plugin.collectUsage(context);
+	assert.equal(custom.sessions.find((session) => session.sessionId === oldSession.id).estimatedCost, null,
+		"official to custom must invalidate the already-loaded in-memory billing cache");
+	const customCacheText = await readFile(join(home, "storages", "usage-stats-cache.json"), "utf8");
+	const customCache = JSON.parse(customCacheText);
+	assert.notEqual(customCache.pricingFingerprint, officialCache.pricingFingerprint);
+	assert.equal(Number.isFinite(customCache.pricingIdentityCutoffs["route-a"]), true);
+	assert.doesNotMatch(customCache.pricingFingerprint, /username|password|token=|SECRET/i,
+		"runtime fingerprint must never persist URL credentials or query secrets");
+
+	baseURL = "https://api.deepseek.com/v1";
+	const restoredOfficial = await plugin.collectUsage(context);
+	assert.equal(restoredOfficial.sessions.find((session) => session.sessionId === oldSession.id).estimatedCost, null,
+		"custom to official must not reinterpret historical custom-relay usage as official usage");
+	const restoredCache = JSON.parse(await readFile(join(home, "storages", "usage-stats-cache.json"), "utf8"));
+	assert.notEqual(restoredCache.pricingFingerprint, customCache.pricingFingerprint);
+	assert.equal(restoredCache.pricingIdentityCutoffs["route-a"] >= customCache.pricingIdentityCutoffs["route-a"], true);
+
+	const futureAt = restoredCache.pricingIdentityCutoffs["route-a"] + 1;
+	liveSessions.push({ id: "new-official-session", events: [pricedUsageEvent(0, futureAt, "route-a", "deepseek-v4-pro", 1_000_000)] });
+	const future = await plugin.collectUsage(context);
+	assert.equal(future.sessions.find((session) => session.sessionId === oldSession.id).costComplete, false);
+	assert.equal(future.sessions.find((session) => session.sessionId === "new-official-session").costComplete, true,
+		"events after the observed identity transition may use the new official pricing identity");
 }
 
 async function testConfigValidation(root) {
@@ -570,6 +627,7 @@ try {
 	await testSessionContext(root);
 	await testV4CacheUpgradeRefoldsBilling(root);
 	await testPricingFingerprintInvalidatesDerivedCosts(root);
+	await testRuntimeProviderPricingIdentityChange(root);
 	await testConfigValidation(root);
 	await testUsageBillingWire(root);
 	await testLegacyZaiSubscriptionId(root);

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -26,6 +26,20 @@ function routeEvent(seq, provider, model) {
 	};
 }
 
+function pricedUsageEvent(seq, time, provider, model, inputTokens) {
+	return {
+		seq,
+		time,
+		type: "assistant/message",
+		data: {
+			turn: `priced-${seq}`,
+			step: 0,
+			usage: { inputTokens, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+			message: { source: { provider, model } }
+		}
+	};
+}
+
 async function freshModule(label, home) {
 	process.env.DSH_HOME = home;
 	return import(new URL(`../lib/index.js?test=${label}-${Date.now()}-${Math.random()}`, import.meta.url));
@@ -124,27 +138,34 @@ async function testSessionContext(root) {
 	const first = makeResponse();
 	await handler({ method: "GET", url: `${plugin.SESSION_CONTEXT_PATH}?session=live-session`, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, first);
 	assert.equal(first.status, 200);
-	assert.deepEqual(JSON.parse(first.body).context, {
+	const firstContext = JSON.parse(first.body).context;
+	assert.deepEqual({ ...firstContext, session: void 0 }, {
 		sessionId: "live-session",
 		providerId: "route-a",
 		providerFamily: "deepseek",
 		model: "shared-model",
 		accountId: "route-a",
-		updatedAt: Date.UTC(2026, 7, 23, 12, 0, 0)
+		updatedAt: Date.UTC(2026, 7, 23, 12, 0, 0),
+		session: void 0
 	});
+	assert.equal(firstContext.session.sessionId, "live-session");
+	assert.equal(firstContext.session.tokens, 0);
 	assert.doesNotMatch(first.body, /SECRET|apiKey|baseURL/i, "session context must not expose connection or credential fields");
 	assert.deepEqual(touches.at(-1), ["route-a", "active"], "session context must signal only its resolver-owned account identity");
 
 	const selectorSwitched = makeResponse();
 	await handler({ method: "GET", url: `${plugin.SESSION_CONTEXT_PATH}?session=live-session&provider=route-b&model=shared-model`, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, selectorSwitched);
-	assert.deepEqual(JSON.parse(selectorSwitched.body).context, {
+	const switchedContext = JSON.parse(selectorSwitched.body).context;
+	assert.deepEqual({ ...switchedContext, session: void 0 }, {
 		sessionId: "live-session",
 		providerId: "route-b",
 		providerFamily: "ollama",
 		model: "shared-model",
 		accountId: "route-b",
-		updatedAt: null
+		updatedAt: null,
+		session: void 0
 	}, "an accepted selector route must override the last request/header immediately");
+	assert.deepEqual(switchedContext.session, firstContext.session, "selector hints must not rewrite historical session billing");
 	assert.deepEqual(touches.at(-1), ["route-b", "active"], "selector route changes must update central scheduler activity");
 	const invalidSelectionQueries = [
 		"provider=route-b",
@@ -188,25 +209,29 @@ async function testSessionContext(root) {
 	assert.equal(JSON.parse(ambiguous.body).error, "session-required");
 }
 
-async function testV3CacheUpgradeRefoldsCurrentRoute(root) {
-	const home = join(root, "v3-cache-upgrade");
+async function testV4CacheUpgradeRefoldsBilling(root) {
+	const home = join(root, "v4-cache-upgrade");
 	const storage = join(home, "storages");
 	await mkdir(storage, { recursive: true });
 	const sessionId = "cached-live-session";
 	await writeFile(join(storage, "usage-stats-cache.json"), JSON.stringify({
-		version: 3,
+		version: 4,
 		sessions: {
 			[sessionId]: {
 				kind: "live",
-				consumed: 1,
+				consumed: 2,
 				days: {},
 				lastSample: null,
 				currentModel: "route-a/deepseek-chat"
 			}
 		}
 	}), "utf8");
-	const plugin = await freshModule("v3-cache-upgrade", home);
-	const session = { id: sessionId, events: [routeEvent(0, "route-a", "deepseek-chat")] };
+	const plugin = await freshModule("v4-cache-upgrade", home);
+	const eventTime = Date.UTC(2026, 7, 24, 2, 0, 0);
+	const session = { id: sessionId, events: [
+		routeEvent(0, "route-a", "deepseek-v4-pro"),
+		pricedUsageEvent(1, eventTime, "route-a", "deepseek-v4-pro", 1_000_000)
+	] };
 	const settings = {
 		get: (name) => name === "llm-pi-ai" ? {
 			providers: {
@@ -220,17 +245,56 @@ async function testV3CacheUpgradeRefoldsCurrentRoute(root) {
 		settings
 	});
 
-	assert.deepEqual(await plugin.collectSessionContext(context, sessionId), {
+	const migratedContext = await plugin.collectSessionContext(context, sessionId);
+	assert.deepEqual({ ...migratedContext, session: void 0 }, {
 		sessionId,
 		providerId: "route-a",
 		providerFamily: "deepseek",
-		model: "deepseek-chat",
+		model: "deepseek-v4-pro",
 		accountId: "route-a",
-		updatedAt: Date.UTC(2026, 7, 23, 12, 0, 0)
-	}, "a v3 cache without currentRoute must be invalidated and refolded even when no event is new");
+		updatedAt: eventTime,
+		session: void 0
+	}, "a v4 cache without billing must be invalidated and refolded even when no event is new");
+	assert.equal(migratedContext.session.costComplete, true);
+	assert.equal(migratedContext.session.currency, "USD");
+	assert.equal(migratedContext.session.tokens, 1_000_000);
 	const migrated = JSON.parse(await readFile(join(storage, "usage-stats-cache.json"), "utf8"));
-	assert.equal(migrated.version, 4, "the rewritten cache must use schema v4");
+	assert.equal(migrated.version, 5, "the rewritten cache must use schema v5");
+	assert.equal(typeof migrated.pricingFingerprint, "string");
 	assert.equal(migrated.sessions[sessionId].currentRoute.providerId, "route-a");
+	assert.equal(migrated.sessions[sessionId].billing.sampleCount, 1);
+}
+
+async function testPricingFingerprintInvalidatesDerivedCosts(root) {
+	const home = join(root, "pricing-fingerprint");
+	const storage = join(home, "storages");
+	await mkdir(storage, { recursive: true });
+	const sessionId = "fingerprint-session";
+	await writeFile(join(storage, "usage-stats-cache.json"), JSON.stringify({
+		version: 5,
+		pricingFingerprint: "stale-catalog",
+		sessions: {
+			[sessionId]: {
+				kind: "live",
+				consumed: 1,
+				days: {},
+				lastSample: null,
+				currentModel: "deepseek-official/deepseek-v4-pro"
+			}
+		}
+	}), "utf8");
+	const plugin = await freshModule("pricing-fingerprint", home);
+	const eventTime = Date.UTC(2026, 7, 24, 2, 0, 0);
+	const session = { id: sessionId, events: [pricedUsageEvent(0, eventTime, "deepseek-official", "deepseek-v4-pro", 1_000_000)] };
+	const usage = await plugin.collectUsage(makeContext({
+		sessions: { list: () => [session] },
+		persistence: { listSnapshots: async () => [], list: async () => [] },
+		settings: { get: () => void 0 }
+	}));
+	assert.equal(usage.sessions[0].costComplete, true, "a stale pricing fingerprint must refold event-time costs");
+	assert.equal(usage.sessions[0].tokens, 1_000_000);
+	const rewritten = JSON.parse(await readFile(join(storage, "usage-stats-cache.json"), "utf8"));
+	assert.notEqual(rewritten.pricingFingerprint, "stale-catalog");
 }
 
 async function testConfigValidation(root) {
@@ -241,6 +305,9 @@ async function testConfigValidation(root) {
 	});
 	assert.deepEqual(validated.issues, void 0);
 	assert.deepEqual(validated.value.refresh, { enabled: false, activeMs: 120000, detailMs: 180000, backgroundMs: 240000 });
+	assert.deepEqual(validated.value.budgets, { currency: "USD", daily: null, monthly: null });
+	assert.deepEqual(plugin.Config["~standard"].validate({ budgets: { currency: "CNY", daily: 5, monthly: 100 } }).value.budgets, { currency: "CNY", daily: 5, monthly: 100 });
+	assert.match(plugin.Config["~standard"].validate({ budgets: { daily: 0 } }).issues[0].message, /budgets\.daily/);
 	assert.equal(plugin.Config["~standard"].validate({ disableBackgroundRefresh: true }).value.refresh.enabled, false);
 	assert.match(plugin.Config["~standard"].validate({ refresh: { activeMs: 1 } }).issues[0].message, /refresh\.activeMs/);
 	assert.match(plugin.Config["~standard"].validate({ monitors: { relay: { adapter: "missing" } } }).issues[0].message, /adapter is unsupported/);
@@ -256,6 +323,37 @@ async function testConfigValidation(root) {
 		/unknown provider: missing/
 	);
 	assert.equal(routes.size, 0, "invalid provider config must fail before routes are registered");
+}
+
+async function testUsageBillingWire(root) {
+	const plugin = await freshModule("usage-billing-wire", join(root, "usage-billing-wire"));
+	const routes = new Map();
+	const eventTime = Date.now();
+	const event = pricedUsageEvent(0, eventTime, "deepseek-official", "deepseek-v4-pro", 1_000_000);
+	const context = makeContext({
+		sessions: { list: () => [{ id: "billed-session", title: "Billing test", events: [event] }] },
+		persistence: { listSnapshots: async () => [], list: async () => [] },
+		routes,
+		settings: { get: () => void 0 }
+	});
+	await plugin.apply(context, { budgets: { currency: "USD", daily: 0.000001, monthly: 0.000001 } }, { disableBackgroundRefresh: true });
+	const response = makeResponse();
+	await routes.get(plugin.USAGE_PATH)({ method: "GET", url: plugin.USAGE_PATH, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } }, response);
+	assert.equal(response.status, 200);
+	const payload = JSON.parse(response.body);
+	assert.equal(payload.total.tokens, 1_000_000);
+	assert.equal(payload.total.inputTokens, 1_000_000);
+	assert.equal(payload.total.costComplete, true);
+	assert.equal(payload.total.currency, "USD");
+	assert.equal(payload.days[0].models[0].tokens, 1_000_000, "legacy day/model token totals must remain unchanged");
+	assert.equal(payload.days[0].models[0].costComplete, true);
+	assert.deepEqual(payload.sessions[0].providers, ["deepseek-official"]);
+	assert.deepEqual(payload.sessions[0].models, ["deepseek-official/deepseek-v4-pro"]);
+	assert.equal(payload.sessions[0].title, "Billing test");
+	assert.equal(payload.sessions[0].estimatedCost, payload.total.estimatedCost);
+	assert.equal(payload.budgets.daily.level, "critical");
+	assert.equal(payload.budgets.monthly.level, "critical");
+	assert.doesNotMatch(response.body, /apiKey|credential|SECRET/i);
 }
 
 async function testLegacyZaiSubscriptionId(root) {
@@ -380,7 +478,7 @@ async function testDisabledAccountRefresh(root) {
 	await schedulerCleanup.ready;
 	assert.equal(adaptiveCalls, 0, "disabled mode must not start the adaptive account scheduler");
 	const cache = JSON.parse(await readFile(join(home, "storages", "usage-stats-cache.json"), "utf8"));
-	assert.equal(cache.version, 4, "the surviving usage lifecycle must still fold and persist usage");
+	assert.equal(cache.version, 5, "the surviving usage lifecycle must still fold and persist usage");
 	await schedulerCleanup();
 }
 
@@ -470,8 +568,10 @@ const root = await mkdtemp(join(tmpdir(), "dsh-usage-stats-"));
 try {
 	await testRouteFence(root);
 	await testSessionContext(root);
-	await testV3CacheUpgradeRefoldsCurrentRoute(root);
+	await testV4CacheUpgradeRefoldsBilling(root);
+	await testPricingFingerprintInvalidatesDerivedCosts(root);
 	await testConfigValidation(root);
+	await testUsageBillingWire(root);
 	await testLegacyZaiSubscriptionId(root);
 	await testBackgroundRefresh(root);
 	await testDisabledAccountRefresh(root);


### PR DESCRIPTION
Closes #63
Closes #20
Reference #65

## Summary
- derive event-time session/day/model costs through the existing incremental usage fold and `pricing.js`
- expose per-session billing, daily/monthly budget state, and cache-v5 pricing/identity invalidation
- extend the existing Current Session Pill with a fail-closed estimated cost driven by DSH's native `tokenUsage` projection

## Correctness boundaries
- no second token ledger, `llm/stream` listener, client accumulator, or new polling loop
- replacement samples subtract the old token and cost contribution before adding the new one
- unpriced samples and mixed currencies render `estimatedCost: null` / `costComplete: false`
- no FX, Top Sessions UI, export, notification, or version changes

## Validation
- `npm run check`
- `npm test`
- `npm pack --json`

Package version remains `0.2.10`.