### PR TITLE
feat: harden v0.3 release candidate

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,20 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate catalog metadata
-        shell: bash
-        run: |
-          set -euo pipefail
-          node <<'NODE'
-          const fs = require('fs');
-          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-          const page = JSON.parse(fs.readFileSync('catalog/v1/plugins.json', 'utf8'));
-          const source = JSON.parse(fs.readFileSync('catalog/catalog-source.json', 'utf8'));
-          if (pkg.name !== '@ychris12138/dsh-usage-stats') throw new Error('unexpected npm package identity');
-          if (page.revision !== pkg.version) throw new Error('catalog revision does not match package version');
-          if (page.items?.[0]?.latestVersion !== pkg.version) throw new Error('catalog latestVersion does not match package version');
-          if (page.items?.[0]?.package?.name !== pkg.name) throw new Error('catalog package name does not match package name');
-          if (source.transport?.endpoint !== 'https://ychris12138.github.io/dsh-usage-stats/v1/plugins') throw new Error('unexpected catalog endpoint');
-          NODE
+        run: npm run check:release
 
       - name: Build static catalog site
         shell: bash

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dsh-usage-stats
 
+<!-- stable-version: 0.2.10 -->
+
 [![GitHub Release](https://img.shields.io/github/v/release/Ychris12138/dsh-usage-stats?display_name=tag&sort=semver&color=1f6feb)](https://github.com/Ychris12138/dsh-usage-stats/releases/latest)
 [![CI](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml/badge.svg)](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-2da44e)](LICENSE)
@@ -8,7 +10,7 @@
 
 Provider balances, subscription quotas, and token-usage analytics for the DeepSeek Harness Web GUI (`dsh web`).
 
-![dsh-usage-stats v0.2.0 interface preview](docs/images/usage-panel.svg)
+![dsh-usage-stats interface preview](docs/images/usage-panel.svg)
 
 > 展示图使用脱敏演示数据；插件不会把 API Key、Cookie、管理 PAT 或上游原始响应发送到浏览器。
 
@@ -21,7 +23,8 @@ Provider balances, subscription quotas, and token-usage analytics for the DeepSe
 | 💰 | 估算费用与预算 | 按事件时间匹配历史价格，提供当前会话、日/月与 session 维度费用；可选日/月预算预警 |
 | 🔄 | 后台监测 | 账户按 active/detail/background 自适应刷新；间隔可配置或完全关闭，本地 Token 聚合保持独立运行 |
 | 🧩 | 可扩展适配器 | 支持 New API、Sub2API、通用余额模板，以及声明式 JSON Pointer 自定义查询 |
-| 🔒 | 本机安全边界 | 六个端点仅接受回环 GET；凭据只在服务端解析并发往校验后的供应商地址 |
+| 📦 | 安全导出 | 提供 daily/session CSV 与版本化 JSON；Unicode、CSV 公式前缀和不完整费用均安全处理 |
+| 🔒 | 本机安全边界 | 九个端点仅接受回环 GET；凭据只在服务端解析并发往校验后的供应商地址 |
 
 界面支持中文和英文。浏览器只请求当前选择的 provider；账户自动刷新由服务端统一调度。手动刷新会更新用量、供应商列表，并强制刷新当前账户，不会批量强制请求其他供应商。
 
@@ -29,9 +32,13 @@ Provider balances, subscription quotas, and token-usage analytics for the DeepSe
 
 需要 DeepSeek Harness `web` profile（`@deepseek-ai/dsh >= 0.1.0-rc.6`）。
 
+稳定版优先安装 npm 上的精确版本；这也是 DSH Desktop Market 使用的同一个包：
+
 ```bash
-dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"
+dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.2.10"
 ```
+
+只有测试尚未发布的 source/RC 时才使用 `dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"`。GitHub `main` 可能领先 npm stable，不应把 source 安装当作市场安装验收。
 
 然后重启已经运行的 `dsh web`，并在浏览器中硬刷新。侧边栏底部会出现“用量/余额”（Usage/Balance）入口。
 
@@ -42,14 +49,14 @@ dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"
 - `catalog/catalog-source.json` — 来源 manifest（`catalog-source.schema.json` v1.0.0）
 - `catalog/v1/plugins.json` — 标准 provider page（`catalog-provider-page.schema.json` v1.0.0）
 
-**使用前提（重要）**：市场托管安装只接受 npm registry 的精确稳定版本，git 条目仅可浏览。`dsh-usage-stats` 这个 npm 名已被其他项目占用，因此目录条目身份使用 `@ychris12138/dsh-usage-stats`（当前可用）。要启用 GUI「安装」按钮，需先发布：
+**使用前提（重要）**：市场托管安装只接受 npm registry 的精确稳定版本，git 条目仅可浏览。`dsh-usage-stats` 这个 npm 名已被其他项目占用，因此目录条目身份使用 `@ychris12138/dsh-usage-stats`。当前 stable/catalog 版本是 `0.2.10`；每个新版本都按以下顺序发布：
 
-1. 仓库包身份已统一为 `@ychris12138/dsh-usage-stats`；每次发版需同步 `package.json` / `package-lock.json` / `catalog/v1/plugins.json` 的版本。
+1. 运行 `npm run release:sync -- <version>` 同步 `package.json` / `package-lock.json` / `catalog/v1/plugins.json`，再由 `npm run check:release` 阻止身份或版本漂移。
 2. 发布 scoped 公共包：`npm publish --access public`。
 3. 把 `catalog/v1/plugins.json` 内容发布到 `https://ychris12138.github.io/dsh-usage-stats/v1/plugins`（GitHub Pages，manifest 与 endpoint 必须同源、HTTPS 443、无凭据）。
 4. 在 DSH 插件市场 → 来源管理 → 添加来源，粘贴 manifest URL：`https://ychris12138.github.io/dsh-usage-stats/catalog-source.json`，选择后即可走「可恢复安装边界」GUI 安装。
 
-> 若最终包名不同，请同步修改 `catalog-source.json` 的 `providerId`/`transport.endpoint` 与 `catalog/v1/plugins.json` 的身份字段。发布前目录条目可浏览但安装保持禁用（fail-closed，属预期）。
+> 目录若先指向尚未发布的版本，市场安装会 fail-closed，这是预期行为。只有 npm、Pages catalog 与 Desktop Market 实际安装全部验证后，才算完成发布。
 
 升级或卸载：
 
@@ -149,6 +156,21 @@ npx --yes github:Ychris12138/dsh-usage-stats --no-enable
 ```
 
 预算使用本机日历日/月边界：低于 80% 为正常，达到 80% 为 warning，达到 100% 为 critical。`daily` / `monthly` 必须是正数或 `null`；当前版本不做 FX 换算，因此预算货币与可靠价格货币不兼容时状态保持 unknown。
+
+### 界面设置 / Display settings
+
+Current Session Pill 默认开启。只隐藏 composer 附近的 Pill、保留侧边栏账户面板时：
+
+```yaml
+- insert:
+    - id: usage-stats
+      name: "@ychris12138/dsh-usage-stats"
+      config:
+        display:
+          currentSessionPill: false
+```
+
+面板的当前 provider 会保存在浏览器的命名空间 localStorage 中；刷新页面或重启 DSH 后恢复。若该 provider 已被删除，插件会清除旧值并使用原有的 DeepSeek/已配置 provider fallback。该选择不会写入 DSH 设置、服务端缓存或新 API。
 
 ### 余额型供应商
 
@@ -304,6 +326,16 @@ Passion（provider id 为 `passion` 或域名为 `*.passionapi.com`）会自动�
 3. 使用 `‹` / `›` 切换月份，点击热图日期查看当天的 provider/model 明细。
 4. 标题栏刷新会更新 Token、provider 列表，并强制刷新当前账户。
 
+### 安全导出 / Secret-free export
+
+三个下载端点只导出聚合后的白名单字段，不包含 credential ref/value、Authorization、Cookie、上游原始响应、prompt/reply 或文件路径：
+
+- `/api/usage-stats/export/daily.csv`：每天 × provider/model 的四类 Token 与完整费用估算。
+- `/api/usage-stats/export/sessions.csv`：session 标题、provider/model 集合、Token、完整费用估算和最后活动时间。
+- `/api/usage-stats/export.json`：带 `schemaVersion` 的完整聚合数据、公开 pricing provenance、预算和安全账户状态。
+
+CSV 使用 UTF-8、RFC 4180 引号与 spreadsheet formula 防护；Unicode 标题可直接打开。费用只在 `costComplete=true` 时导出，未知/混合币种保持空白或 `null`，不会输出部分金额。
+
 “最近 14 天”按本地日历计算，只显示窗口内存在用量的日期；未来时间戳不会计入。同一模型来自不同 provider 时会分别统计，例如 `deepseek-official · deepseek-chat` 与 `ark · deepseek-chat`。
 
 ## Agent 友好安装 / Agent-friendly installation
@@ -323,12 +355,13 @@ Constraints:
 
 Procedure:
 1. Confirm node, npx, and dsh are available.
-2. Prefer `dsh plugin --profile web update "@ychris12138/dsh-usage-stats"` when already installed; otherwise use `dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"`.
-3. If unavailable, use: npx --yes github:Ychris12138/dsh-usage-stats
-4. Do not combine bundle installation with an existing manual dsh-usage-stats Cordis entry.
-5. For npx, require a verified package and exactly one Cordis entry, then run again with --check.
-6. Report the installation path and resolved profile paths.
-7. If dsh web is running, report that a restart is needed and stop.
+2. Prefer the exact npm stable used by Desktop Market: `dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.2.10"` (or update the existing scoped package).
+3. Use `github:Ychris12138/dsh-usage-stats` only when I explicitly ask to test unreleased source/RC code.
+4. If dsh plugin is unavailable, use the compatible source installer only with my approval: `npx --yes github:Ychris12138/dsh-usage-stats`.
+5. Do not combine bundle installation with an existing manual dsh-usage-stats Cordis entry.
+6. For npx, require a verified package and exactly one Cordis entry, then run again with --check.
+7. Report the exact package identity/version, installation path, and resolved profile paths.
+8. If dsh web is running, report that a restart is needed and stop.
 
 Optional account setup (never handle secret values yourself):
 - OpenRouter account balance requires OPENROUTER_MANAGEMENT_KEY, not the inference key.
@@ -362,7 +395,7 @@ npx --yes github:Ychris12138/dsh-usage-stats --check
 - 自定义 monitor 默认要求 HTTPS、同源相对路径、手动 redirect 和 JSON 响应，body 上限为 1 MiB。
 - 发凭据前会筛选域名的 IPv4/IPv6 解析结果并固定一个允许的连接地址，优先使用公网地址；HTTPS 域名解析到 `198.18.0.0/15` 时可作为 Clash/Mihomo 等代理的 synthetic fake-IP 使用。字面量 `198.18/15`、其他私网/特殊地址仍默认拒绝，防止 DNS rebinding 绕过私网限制。
 - `usageBaseURL` 禁止内嵌 username/password；`Authorization`、`X-API-Key`、`API-Key` 等 header 必须由 credential ref 注入。
-- 六个端点仅接受 GET，并同时校验 peer socket 与 Host；支持 IPv4、IPv4-mapped IPv6 和 `[::1]:port`。
+- 九个端点仅接受 GET，并同时校验 peer socket 与 Host；支持 IPv4、IPv4-mapped IPv6 和 `[::1]:port`。
 - 用量缓存 `~/.dsh/storages/usage-stats-cache.json` 只保存聚合 Token、会话 id、不透明 revision 与折叠游标，不保存提示词、回复或文件路径。
 
 本机反向代理会让插件看到代理自身的回环地址。请勿把端点经反向代理暴露到局域网或公网；确需代理时必须在代理层增加可靠认证与访问控制。安全问题请按 [SECURITY.md](SECURITY.md) 私下报告。
@@ -389,8 +422,11 @@ Token 统计值来自 `assistant/chunk` 或 `assistant/message` 中 provider-rep
 | `GET` | `/api/usage-stats/balance?provider=<id>` | `0.1.x` 余额兼容路由 |
 | `GET` | `/api/usage-stats/subscriptions` | `0.1.x` Token Plan 兼容路由 |
 | `GET` | `/api/usage-stats/session-context?session=<id>` | 当前 live session 的 route/model/account 与同一增量 fold 的 session 费用快照 |
+| `GET` | `/api/usage-stats/export/daily.csv` | secret-free daily provider/model CSV |
+| `GET` | `/api/usage-stats/export/sessions.csv` | secret-free session CSV |
+| `GET` | `/api/usage-stats/export.json` | versioned usage、budget、pricing provenance 与 account-safe JSON |
 
-非 GET 返回 `405`，非回环请求返回 `403`；所有响应均为 JSON 并带 `Cache-Control: no-cache`。
+非 GET 返回 `405`，非回环请求返回 `403`。API JSON 使用 `Cache-Control: no-cache`；下载响应使用 `Cache-Control: no-store` 与固定文件名。
 
 ## 开发与验证 / Development
 
@@ -398,7 +434,7 @@ Token 统计值来自 `assistant/chunk` 或 `assistant/message` 中 provider-rep
 npm install
 npm run check
 npm test
-npm pack --dry-run
+npm pack --json
 ```
 
 `npm test` 完全离线，覆盖 bundle、客户端渲染与请求竞态、服务端安全边界、余额/Token Plan adapter、缓存和安装器幂等性。真实数据验证需先运行 `dsh web`：
@@ -412,7 +448,7 @@ node scripts/check-balance.mjs
 
 ## 兼容性与致谢 / Compatibility & credits
 
-当前版本为 `0.2.0`。插件依赖 Harness 客户端模块加载器、Cordis 服务与 session persistence；Harness 预发布接口变化时可能需要同步适配。
+当前 npm stable 为 `0.2.10`；`v0.3.0` release candidate 的完整门禁见 [`docs/release-checklist.md`](docs/release-checklist.md)，变更摘要见 [`docs/release-notes-v0.3.0.md`](docs/release-notes-v0.3.0.md)。插件依赖 Harness 客户端模块加载器、Cordis 服务与 session persistence；Harness 预发布接口变化时可能需要同步适配。
 
 - [Javis603/token-monitor](https://github.com/Javis603/token-monitor)：参考多 provider 配额归一化与 Z.ai 限额解析。
 - [xiaoqi20/dsh-opencode-go-usage](https://github.com/xiaoqi20/dsh-opencode-go-usage)：参考 DSH 凭据接入、OpenCode `auth.json` 回退与 Bearer usage endpoint。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,8 @@ Never include DeepSeek API keys, credentials files, session contents, raw logs, 
 
 ## Scope
 
-Security fixes target the latest version on the default branch. The five HTTP endpoints are designed for direct loopback use only; exposing them through a reverse proxy is outside the supported security model unless the proxy adds authentication and access control.
+Security fixes target the latest version on the default branch. The nine HTTP endpoints are designed for direct loopback use only; exposing them through a reverse proxy is outside the supported security model unless the proxy adds authentication and access control.
+
+CSV and JSON exports are fixed, versioned projections of normalized usage and account-safe metadata. They do not serialize plugin/provider configuration, credential references or values, raw upstream responses, prompts, replies, or file paths. CSV text fields are quoted and guarded against spreadsheet-formula execution; incomplete monetary derivations remain blank/null.
 
 Declarative account monitors are trusted local configuration, but they still default to HTTPS, same-origin relative paths, manual redirects, JSON-only responses, and a 1 MiB response limit. Before sending credentials, the plugin filters IPv4/IPv6 DNS answers and pins one validated address for the connection. Public addresses are preferred. For HTTPS hostnames only, an IPv4 address in `198.18.0.0/15` may be accepted as a proxy-synthetic fake-IP mapping for Clash/Mihomo-style TUN DNS. Literal targets in that range remain blocked by default, and other private or special-use addresses still require explicit `allowPrivateNetwork` opt-in. Enabling cross-origin, insecure HTTP, or private-network access expands the trust boundary and should be done only for an endpoint you control.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -2,12 +2,10 @@
 
 This is the release gate for `@ychris12138/dsh-usage-stats`. Completing the checklist prepares a release; it does not authorize npm publishing, tagging, or creating a GitHub Release.
 
-## 1. Release candidate identity
+## 1. Release candidate baseline
 
-- [ ] Start from a reviewed, clean `main`; record the exact commit SHA.
-- [ ] Run `npm run release:sync -- <version>` once to update `package.json`, `package-lock.json`, and the Community Market catalog together.
-- [ ] Remove release-candidate wording/status from the target version's release notes after the final version sync.
-- [ ] Confirm `npm run check:release` reports the scoped package identity and target version.
+- [ ] Start from the reviewed release-candidate PR merged into a clean `main`; record this commit as `RC_BASE_SHA` for provenance only.
+- [ ] Do not publish or tag `RC_BASE_SHA`: the release version has not been committed yet.
 - [ ] Confirm `cordis.patch.yml` quotes `@ychris12138/dsh-usage-stats` and `lib/client.js` registers the same identity through `__ModuleLoader__.load()`.
 - [ ] Confirm the release notes describe estimated costs as estimates and list every unsupported/fail-closed case.
 
@@ -53,14 +51,56 @@ npm pack --json
 - [ ] Recheck #53 only in an available enterprise proxy environment; record evidence, but do not infer a fix without reproduction.
 - [ ] Recheck #14 with a real MiniMax Coding Plan account: both current and weekly windows plus reset information. Record the sanitized response shape if it fails.
 
-## 6. Publish and market closeout
+## 6. Create the immutable release commit
 
-Do not run this section until the release candidate PR is approved and the maintainer explicitly authorizes publishing.
+Do not run this section until every release-candidate gate above passes and the maintainer approves preparing the release commit.
+
+- [ ] Create a release branch from the reviewed `main` at `RC_BASE_SHA`.
+- [ ] Run `npm run release:sync -- 0.3.0` once to update `package.json`, `package-lock.json`, the Community Market catalog, and documented stable-version references together.
+- [ ] Remove release-candidate wording/status from the v0.3.0 release notes.
+- [ ] Run the release gates again against the synchronized version:
+
+```bash
+npm run check
+npm test
+npm pack --json
+```
+
+- [ ] Inspect the final pack manifest, then commit all version/release metadata changes with `chore: prepare v0.3.0 release`.
+- [ ] Record that commit as `RELEASE_SHA`; this replaces `RC_BASE_SHA` as the only publish/tag identity.
+- [ ] Confirm the working tree is clean and `HEAD` equals `RELEASE_SHA`.
+- [ ] Confirm the committed package version, not merely the working-tree version:
+
+```bash
+test "$(git show "$RELEASE_SHA:package.json" | jq -r .version)" = "0.3.0"
+```
+
+The release invariant is:
+
+```text
+npm published source commit
+== v0.3.0 tag commit
+== GitHub Release commit
+== package/catalog version commit
+== RELEASE_SHA
+```
+
+## 7. Publish and market closeout
+
+Do not run this section until the immutable release commit exists and the maintainer explicitly authorizes publishing.
 
 - [ ] `npm whoami` returns the expected publisher.
-- [ ] `npm publish --access public --registry=https://registry.npmjs.org/` succeeds.
+- [ ] From a clean checkout/worktree at exactly `RELEASE_SHA`, run `npm publish --access public --registry=https://registry.npmjs.org/`.
 - [ ] `npm view "@ychris12138/dsh-usage-stats" version --registry=https://registry.npmjs.org/` equals the target version.
-- [ ] Only after npm verification: create the signed/annotated tag and GitHub Release from the recorded `main` SHA.
+- [ ] Merge or push the release commit to `main` according to the chosen branch workflow; verify `main` contains the exact `RELEASE_SHA` without recreating the release changes.
+- [ ] Only after npm and `main` verification: create the signed/annotated `v0.3.0` tag pointing explicitly to `RELEASE_SHA`.
+- [ ] Verify the tag resolves to the published source commit:
+
+```bash
+test "$(git rev-parse v0.3.0^{commit})" = "$RELEASE_SHA"
+```
+
+- [ ] Create the GitHub Release from `v0.3.0`; verify it resolves to `RELEASE_SHA`.
 - [ ] Verify the public Pages `catalog-source.json` and `/v1/plugins` response content type, package name, and exact version.
 - [ ] Install the exact npm version through DSH Desktop Community Market and restart the host.
 - [ ] Close the npm/market release issue only after the Desktop Market installation succeeds.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,66 @@
+# Release checklist
+
+This is the release gate for `@ychris12138/dsh-usage-stats`. Completing the checklist prepares a release; it does not authorize npm publishing, tagging, or creating a GitHub Release.
+
+## 1. Release candidate identity
+
+- [ ] Start from a reviewed, clean `main`; record the exact commit SHA.
+- [ ] Run `npm run release:sync -- <version>` once to update `package.json`, `package-lock.json`, and the Community Market catalog together.
+- [ ] Remove release-candidate wording/status from the target version's release notes after the final version sync.
+- [ ] Confirm `npm run check:release` reports the scoped package identity and target version.
+- [ ] Confirm `cordis.patch.yml` quotes `@ychris12138/dsh-usage-stats` and `lib/client.js` registers the same identity through `__ModuleLoader__.load()`.
+- [ ] Confirm the release notes describe estimated costs as estimates and list every unsupported/fail-closed case.
+
+## 2. Automated gates
+
+```bash
+npm ci
+npm run check
+npm test
+npm pack --json
+```
+
+- [ ] Inspect the pack manifest: no credentials, local caches, screenshots, backups, review diffs, or untracked planning files.
+- [ ] Install the generated tarball into an isolated DSH profile; do not validate only against the source checkout.
+- [ ] Confirm malformed settings fail before routes or timers register.
+- [ ] Confirm non-GET and non-loopback export/API requests remain rejected.
+
+## 3. Fresh install and migration
+
+- [ ] Fresh isolated profile: install, restart DSH, hard-refresh the browser, open Usage Stats.
+- [ ] Upgrade an existing v0.2.10 profile without deleting its usage cache or monitor configuration.
+- [ ] Confirm a valid old cache is migrated/refolded and retains exact token totals.
+- [ ] Replace the cache with malformed JSON; confirm the plugin rebuilds from authoritative session events without blocking DSH startup.
+- [ ] Confirm existing account monitors remain compatible and no new provider/monitor is inserted into user configuration.
+- [ ] Confirm `display.currentSessionPill` defaults on and `false` removes the Pill without affecting the sidebar panel.
+- [ ] Confirm a persisted provider selection survives browser refresh and DSH restart; removing that provider clears the saved id and uses the existing fallback.
+
+## 4. Export and security
+
+- [ ] Download daily CSV, session CSV, and the versioned JSON export.
+- [ ] Check commas, quotes, CR/LF, Unicode titles, and spreadsheet-formula prefixes.
+- [ ] Confirm incomplete/mixed-currency estimates export as blank/null rather than partial amounts.
+- [ ] Search every export for credential names/values, Authorization, cookies, raw URLs with userinfo/query data, prompt text, response text, and file paths.
+- [ ] Confirm exported pricing provenance contains only public rule/source metadata.
+
+## 5. Real DSH release-candidate regression
+
+- [ ] Test the latest supported `@deepseek-ai/dsh` Desktop/Web release candidate with an isolated profile.
+- [ ] Confirm DSH starts without `Failed to load plugins` or loader identity errors.
+- [ ] Confirm client bundle load, sidebar entry, panel open/close, provider switching, Current Session Pill, cost/budget states, and manual Retry.
+- [ ] Test light and dark themes; confirm a missing composer mount point degrades silently.
+- [ ] With `refresh.enabled: false`, confirm one first account fetch, no expiry-driven upstream requests, manual Retry, and a fresh fetch after provider configuration changes.
+- [ ] Recheck #53 only in an available enterprise proxy environment; record evidence, but do not infer a fix without reproduction.
+- [ ] Recheck #14 with a real MiniMax Coding Plan account: both current and weekly windows plus reset information. Record the sanitized response shape if it fails.
+
+## 6. Publish and market closeout
+
+Do not run this section until the release candidate PR is approved and the maintainer explicitly authorizes publishing.
+
+- [ ] `npm whoami` returns the expected publisher.
+- [ ] `npm publish --access public --registry=https://registry.npmjs.org/` succeeds.
+- [ ] `npm view "@ychris12138/dsh-usage-stats" version --registry=https://registry.npmjs.org/` equals the target version.
+- [ ] Only after npm verification: create the signed/annotated tag and GitHub Release from the recorded `main` SHA.
+- [ ] Verify the public Pages `catalog-source.json` and `/v1/plugins` response content type, package name, and exact version.
+- [ ] Install the exact npm version through DSH Desktop Community Market and restart the host.
+- [ ] Close the npm/market release issue only after the Desktop Market installation succeeds.

--- a/docs/release-notes-v0.3.0.md
+++ b/docs/release-notes-v0.3.0.md
@@ -1,0 +1,28 @@
+# v0.3.0 release notes (release candidate)
+
+`v0.3.0` turns dsh-usage-stats from an account/Token dashboard into a route-aware usage and cost observability layer while preserving the v0.2.x credential and loopback security boundaries.
+
+## Highlights
+
+- A shared provider identity policy keeps route, provider family, account adapter, and pricing eligibility separate. Unknown/custom gateways remain unknown unless explicitly configured.
+- The Current Session Pill shows the active route's account state and event-derived current-session cost beside the composer, and opens the existing provider panel when clicked. It is enabled by default and can be disabled with `display.currentSessionPill: false`.
+- Account health now includes provenance, stale state, last attempt/success, age, bounded diagnostics, configurable refresh intervals, and a true automatic-refresh off switch.
+- DeepSeek historical pricing is matched by exact model, route eligibility, event time, and Shanghai pricing windows. Daily/monthly budgets are optional and fail closed.
+- New API balance display respects the instance's USD/CNY quota settings. Unsupported display types and invalid CNY exchange rates do not masquerade as money.
+- Daily CSV, session CSV, and versioned JSON exports use explicit secret-free projections, preserve Unicode, escape CSV safely, and omit incomplete cost amounts.
+- The account panel remembers its last valid provider in namespaced browser localStorage and falls back safely if that provider is removed.
+
+## Cost accuracy statement
+
+All monetary values are **estimates**, not invoices. A sample is priced only when its provider route is eligible for an official catalog, its model matches exactly, its event timestamp selects a known historical rule, every reported token bucket has a price, and the result has one supported currency. Custom gateways, subscriptions, unknown models, ambiguous historical identity, unpriced cache writes, and mixed currencies return no estimate. The plugin does not call an FX service and does not reinterpret old usage using today's route or price.
+
+## Upgrade notes
+
+- Existing v0.2.10 configuration remains valid. The new display setting, budgets, and refresh controls are additive and default to the previous behavior.
+- Older usage-cache schemas are invalidated and refolded from authoritative session events. Malformed cache JSON is ignored and rebuilt; it must not block DSH startup.
+- Existing account monitor configuration is normalized without writing credentials or inserting new monitor entries.
+- Browser provider selection is local UI state only; it creates no endpoint and no server-side setting.
+
+## Release status
+
+This document describes the `v0.3.0` release candidate. The package version remains `0.2.10` until maintainer review and the complete RC checklist pass. npm publish, tag creation, GitHub Release creation, Pages verification, and Desktop Market installation are separate final release steps.

--- a/lib/client.js
+++ b/lib/client.js
@@ -68,6 +68,9 @@ window.__ModuleLoader__.load({
 			".usg_providerPickerLabel{color:var(--dsw-alias-label-tertiary);flex:none}",
 			".usg_providerSelect{box-sizing:border-box;min-width:0;flex:1;color:var(--dsw-alias-label-primary);background:var(--dsw-alias-bg-overlay,var(--dsw-alias-bg-base));border:1px solid var(--dsw-alias-border-l2);border-radius:8px;padding:4px 6px;font:inherit;font-size:12px;line-height:18px}",
 			".usg_accountGrid{flex-direction:column;gap:8px;display:flex}",
+			".usg_exportLinks{display:flex;flex-wrap:wrap;gap:6px}",
+			".usg_exportLink{color:var(--dsw-alias-label-secondary);background:var(--dsw-alias-fill-l1,transparent);border:1px solid var(--dsw-alias-border-l2);border-radius:7px;padding:4px 7px;font-size:11px;line-height:16px;text-decoration:none}",
+			".usg_exportLink:hover{color:var(--dsw-alias-label-primary);background:var(--dsw-alias-interactive-bg-hover)}",
 			".usg_accountCard{--usg-providerAccent:#1f6feb;box-sizing:border-box;border:1px solid var(--dsw-alias-border-l2);background:linear-gradient(135deg,color-mix(in srgb,var(--usg-providerAccent) 8%,transparent),transparent 42%);border-radius:12px;padding:10px 11px;display:flex;flex-direction:column;gap:9px}",
 			".usg_accountCard[data-provider=deepseek],.usg_accountCard[data-provider=deepseek-official]{--usg-providerAccent:#1f6feb}",
 			".usg_accountCard[data-provider=opencode-go]{--usg-providerAccent:#00a67d}",
@@ -187,6 +190,8 @@ window.__ModuleLoader__.load({
 			providerPickerLabel: "usg_providerPickerLabel",
 			providerSelect: "usg_providerSelect",
 			accountGrid: "usg_accountGrid",
+			exportLinks: "usg_exportLinks",
+			exportLink: "usg_exportLink",
 			accountCard: "usg_accountCard",
 			accountHead: "usg_accountHead",
 			accountMark: "usg_accountMark",
@@ -770,6 +775,57 @@ window.__ModuleLoader__.load({
 		//#endregion
 
 		//#region UsageStatsPanel
+		const SELECTED_PROVIDER_STORAGE_KEY = "@ychris12138/dsh-usage-stats:selected-provider:v1";
+
+		function browserStorage() {
+			try {
+				return typeof window === "object" ? window.localStorage ?? null : null;
+			} catch {
+				return null;
+			}
+		}
+
+		function validStoredProvider(value) {
+			return typeof value === "string" && value.length > 0 && value.length <= 256 && !value.includes("\0") ? value : null;
+		}
+
+		function readSelectedProvider(storage = browserStorage()) {
+			try {
+				const stored = storage?.getItem?.(SELECTED_PROVIDER_STORAGE_KEY) ?? null;
+				const normalized = validStoredProvider(stored);
+				if (stored !== null && normalized === null) storage?.removeItem?.(SELECTED_PROVIDER_STORAGE_KEY);
+				return normalized;
+			} catch {
+				return null;
+			}
+		}
+
+		function writeSelectedProvider(providerId, storage = browserStorage()) {
+			try {
+				const normalized = validStoredProvider(providerId);
+				if (normalized === null) storage?.removeItem?.(SELECTED_PROVIDER_STORAGE_KEY);
+				else storage?.setItem?.(SELECTED_PROVIDER_STORAGE_KEY, normalized);
+			} catch {
+				// Storage may be disabled or quota-limited. Selection remains usable
+				// for the current mount and silently falls back on the next one.
+			}
+		}
+
+		function reconcileSelectedProvider(current, providers, storage = browserStorage()) {
+			if (Array.isArray(providers) && providers.some((provider) => provider?.id === current)) return current;
+			if (current !== null) writeSelectedProvider(null, storage);
+			if (!Array.isArray(providers) || providers.length === 0) return null;
+			return providers.find((provider) => provider.id === "deepseek-official" && provider.configured)?.id
+				?? providers.find((provider) => provider.id === "deepseek")?.id
+				?? providers.find((provider) => provider.configured)?.id
+				?? providers[0].id;
+		}
+
+		function authoritativeProviderList(payload) {
+			if (payload?.ok !== true) return null;
+			return Array.isArray(payload.providers) ? payload.providers : [];
+		}
+
 		/**
 		 * Sidebar footer action: badge + floating panel with balance and usage.
 		 * @param props - `wide` from the sidebar shell, `t` bound by the slot runtime.
@@ -782,8 +838,9 @@ window.__ModuleLoader__.load({
 			const [selectedDay, setSelectedDay] = react.useState(null);
 			const [viewMonth, setViewMonth] = react.useState(() => currentMonthKey());
 			const [providers, setProviders] = react.useState([]);
-			const [providersLoaded, setProvidersLoaded] = react.useState(false);
-			const [selectedProvider, setSelectedProvider] = react.useState(null);
+			const [providersAuthoritative, setProvidersAuthoritative] = react.useState(false);
+			const storageRef = react.useRef(browserStorage());
+			const [selectedProvider, setSelectedProvider] = react.useState(() => readSelectedProvider(storageRef.current));
 			const [account, setAccount] = react.useState(null);
 			const [accountLoading, setAccountLoading] = react.useState(false);
 			const [accountError, setAccountError] = react.useState(null);
@@ -797,10 +854,15 @@ window.__ModuleLoader__.load({
 			if (accountLoaderRef.current === null) accountLoaderRef.current = createLoader();
 			const providerChoices = react.useMemo(() => buildProviderChoices(providers), [providers]);
 			const selectedProviderInfo = providerChoices.find((provider) => provider.id === selectedProvider) ?? null;
-			const openForProvider = react.useCallback((providerId) => {
-				if (typeof providerId === "string" && providerId !== "") setSelectedProvider(providerId);
-				setOpen(true);
+			const selectProvider = react.useCallback((providerId) => {
+				const normalized = validStoredProvider(providerId);
+				setSelectedProvider(normalized);
+				writeSelectedProvider(normalized, storageRef.current);
 			}, []);
+			const openForProvider = react.useCallback((providerId) => {
+				if (validStoredProvider(providerId) !== null) selectProvider(providerId);
+				setOpen(true);
+			}, [selectProvider]);
 
 			// The composer pill and sidebar panel are separate slot roots. A tiny
 			// in-module subscription bridge opens this existing panel without DOM
@@ -827,14 +889,11 @@ window.__ModuleLoader__.load({
 			const loadProviders = react.useCallback(() => {
 				fetchJson("/api/usage-stats/providers").then((payload) => {
 					if (!mountedRef.current) return;
-					if (payload.ok !== true) {
-						setProvidersLoaded(true);
-						return;
-					}
-					const list = Array.isArray(payload.providers) ? payload.providers : [];
+					const list = authoritativeProviderList(payload);
+					if (list === null) return;
 					setProviders(list);
-					setProvidersLoaded(true);
-				}).catch(() => { setProvidersLoaded(true); });
+					setProvidersAuthoritative(true);
+				}).catch(() => {});
 			}, []);
 
 			const loadAccount = react.useCallback((providerId, force = false, activity = null) => {
@@ -918,15 +977,9 @@ window.__ModuleLoader__.load({
 			// Keep exactly one valid provider selected across independent provider
 			// and subscription responses. DeepSeek remains the initial preference.
 			react.useEffect(() => {
-				if (!providersLoaded || providerChoices.length === 0) return;
-				setSelectedProvider((current) => {
-					if (current !== null && providerChoices.some((provider) => provider.id === current)) return current;
-					return providerChoices.find((provider) => provider.id === "deepseek-official" && provider.configured)?.id
-						?? providerChoices.find((provider) => provider.id === "deepseek")?.id
-						?? providerChoices.find((provider) => provider.configured)?.id
-						?? providerChoices[0].id;
-				});
-			}, [providerChoices, providersLoaded]);
+				if (!providersAuthoritative) return;
+				setSelectedProvider((current) => reconcileSelectedProvider(current, providerChoices, storageRef.current));
+			}, [providerChoices, providersAuthoritative]);
 
 			react.useEffect(() => {
 				if (!open) return;
@@ -1110,9 +1163,9 @@ window.__ModuleLoader__.load({
 												children: react_jsx_runtime.jsx("h3", { className: S.sectionTitle, children: translate("account.title") })
 											}),
 											react_jsx_runtime.jsx(ProviderPicker, {
-												providers: providerChoices,
-												selectedProvider,
-												onSelect: (id) => setSelectedProvider(id),
+								providers: providerChoices,
+								selectedProvider,
+								onSelect: selectProvider,
 												translate
 											}),
 											selectedProviderInfo === null ? react_jsx_runtime.jsx("p", { className: S.note, children: translate("account.loading") }) : react_jsx_runtime.jsx("div", {
@@ -1215,7 +1268,7 @@ window.__ModuleLoader__.load({
 													})
 												]
 											}),
-											recent.length > 0 && react_jsx_runtime.jsxs("section", {
+										recent.length > 0 && react_jsx_runtime.jsxs("section", {
 												className: S.section,
 												children: [
 													react_jsx_runtime.jsx("h3", { className: S.sectionTitle, children: translate("usage.recent") }),
@@ -1240,8 +1293,22 @@ window.__ModuleLoader__.load({
 														})
 													})
 												]
-											}),
-											updatedLabel !== "" && react_jsx_runtime.jsx("p", { className: S.footerNote, children: updatedLabel })
+										}),
+										react_jsx_runtime.jsxs("section", {
+											className: S.section,
+											children: [
+												react_jsx_runtime.jsx("h3", { className: S.sectionTitle, children: translate("export.title") }),
+												react_jsx_runtime.jsxs("div", {
+													className: S.exportLinks,
+													children: [
+														react_jsx_runtime.jsx("a", { className: S.exportLink, href: "/api/usage-stats/export/daily.csv", download: "dsh-usage-daily.csv", "data-export-format": "daily-csv", children: translate("export.dailyCsv") }),
+														react_jsx_runtime.jsx("a", { className: S.exportLink, href: "/api/usage-stats/export/sessions.csv", download: "dsh-usage-sessions.csv", "data-export-format": "sessions-csv", children: translate("export.sessionsCsv") }),
+														react_jsx_runtime.jsx("a", { className: S.exportLink, href: "/api/usage-stats/export.json", download: "dsh-usage-stats.json", "data-export-format": "json", children: translate("export.json") })
+													]
+												})
+											]
+										}),
+										updatedLabel !== "" && react_jsx_runtime.jsx("p", { className: S.footerNote, children: updatedLabel })
 										]
 									})
 								]
@@ -1789,6 +1856,10 @@ window.__ModuleLoader__.load({
 			"usage.cacheRead": "缓存读",
 			"usage.unknownModel": "未知模型",
 			"usage.noModels": "这一天没有分模型数据。",
+			"export.title": "安全导出",
+			"export.dailyCsv": "每日 CSV",
+			"export.sessionsCsv": "会话 CSV",
+			"export.json": "完整 JSON",
 			"budget.period.daily": "今日估算",
 			"budget.period.monthly": "本月估算",
 			"budget.level.normal": "正常",
@@ -1909,6 +1980,10 @@ window.__ModuleLoader__.load({
 			"usage.cacheRead": "Cache read",
 			"usage.unknownModel": "Unknown model",
 			"usage.noModels": "No per-model data for this day.",
+			"export.title": "Secret-free export",
+			"export.dailyCsv": "Daily CSV",
+			"export.sessionsCsv": "Sessions CSV",
+			"export.json": "Full JSON",
 			"budget.period.daily": "Today estimated",
 			"budget.period.monthly": "This month estimated",
 			"budget.level.normal": "Normal",
@@ -1996,6 +2071,11 @@ window.__ModuleLoader__.load({
 		exports.sessionContextSignalOf = sessionContextSignalOf;
 		exports.sessionPillViewOf = sessionPillViewOf;
 		exports.subscribeUsageStatsPanel = subscribeUsageStatsPanel;
+		exports.SELECTED_PROVIDER_STORAGE_KEY = SELECTED_PROVIDER_STORAGE_KEY;
+		exports.authoritativeProviderList = authoritativeProviderList;
+		exports.readSelectedProvider = readSelectedProvider;
+		exports.reconcileSelectedProvider = reconcileSelectedProvider;
+		exports.writeSelectedProvider = writeSelectedProvider;
 		return module.exports;
 	}
 });

--- a/lib/export.js
+++ b/lib/export.js
@@ -1,0 +1,227 @@
+/**
+ * Secret-free export projections for the usage-stats read model.
+ *
+ * This module deliberately accepts only already-normalized usage/account
+ * snapshots and copies a fixed allow-list. Never pass configuration objects,
+ * credentials, request headers, or raw upstream responses to an export.
+ */
+
+export const EXPORT_SCHEMA_VERSION = "1.0.0";
+
+const CSV_FORMULA_PREFIX = /^[\t\r\n ]*[=+\-@]/;
+
+function finiteOrNull(value) {
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function stringOrNull(value) {
+	return typeof value === "string" ? value : null;
+}
+
+function booleanOrFalse(value) {
+	return value === true;
+}
+
+function tokenFields(value = {}) {
+	return {
+		inputTokens: finiteOrNull(value.inputTokens) ?? 0,
+		cacheReadTokens: finiteOrNull(value.cacheReadTokens) ?? 0,
+		cacheWriteTokens: finiteOrNull(value.cacheWriteTokens) ?? 0,
+		outputTokens: finiteOrNull(value.outputTokens) ?? 0,
+		tokens: finiteOrNull(value.tokens) ?? 0
+	};
+}
+
+function pricingProjection(value) {
+	const pricing = value !== null && typeof value === "object" ? value : {};
+	const source = pricing.source !== null && typeof pricing.source === "object"
+		? {
+			kind: stringOrNull(pricing.source.kind),
+			provider: stringOrNull(pricing.source.provider),
+			url: stringOrNull(pricing.source.url)
+		}
+		: null;
+	return {
+		ruleIds: Array.isArray(pricing.ruleIds) ? pricing.ruleIds.filter((entry) => typeof entry === "string") : [],
+		source,
+		updatedAt: stringOrNull(pricing.updatedAt)
+	};
+}
+
+function costFields(value = {}) {
+	const complete = booleanOrFalse(value.costComplete);
+	return {
+		estimatedCost: complete ? finiteOrNull(value.estimatedCost) : null,
+		currency: complete ? stringOrNull(value.currency) : null,
+		costComplete: complete,
+		pricing: pricingProjection(value.pricing)
+	};
+}
+
+function splitModelKey(value) {
+	if (typeof value !== "string") return { provider: "unknown", model: "unknown" };
+	const slash = value.indexOf("/");
+	if (slash <= 0 || slash === value.length - 1) return { provider: "unknown", model: value || "unknown" };
+	return { provider: value.slice(0, slash), model: value.slice(slash + 1) };
+}
+
+function csvCell(value, text = false) {
+	if (value === null || value === void 0) return "\"\"";
+	let rendered = String(value);
+	if (text && CSV_FORMULA_PREFIX.test(rendered)) rendered = `'${rendered}`;
+	return `"${rendered.replaceAll('"', '""')}"`;
+}
+
+function csv(rows) {
+	return `\uFEFF${rows.map((row) => row.map((cell) => csvCell(cell.value, cell.text)).join(",")).join("\r\n")}\r\n`;
+}
+
+/** Daily provider/model rows, one row per rendered day/model bucket. */
+export function dailyCsv(usage) {
+	const rows = [[
+		{ value: "date" },
+		{ value: "provider" },
+		{ value: "model" },
+		{ value: "input_tokens" },
+		{ value: "cache_read_tokens" },
+		{ value: "cache_write_tokens" },
+		{ value: "output_tokens" },
+		{ value: "total_tokens" },
+		{ value: "estimated_cost" },
+		{ value: "currency" }
+	]];
+	for (const day of Array.isArray(usage?.days) ? usage.days : []) {
+		if (day === null || typeof day !== "object") continue;
+		for (const entry of Array.isArray(day.models) ? day.models : []) {
+			if (entry === null || typeof entry !== "object") continue;
+			const route = splitModelKey(entry.model);
+			const tokens = tokenFields(entry);
+			rows.push([
+				{ value: stringOrNull(day.date), text: true },
+				{ value: route.provider, text: true },
+				{ value: route.model, text: true },
+				{ value: tokens.inputTokens },
+				{ value: tokens.cacheReadTokens },
+				{ value: tokens.cacheWriteTokens },
+				{ value: tokens.outputTokens },
+				{ value: tokens.tokens },
+				{ value: entry.costComplete === true ? finiteOrNull(entry.estimatedCost) : null },
+				{ value: entry.costComplete === true ? stringOrNull(entry.currency) : null, text: true }
+			]);
+		}
+	}
+	return csv(rows);
+}
+
+/** Session rows. Provider/model sets stay in one row to avoid duplicating totals. */
+export function sessionsCsv(usage) {
+	const rows = [[
+		{ value: "session_id" },
+		{ value: "title" },
+		{ value: "provider" },
+		{ value: "model" },
+		{ value: "tokens" },
+		{ value: "estimated_cost" },
+		{ value: "currency" },
+		{ value: "last_active" }
+	]];
+	for (const session of Array.isArray(usage?.sessions) ? usage.sessions : []) {
+		if (session === null || typeof session !== "object") continue;
+		rows.push([
+			{ value: stringOrNull(session.sessionId), text: true },
+			{ value: stringOrNull(session.title), text: true },
+			{ value: Array.isArray(session.providers) ? session.providers.filter((entry) => typeof entry === "string").join(" | ") : "", text: true },
+			{ value: Array.isArray(session.models) ? session.models.filter((entry) => typeof entry === "string").join(" | ") : "", text: true },
+			{ value: finiteOrNull(session.tokens) ?? 0 },
+			{ value: session.costComplete === true ? finiteOrNull(session.estimatedCost) : null },
+			{ value: session.costComplete === true ? stringOrNull(session.currency) : null, text: true },
+			{ value: stringOrNull(session.lastAt), text: true }
+		]);
+	}
+	return csv(rows);
+}
+
+function usageEntryProjection(value) {
+	return {
+		...tokenFields(value),
+		cacheHitRate: finiteOrNull(value?.cacheHitRate),
+		...costFields(value)
+	};
+}
+
+function budgetWindowProjection(value) {
+	return {
+		limit: finiteOrNull(value?.limit),
+		currency: stringOrNull(value?.currency),
+		estimatedSpend: finiteOrNull(value?.estimatedSpend),
+		percent: finiteOrNull(value?.percent),
+		costComplete: booleanOrFalse(value?.costComplete),
+		level: stringOrNull(value?.level)
+	};
+}
+
+function alertProjection(value) {
+	if (value === null || typeof value !== "object") return null;
+	return {
+		level: stringOrNull(value.level),
+		metric: stringOrNull(value.metric),
+		value: finiteOrNull(value.value),
+		threshold: finiteOrNull(value.threshold)
+	};
+}
+
+function accountProjection(value) {
+	return {
+		id: stringOrNull(value?.id),
+		displayName: stringOrNull(value?.displayName),
+		accountMode: stringOrNull(value?.accountMode),
+		adapter: stringOrNull(value?.adapter),
+		configured: booleanOrFalse(value?.configured),
+		status: stringOrNull(value?.status),
+		fetchedAt: finiteOrNull(value?.fetchedAt),
+		stale: booleanOrFalse(value?.stale),
+		lastAttemptAt: finiteOrNull(value?.lastAttemptAt),
+		lastSuccessAt: finiteOrNull(value?.lastSuccessAt),
+		ageMs: finiteOrNull(value?.ageMs),
+		provenance: stringOrNull(value?.provenance),
+		reason: stringOrNull(value?.reason),
+		alert: alertProjection(value?.alert)
+	};
+}
+
+/** Versioned full export with only explicitly approved fields. */
+export function jsonExport(usage, accounts = [], exportedAt = Date.now()) {
+	const days = (Array.isArray(usage?.days) ? usage.days : []).filter((entry) => entry !== null && typeof entry === "object").map((day) => ({
+		date: stringOrNull(day.date),
+		...usageEntryProjection(day),
+		models: (Array.isArray(day.models) ? day.models : []).filter((entry) => entry !== null && typeof entry === "object").map((entry) => ({
+			model: stringOrNull(entry.model),
+			...usageEntryProjection(entry)
+		}))
+	}));
+	const sessions = (Array.isArray(usage?.sessions) ? usage.sessions : []).filter((entry) => entry !== null && typeof entry === "object").map((session) => ({
+		sessionId: stringOrNull(session.sessionId),
+		title: stringOrNull(session.title),
+		providers: Array.isArray(session.providers) ? session.providers.filter((entry) => typeof entry === "string") : [],
+		models: Array.isArray(session.models) ? session.models.filter((entry) => typeof entry === "string") : [],
+		...usageEntryProjection(session),
+		firstAt: stringOrNull(session.firstAt),
+		lastAt: stringOrNull(session.lastAt)
+	}));
+	return {
+		schemaVersion: EXPORT_SCHEMA_VERSION,
+		exportedAt: new Date(exportedAt).toISOString(),
+		usage: {
+			updatedAt: finiteOrNull(usage?.updatedAt),
+			total: usageEntryProjection(usage?.total),
+			days,
+			sessions,
+			budgets: {
+				currency: stringOrNull(usage?.budgets?.currency),
+				daily: budgetWindowProjection(usage?.budgets?.daily),
+				monthly: budgetWindowProjection(usage?.budgets?.monthly)
+			}
+		},
+		accounts: (Array.isArray(accounts) ? accounts : []).map(accountProjection)
+	};
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,16 @@
 /**
  * dsh-usage-stats — server half.
  *
- * Registers six read-only, loopback-only endpoints on the web server:
+ * Registers nine read-only, loopback-only endpoints on the web server:
  *   GET /api/usage-stats/usage         — per-day token usage across every session
  *   GET /api/usage-stats/providers     — configured providers + balance schemes
  *   GET /api/usage-stats/balance       — balance for one provider (?provider=<id>)
  *   GET /api/usage-stats/subscriptions — OpenCode Go + Z.ai quota windows
  *   GET /api/usage-stats/account       — unified account snapshot for one provider
  *   GET /api/usage-stats/session-context — provider/model context for one live session
+ *   GET /api/usage-stats/export/daily.csv — daily provider/model usage export
+ *   GET /api/usage-stats/export/sessions.csv — per-session usage export
+ *   GET /api/usage-stats/export.json — versioned usage/account-safe export
  *
  * Provider configuration is read straight from the harness settings
  * (`llm-deepseek` for the official DeepSeek route, `llm-pi-ai` for every
@@ -37,6 +40,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { applyUsageDelta, createUsageState, currentSessionContext, mergeBillingInto, mergeInto, renderSessionUsage, renderUsage, resetUsageState, totalTokens, zeroBuckets } from "./usage.js";
 import { ACCOUNT_REFRESH_MS, createAccountService, validateAccountConfig } from "./accounts.js";
 import { changedProviderPricingRoutes, createUsageCostEstimator, parseCostAccumulator, pricingFingerprint, renderBudgetSummary, serializeCostAccumulator, validateBudgetConfig } from "./billing.js";
+import { dailyCsv, jsonExport, sessionsCsv } from "./export.js";
 
 /** Stable Cordis plugin name. */
 const name = "usage-stats";
@@ -50,6 +54,9 @@ const BALANCE_PATH = "/api/usage-stats/balance";
 const SUBSCRIPTIONS_PATH = "/api/usage-stats/subscriptions";
 const ACCOUNT_PATH = "/api/usage-stats/account";
 const SESSION_CONTEXT_PATH = "/api/usage-stats/session-context";
+const DAILY_EXPORT_PATH = "/api/usage-stats/export/daily.csv";
+const SESSIONS_EXPORT_PATH = "/api/usage-stats/export/sessions.csv";
+const JSON_EXPORT_PATH = "/api/usage-stats/export.json";
 const UPSTREAM_TIMEOUT_MS = 15000;
 const CACHE_VERSION = 5;
 
@@ -65,6 +72,16 @@ function json(res, status, value) {
 	res.writeHead(status, {
 		"content-type": "application/json; charset=utf-8",
 		"cache-control": "no-cache"
+	});
+	res.end(body);
+}
+
+function attachment(res, contentType, filename, body) {
+	res.writeHead(200, {
+		"content-type": contentType,
+		"content-disposition": `attachment; filename="${filename}"`,
+		"cache-control": "no-store",
+		"x-content-type-options": "nosniff"
 	});
 	res.end(body);
 }
@@ -502,6 +519,40 @@ async function handleUsage(ctx, config, req, res) {
 	}
 }
 
+function exportFailure(ctx, kind, error, res) {
+	const name = error instanceof Error && typeof error.name === "string" ? error.name : "Error";
+	ctx.logger.warn(`usage-stats: ${kind} export failed (${name})`);
+	json(res, 500, { ok: false, error: "internal", message: "export failed" });
+}
+
+async function handleDailyExport(ctx, config, req, res) {
+	if (rejectForeignCaller(req, res)) return;
+	try {
+		attachment(res, "text/csv; charset=utf-8", "dsh-usage-daily.csv", dailyCsv(await collectUsage(ctx, config)));
+	} catch (error) {
+		exportFailure(ctx, "daily CSV", error, res);
+	}
+}
+
+async function handleSessionsExport(ctx, config, req, res) {
+	if (rejectForeignCaller(req, res)) return;
+	try {
+		attachment(res, "text/csv; charset=utf-8", "dsh-usage-sessions.csv", sessionsCsv(await collectUsage(ctx, config)));
+	} catch (error) {
+		exportFailure(ctx, "session CSV", error, res);
+	}
+}
+
+async function handleJsonExport(ctx, config, accounts, req, res) {
+	if (rejectForeignCaller(req, res)) return;
+	try {
+		const [usage, providerViews] = await Promise.all([collectUsage(ctx, config), accounts.providerViews()]);
+		attachment(res, "application/json; charset=utf-8", "dsh-usage-stats.json", JSON.stringify(jsonExport(usage, providerViews)));
+	} catch (error) {
+		exportFailure(ctx, "JSON", error, res);
+	}
+}
+
 /**
  * Enumerate the harness's configured providers: the official DeepSeek route
  * (`llm-deepseek` settings namespace) plus every pi-ai provider profile
@@ -593,6 +644,13 @@ export async function collectActiveAccountIds(ctx, config = { monitors: {} }) {
 async function handleSessionContext(ctx, config, accounts, req, res) {
 	if (rejectForeignCaller(req, res)) return;
 	try {
+		// Client loader entries carry module identity, not the server Cordis
+		// config. Keep the display policy server-owned on this existing request:
+		// a hidden Pill performs no usage fold or account read and renders null.
+		if (config.display?.currentSessionPill === false) {
+			json(res, 200, { ok: true, context: null, display: { currentSessionPill: false } });
+			return;
+		}
 		const url = new URL(req.url ?? "/", "http://x");
 		const requested = url.searchParams.get("session");
 		const selectedProvider = url.searchParams.get("provider");
@@ -628,7 +686,7 @@ async function handleSessionContext(ctx, config, accounts, req, res) {
 		};
 		const context = await collectSessionContext(ctx, sessionId, config, selectedRoute);
 		if (typeof context?.accountId === "string" && context.accountId !== "") accounts.touch?.(context.accountId, "active");
-		json(res, 200, { ok: true, context });
+		json(res, 200, { ok: true, context, display: { currentSessionPill: true } });
 	} catch (error) {
 		ctx.logger.warn(`usage-stats: session context failed: ${String(error)}`);
 		json(res, 500, { ok: false, error: "internal", message: error instanceof Error ? error.message : String(error) });
@@ -837,7 +895,7 @@ export function startBackgroundRefresh(ctx, accounts, deps = {}) {
 }
 
 /**
- * Plugin body: register the six exact routes and start background refresh.
+ * Plugin body: register the nine exact routes and start background refresh.
  * @param ctx - plugin context carrying webServer, credentials, sessions, sessionPersistence, settings, and llm.
  */
 const Config = {
@@ -855,9 +913,16 @@ const Config = {
 };
 
 function validateConfig(raw = {}) {
+	if (raw === null || typeof raw !== "object" || Array.isArray(raw)) throw new Error("plugin config must be an object");
+	const display = raw.display ?? {};
+	if (display === null || typeof display !== "object" || Array.isArray(display)) throw new Error("display must be an object");
+	if (display.currentSessionPill !== void 0 && typeof display.currentSessionPill !== "boolean") {
+		throw new Error("display.currentSessionPill must be a boolean");
+	}
 	return {
 		...validateAccountConfig(raw),
-		budgets: validateBudgetConfig(raw.budgets)
+		budgets: validateBudgetConfig(raw.budgets),
+		display: { currentSessionPill: display.currentSessionPill !== false }
 	};
 }
 
@@ -902,10 +967,25 @@ async function apply(ctx, rawConfig = {}, deps = {}) {
 		path: SESSION_CONTEXT_PATH,
 		handler: (req, res) => handleSessionContext(ctx, config, accounts, req, res)
 	}), "usage-stats: session context route");
+	ctx.effect(() => ctx.webServer.register({
+		kind: "exact",
+		path: DAILY_EXPORT_PATH,
+		handler: (req, res) => handleDailyExport(ctx, config, req, res)
+	}), "usage-stats: daily CSV export route");
+	ctx.effect(() => ctx.webServer.register({
+		kind: "exact",
+		path: SESSIONS_EXPORT_PATH,
+		handler: (req, res) => handleSessionsExport(ctx, config, req, res)
+	}), "usage-stats: sessions CSV export route");
+	ctx.effect(() => ctx.webServer.register({
+		kind: "exact",
+		path: JSON_EXPORT_PATH,
+		handler: (req, res) => handleJsonExport(ctx, config, accounts, req, res)
+	}), "usage-stats: JSON export route");
 	if (deps.disableBackgroundRefresh !== true) ctx.effect(() => startBackgroundRefresh(ctx, accounts, {
 		config,
 		accountRefreshEnabled: config.refresh.enabled
 	}), "usage-stats: background usage/account refresh");
 }
 
-export { apply, Config, inject, name, USAGE_PATH, PROVIDERS_PATH, BALANCE_PATH, SUBSCRIPTIONS_PATH, ACCOUNT_PATH, SESSION_CONTEXT_PATH, configuredProviders, totalTokens, validateConfig, zeroBuckets };
+export { apply, Config, inject, name, USAGE_PATH, PROVIDERS_PATH, BALANCE_PATH, SUBSCRIPTIONS_PATH, ACCOUNT_PATH, SESSION_CONTEXT_PATH, DAILY_EXPORT_PATH, SESSIONS_EXPORT_PATH, JSON_EXPORT_PATH, configuredProviders, totalTokens, validateConfig, zeroBuckets };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ychris12138/dsh-usage-stats",
-  "description": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI",
+  "description": "Token usage, provider accounts, session cost estimates, budgets, and exports for the dsh web GUI",
   "version": "0.2.10",
   "repository": {
     "type": "git",
@@ -21,6 +21,8 @@
     "lib/",
     "cordis.patch.yml",
     "docs/images/usage-panel.svg",
+    "docs/release-checklist.md",
+    "docs/release-notes-v0.3.0.md",
     "scripts/install.mjs",
     "README.md",
     "LICENSE",
@@ -49,13 +51,16 @@
     }
   },
   "scripts": {
-    "check": "node --check lib/index.js && node --check lib/usage.js && node --check lib/billing.js && node --check lib/pricing.js && node --check lib/network.js && node --check lib/provider-identity.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/accounts.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-overlay-layering.mjs && node --check scripts/test-bundle.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-provider-identity.mjs && node --check scripts/test-pricing.mjs && node --check scripts/test-billing.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/test-accounts.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
-    "test": "npm run test:bundle && npm run test:client && npm run test:overlay && npm run test:server && npm run test:provider-identity && npm run test:pricing && npm run test:billing && npm run test:balance && npm run test:subscriptions && npm run test:accounts && npm run test:install",
+    "check": "npm run check:release && node --check lib/index.js && node --check lib/usage.js && node --check lib/billing.js && node --check lib/pricing.js && node --check lib/network.js && node --check lib/provider-identity.js && node --check lib/balance.js && node --check lib/subscriptions.js && node --check lib/accounts.js && node --check lib/export.js && node --check lib/client.js && node --check scripts/install.mjs && node --check scripts/smoke-client.mjs && node --check scripts/test-overlay-layering.mjs && node --check scripts/test-bundle.mjs && node --check scripts/test-install.mjs && node --check scripts/test-server.mjs && node --check scripts/test-export.mjs && node --check scripts/test-provider-identity.mjs && node --check scripts/test-pricing.mjs && node --check scripts/test-billing.mjs && node --check scripts/test-balance.mjs && node --check scripts/test-subscriptions.mjs && node --check scripts/test-accounts.mjs && node --check scripts/release-metadata.mjs && node --check scripts/check-release-metadata.mjs && node --check scripts/sync-release-version.mjs && node --check scripts/validate-fold.mjs && node --check scripts/verify-raw.mjs && node --check scripts/check-balance.mjs",
+    "check:release": "node scripts/check-release-metadata.mjs",
+    "release:sync": "node scripts/sync-release-version.mjs",
+    "test": "npm run test:bundle && npm run test:client && npm run test:overlay && npm run test:server && npm run test:export && npm run test:provider-identity && npm run test:pricing && npm run test:billing && npm run test:balance && npm run test:subscriptions && npm run test:accounts && npm run test:install",
     "test:bundle": "node scripts/test-bundle.mjs",
     "test:client": "node scripts/smoke-client.mjs",
     "test:overlay": "node scripts/test-overlay-layering.mjs",
     "test:install": "node scripts/test-install.mjs",
     "test:server": "node scripts/test-server.mjs",
+    "test:export": "node scripts/test-export.mjs",
     "test:provider-identity": "node scripts/test-provider-identity.mjs",
     "test:pricing": "node scripts/test-pricing.mjs",
     "test:billing": "node scripts/test-billing.mjs",

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { EXPECTED_CATALOG_ENDPOINT, EXPECTED_PACKAGE_NAME, EXPECTED_REPOSITORY, SEMVER } from "./release-metadata.mjs";
+
+async function json(path) {
+	return JSON.parse(await readFile(path, "utf8"));
+}
+
+const [pkg, lock, catalog, source, patch, client, readme] = await Promise.all([
+	json("package.json"),
+	json("package-lock.json"),
+	json("catalog/v1/plugins.json"),
+	json("catalog/catalog-source.json"),
+	readFile("cordis.patch.yml", "utf8"),
+	readFile("lib/client.js", "utf8"),
+	readFile("README.md", "utf8")
+]);
+
+assert.equal(pkg.name, EXPECTED_PACKAGE_NAME, "unexpected scoped npm package identity");
+assert.match(pkg.version, SEMVER, "package version must be valid SemVer");
+assert.equal(pkg.repository?.url, EXPECTED_REPOSITORY, "repository metadata drifted");
+assert.equal(pkg.homepage, "https://github.com/Ychris12138/dsh-usage-stats#readme", "homepage metadata drifted");
+assert.equal(pkg.bugs, "https://github.com/Ychris12138/dsh-usage-stats/issues", "bugs metadata drifted");
+assert.equal(pkg.publishConfig?.access, "public", "scoped package must publish with public access");
+assert.equal(pkg.main, "lib/index.js");
+assert.equal(pkg.exports?.["."], "./lib/index.js");
+assert.equal(pkg.exports?.["./client"], "./lib/client.js");
+assert.equal(pkg.dsh?.bundle?.patch, "./cordis.patch.yml");
+assert.equal(pkg.dsh?.client?.platform, "web");
+for (const required of ["lib/", "cordis.patch.yml", "README.md", "LICENSE", "SECURITY.md", "docs/release-checklist.md", "docs/release-notes-v0.3.0.md"]) {
+	assert.ok(pkg.files?.includes(required), `npm files is missing ${required}`);
+}
+
+assert.equal(lock.name, pkg.name, "package-lock root name drifted");
+assert.equal(lock.version, pkg.version, "package-lock root version drifted");
+assert.equal(lock.packages?.[""]?.name, pkg.name, "package-lock package name drifted");
+assert.equal(lock.packages?.[""]?.version, pkg.version, "package-lock package version drifted");
+
+assert.equal(catalog.revision, pkg.version, "catalog revision does not match package version");
+assert.equal(catalog.items?.length, 1, "catalog must publish exactly one plugin entry");
+assert.equal(catalog.items[0].latestVersion, pkg.version, "catalog latestVersion does not match package version");
+assert.equal(catalog.items[0].package?.name, pkg.name, "catalog package name does not match package name");
+assert.equal(catalog.items[0].name, pkg.name, "catalog item name does not match package name");
+assert.equal(source.transport?.endpoint, EXPECTED_CATALOG_ENDPOINT, "unexpected catalog endpoint");
+
+const escapedName = pkg.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+assert.match(patch, new RegExp(`^\\s*name:\\s*"${escapedName}"\\s*$`, "m"), "Cordis YAML must quote the scoped package identity");
+assert.doesNotMatch(patch, new RegExp(`^\\s*name:\\s*${escapedName}\\s*$`, "m"), "Cordis YAML contains an unsafe unquoted scoped identity");
+assert.match(client, new RegExp(`__ModuleLoader__\\.load\\(\\{\\s*id:\\s*"${escapedName}"`, "s"), "browser loader identity must match package name");
+assert.match(client, new RegExp(`tag\\.dataset\\.plugin\\s*=\\s*"${escapedName}"`), "client style ownership identity must match package name");
+assert.match(readme, new RegExp(`<!--\\s*stable-version:\\s*${pkg.version.replaceAll(".", "\\.")}\\s*-->`), "README stable-version marker must match package version");
+assert.match(readme, new RegExp(`${escapedName}@${pkg.version.replaceAll(".", "\\.")}`), "README must include an exact npm install for the package version");
+
+console.log(`release metadata ok: ${pkg.name}@${pkg.version}`);

--- a/scripts/release-metadata.mjs
+++ b/scripts/release-metadata.mjs
@@ -1,0 +1,4 @@
+export const EXPECTED_PACKAGE_NAME = "@ychris12138/dsh-usage-stats";
+export const EXPECTED_REPOSITORY = "git+https://github.com/Ychris12138/dsh-usage-stats.git";
+export const EXPECTED_CATALOG_ENDPOINT = "https://ychris12138.github.io/dsh-usage-stats/v1/plugins";
+export const SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;

--- a/scripts/smoke-client.mjs
+++ b/scripts/smoke-client.mjs
@@ -25,7 +25,13 @@ const Stub = () => null;
 const primitives = new Proxy({}, { get: () => Stub });
 
 let captured = null;
-globalThis.window = { __ModuleLoader__: { load: (entry) => { captured = entry; } } };
+const storedValues = new Map();
+const localStorage = {
+	getItem: (key) => storedValues.get(key) ?? null,
+	setItem: (key, value) => { storedValues.set(key, String(value)); },
+	removeItem: (key) => { storedValues.delete(key); }
+};
+globalThis.window = { __ModuleLoader__: { load: (entry) => { captured = entry; } }, localStorage };
 globalThis.document = { querySelector: () => null, createElement: () => ({ dataset: {}, appendChild: () => {} }), head: { appendChild: () => {} } };
 
 const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "lib", "client.js"), "utf8");
@@ -64,6 +70,34 @@ const exports_ = captured.factory((spec) => {
 });
 
 if (typeof exports_.apply !== "function") throw new Error("missing apply export");
+
+const {
+	SELECTED_PROVIDER_STORAGE_KEY,
+	authoritativeProviderList,
+	readSelectedProvider,
+	reconcileSelectedProvider,
+	writeSelectedProvider
+} = exports_;
+assert.equal(SELECTED_PROVIDER_STORAGE_KEY, "@ychris12138/dsh-usage-stats:selected-provider:v1");
+assert.equal(authoritativeProviderList({ ok: false, providers: [] }), null, "a transient provider error must not become an authoritative empty list");
+assert.equal(authoritativeProviderList(null), null);
+writeSelectedProvider("opencode-go", localStorage);
+assert.equal(readSelectedProvider(localStorage), "opencode-go");
+const providerChoicesForStorage = [
+	{ id: "deepseek-official", configured: true },
+	{ id: "opencode-go", configured: true }
+];
+assert.deepEqual(authoritativeProviderList({ ok: true, providers: providerChoicesForStorage }), providerChoicesForStorage);
+assert.equal(reconcileSelectedProvider("opencode-go", providerChoicesForStorage, localStorage), "opencode-go", "a valid persisted provider must be restored");
+writeSelectedProvider("removed-provider", localStorage);
+assert.equal(reconcileSelectedProvider("removed-provider", providerChoicesForStorage, localStorage), "deepseek-official", "a removed provider must use the existing fallback");
+assert.equal(readSelectedProvider(localStorage), null, "a removed provider must be cleared from storage");
+writeSelectedProvider("bad\0provider", localStorage);
+assert.equal(readSelectedProvider(localStorage), null, "malformed provider ids must not be persisted");
+const deniedStorage = { getItem: () => { throw new Error("denied"); }, setItem: () => { throw new Error("denied"); }, removeItem: () => { throw new Error("denied"); } };
+assert.equal(readSelectedProvider(deniedStorage), null);
+writeSelectedProvider("deepseek-official", deniedStorage);
+console.log("client display setting and provider persistence policy ok");
 
 const { shouldDismissPanel, safeDiagnosticReason } = exports_;
 const panelNode = { contains: (target) => target === "panel-child" };
@@ -606,6 +640,13 @@ const switchedPillLoad = await loadSessionPillSnapshot("session/one", fetchPill)
 if (firstPillLoad.account.id !== "deepseek-official" || switchedPillLoad.account.id !== "opencode-go") throw new Error("session provider switch must resolve a fresh account snapshot");
 if (requests[0] !== "/api/usage-stats/session-context?session=session%2Fone") throw new Error(`session context request must carry the explicit encoded session id: ${requests[0]}`);
 if (!requests.includes("/api/usage-stats/account?provider=opencode-go&activity=active")) throw new Error("pill must reuse the unified account endpoint and mark the server-owned active provider");
+const hiddenRequests = [];
+const hiddenPillLoad = await loadSessionPillSnapshot("session/hidden", async (path) => {
+	hiddenRequests.push(path);
+	return { ok: true, context: null, display: { currentSessionPill: false } };
+});
+assert.equal(hiddenPillLoad, null, "the server-owned display switch must hide the Pill");
+assert.deepEqual(hiddenRequests, ["/api/usage-stats/session-context?session=session%2Fhidden"], "a hidden Pill must not query the account endpoint");
 await loadSessionPillSnapshot("session/one", fetchPill, { provider: "route:two", model: "same/model" });
 if (!requests.includes("/api/usage-stats/session-context?session=session%2Fone&provider=route%3Atwo&model=same%2Fmodel")) {
 	throw new Error("the formal model-selector route must be encoded as a session-context hint");
@@ -779,6 +820,9 @@ await act(async () => {
 	await Promise.resolve();
 });
 if (integrationRenderer.root.findAllByProps({ "data-usage-stats-panel": true }).length !== 1) throw new Error("pill click must open the existing account panel");
+const exportLinks = integrationRenderer.root.findAll((node) => typeof node.props?.["data-export-format"] === "string");
+assert.deepEqual(exportLinks.map((node) => node.props["data-export-format"]), ["daily-csv", "sessions-csv", "json"], "the panel must expose all three secret-free downloads without a new fetch loop");
+for (const link of exportLinks) if (link.type !== "a" || typeof link.props.download !== "string" || link.props.className !== "usg_exportLink") throw new Error("exports must be styled browser downloads");
 const selectedPicker = integrationRenderer.root.findByType("select");
 if (selectedPicker.props.value !== "opencode-go") throw new Error(`pill click must select its provider in the existing panel, got ${selectedPicker.props.value}`);
 if (!integrationRequests.some((path) => path.includes("/account?provider=opencode-go&activity=detail"))) throw new Error("the open detail panel must signal its provider to the central scheduler");

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -1,0 +1,39 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { SEMVER } from "./release-metadata.mjs";
+const version = process.argv[2];
+
+if (typeof version !== "string" || !SEMVER.test(version)) {
+	console.error("usage: npm run release:sync -- <semver>");
+	process.exitCode = 1;
+} else {
+	const readJson = async (path) => JSON.parse(await readFile(path, "utf8"));
+	const [pkg, lock, catalog, readme] = await Promise.all([
+		readJson("package.json"),
+		readJson("package-lock.json"),
+		readJson("catalog/v1/plugins.json"),
+		readFile("README.md", "utf8")
+	]);
+	const previousVersion = pkg.version;
+	const marker = `<!-- stable-version: ${previousVersion} -->`;
+	if (!readme.includes(marker)) throw new Error(`README stable-version marker does not match package ${previousVersion}`);
+	const timestamp = new Date().toISOString();
+	pkg.version = version;
+	lock.version = version;
+	lock.packages[""].version = version;
+	catalog.revision = version;
+	catalog.generatedAt = timestamp;
+	catalog.items[0].latestVersion = version;
+	catalog.items[0].updatedAt = timestamp;
+	const nextReadme = readme
+		.replace(marker, `<!-- stable-version: ${version} -->`)
+		.replaceAll(`${pkg.name}@${previousVersion}`, `${pkg.name}@${version}`)
+		.replaceAll(`stable/catalog 版本是 \`${previousVersion}\``, `stable/catalog 版本是 \`${version}\``)
+		.replaceAll(`当前 npm stable 为 \`${previousVersion}\``, `当前 npm stable 为 \`${version}\``);
+	await Promise.all([
+		writeFile("package.json", `${JSON.stringify(pkg, null, 2)}\n`, "utf8"),
+		writeFile("package-lock.json", `${JSON.stringify(lock, null, 2)}\n`, "utf8"),
+		writeFile("catalog/v1/plugins.json", `${JSON.stringify(catalog, null, 2)}\n`, "utf8"),
+		writeFile("README.md", nextReadme, "utf8")
+	]);
+	console.log(`synchronized package, lockfile, catalog, and README install references to ${version}`);
+}

--- a/scripts/test-export.mjs
+++ b/scripts/test-export.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { dailyCsv, EXPORT_SCHEMA_VERSION, jsonExport, sessionsCsv } from "../lib/export.js";
+
+const secret = "sk-super-secret";
+const usage = {
+	updatedAt: Date.parse("2026-08-26T12:00:00Z"),
+	total: {
+		inputTokens: 100,
+		cacheReadTokens: 20,
+		cacheWriteTokens: 10,
+		outputTokens: 5,
+		tokens: 135,
+		cacheHitRate: 15.4,
+		estimatedCost: 0.25,
+		currency: "USD",
+		costComplete: true,
+		pricing: { ruleIds: ["deepseek-c"], source: { kind: "official", provider: "deepseek", url: "https://api-docs.deepseek.com/quick_start/pricing/" }, updatedAt: "2026-08-26" }
+	},
+	days: [{
+		date: "2026-08-26",
+		inputTokens: 100,
+		cacheReadTokens: 20,
+		cacheWriteTokens: 10,
+		outputTokens: 5,
+		tokens: 135,
+		costComplete: true,
+		estimatedCost: 0.25,
+		currency: "USD",
+		models: [{
+			model: "deepseek-official/=HYPERLINK(\"https://evil.invalid\")",
+			inputTokens: 100,
+			cacheReadTokens: 20,
+			cacheWriteTokens: 10,
+			outputTokens: 5,
+			tokens: 135,
+			costComplete: false,
+			estimatedCost: 999,
+			currency: "USD",
+			credential: secret
+		}]
+	}],
+	sessions: [{
+		sessionId: "session,\"一\"",
+		title: "=1+1 中文",
+		providers: ["deepseek-official"],
+		models: ["deepseek-official/deepseek-chat"],
+		tokens: 135,
+		costComplete: true,
+		estimatedCost: 0.25,
+		currency: "USD",
+		firstAt: "2026-08-26T11:00:00.000Z",
+		lastAt: "2026-08-26T12:00:00.000Z",
+		authorization: secret
+	}],
+	budgets: {
+		currency: "USD",
+		daily: { limit: 1, currency: "USD", estimatedSpend: 0.25, percent: 25, costComplete: true, level: "normal" },
+		monthly: { limit: null, currency: "USD", estimatedSpend: 0.25, percent: null, costComplete: true, level: "disabled" }
+	},
+	apiKey: secret
+};
+
+const daily = dailyCsv(usage);
+assert.ok(daily.startsWith("\uFEFF\"date\",\"provider\",\"model\""));
+assert.match(daily, /"deepseek-official"/);
+assert.match(daily, /"'=HYPERLINK\(""https:\/\/evil\.invalid""\)"/);
+assert.match(daily, /,"",""\r\n$/, "incomplete costs must export as blank amount/currency");
+assert.doesNotMatch(daily, new RegExp(secret));
+
+const sessions = sessionsCsv(usage);
+assert.match(sessions, /"session,""一"""/);
+assert.match(sessions, /"'=1\+1 中文"/);
+assert.doesNotMatch(sessions, new RegExp(secret));
+assert.match(sessionsCsv({ sessions: [{ sessionId: "line-break", title: "line 1\r\nline 2", tokens: 0 }] }), /"line 1\r\nline 2"/, "embedded CR/LF must remain inside a quoted CSV field");
+assert.match(sessionsCsv({ sessions: [{ sessionId: "formula-after-newline", title: "\n=cmd", tokens: 0 }] }), /"'\n=cmd"/, "a leading newline must not bypass spreadsheet-formula protection");
+
+const accounts = [{
+	id: "relay-a",
+	displayName: "Relay A",
+	accountMode: "balance",
+	adapter: "new-api",
+	configured: true,
+	status: "ok",
+	provenance: "custom",
+	reason: "healthy",
+	alert: { level: "normal", metric: "balance", value: 12 },
+	credential: secret,
+	baseURL: `https://user:${secret}@relay.invalid/?token=${secret}`
+}];
+const full = jsonExport(usage, accounts, Date.parse("2026-08-26T12:30:00Z"));
+assert.equal(full.schemaVersion, EXPORT_SCHEMA_VERSION);
+assert.equal(full.exportedAt, "2026-08-26T12:30:00.000Z");
+assert.equal(full.usage.days[0].models[0].estimatedCost, null);
+assert.equal(full.usage.days[0].models[0].costComplete, false);
+assert.deepEqual(full.usage.total.pricing.source, { kind: "official", provider: "deepseek", url: "https://api-docs.deepseek.com/quick_start/pricing/" });
+assert.equal(full.accounts[0].id, "relay-a");
+assert.equal(full.accounts[0].baseURL, void 0);
+assert.equal(full.accounts[0].credential, void 0);
+assert.doesNotMatch(JSON.stringify(full), new RegExp(secret));
+
+assert.throws(() => jsonExport(usage, accounts, Infinity), /Invalid time value/);
+
+console.log("secret-free CSV/JSON export tests passed");

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -49,8 +49,9 @@ async function freshModule(label, home) {
 function makeResponse() {
 	return {
 		status: null,
+		headers: {},
 		body: "",
-		writeHead(status) { this.status = status; },
+		writeHead(status, headers = {}) { this.status = status; this.headers = headers; },
 		end(body = "") { this.body = body; }
 	};
 }
@@ -168,6 +169,21 @@ async function testSessionContext(root) {
 	}, "an accepted selector route must override the last request/header immediately");
 	assert.deepEqual(switchedContext.session, firstContext.session, "selector hints must not rewrite historical session billing");
 	assert.deepEqual(touches.at(-1), ["route-b", "active"], "selector route changes must update central scheduler activity");
+	const hiddenRoutes = new Map();
+	const touchCountBeforeHidden = touches.length;
+	await plugin.apply(makeContext({ sessions, persistence, routes: hiddenRoutes, settings }), {
+		display: { currentSessionPill: false }
+	}, { disableBackgroundRefresh: true, accounts });
+	const hidden = makeResponse();
+	await hiddenRoutes.get(plugin.SESSION_CONTEXT_PATH)({
+		method: "GET",
+		url: `${plugin.SESSION_CONTEXT_PATH}?session=live-session`,
+		headers: { host: "localhost:3080" },
+		socket: { remoteAddress: "127.0.0.1" }
+	}, hidden);
+	assert.equal(hidden.status, 200);
+	assert.deepEqual(JSON.parse(hidden.body), { ok: true, context: null, display: { currentSessionPill: false } });
+	assert.equal(touches.length, touchCountBeforeHidden, "a hidden Pill must not touch the account scheduler");
 	const invalidSelectionQueries = [
 		"provider=route-b",
 		"provider=route-b&model=",
@@ -363,7 +379,17 @@ async function testConfigValidation(root) {
 	assert.deepEqual(validated.issues, void 0);
 	assert.deepEqual(validated.value.refresh, { enabled: false, activeMs: 120000, detailMs: 180000, backgroundMs: 240000 });
 	assert.deepEqual(validated.value.budgets, { currency: "USD", daily: null, monthly: null });
+	assert.deepEqual(validated.value.display, { currentSessionPill: true });
+	assert.deepEqual(validated.value.monitors, {}, "release hardening must not insert account monitors into normalized user config");
+	const legacyMonitor = plugin.Config["~standard"].validate({ monitors: {
+		relay: { adapter: "general", usageBaseURL: "https://relay.example.com", credentialRef: "RELAY_KEY" }
+	} }).value.monitors.relay;
+	assert.equal(legacyMonitor.adapter, "general");
+	assert.equal(legacyMonitor.credentialRef, "RELAY_KEY", "existing v0.2.10 monitor references must remain compatible");
+	assert.deepEqual(plugin.Config["~standard"].validate({ display: { currentSessionPill: false } }).value.display, { currentSessionPill: false });
 	assert.deepEqual(plugin.Config["~standard"].validate({ budgets: { currency: "CNY", daily: 5, monthly: 100 } }).value.budgets, { currency: "CNY", daily: 5, monthly: 100 });
+	assert.match(plugin.Config["~standard"].validate({ display: { currentSessionPill: "no" } }).issues[0].message, /display\.currentSessionPill/);
+	assert.match(plugin.Config["~standard"].validate({ display: [] }).issues[0].message, /display must be an object/);
 	assert.match(plugin.Config["~standard"].validate({ budgets: { daily: 0 } }).issues[0].message, /budgets\.daily/);
 	assert.equal(plugin.Config["~standard"].validate({ disableBackgroundRefresh: true }).value.refresh.enabled, false);
 	assert.match(plugin.Config["~standard"].validate({ refresh: { activeMs: 1 } }).issues[0].message, /refresh\.activeMs/);
@@ -376,10 +402,107 @@ async function testConfigValidation(root) {
 		settings: { get: () => void 0 }
 	});
 	await assert.rejects(
+		() => plugin.apply(context, { display: [] }, { disableBackgroundRefresh: true }),
+		/display must be an object/
+	);
+	assert.equal(routes.size, 0, "malformed display settings must fail before routes are registered");
+	await assert.rejects(
 		() => plugin.apply(context, { monitors: { missing: { adapter: "general" } } }, { disableBackgroundRefresh: true }),
 		/unknown provider: missing/
 	);
 	assert.equal(routes.size, 0, "invalid provider config must fail before routes are registered");
+}
+
+async function testExportRoutes(root) {
+	const plugin = await freshModule("export-routes", join(root, "export-routes"));
+	const routes = new Map();
+	const secret = "SECRET_EXPORT_CREDENTIAL";
+	const eventTime = Date.UTC(2026, 7, 26, 12, 0, 0);
+	const context = makeContext({
+		sessions: { list: () => [{
+			id: "export-session",
+			title: "=1+1 中文,\"quoted\"",
+			events: [pricedUsageEvent(0, eventTime, "deepseek-official", "deepseek-v4-pro", 1_000_000)]
+		}] },
+		persistence: { listSnapshots: async () => [], list: async () => [] },
+		routes,
+		settings: {
+			get: (name) => name === "llm-deepseek" ? {
+				apiKeyEnv: secret,
+				baseURL: `https://api.deepseek.com/v1?token=${secret}`
+			} : void 0
+		}
+	});
+	await plugin.apply(context, {}, { disableBackgroundRefresh: true });
+	assert.equal(routes.size, 9, "v0.3 release candidate must register six API views plus three exports");
+
+	const request = (path) => ({ method: "GET", url: path, headers: { host: "localhost:3080" }, socket: { remoteAddress: "127.0.0.1" } });
+	const daily = makeResponse();
+	await routes.get(plugin.DAILY_EXPORT_PATH)(request(plugin.DAILY_EXPORT_PATH), daily);
+	assert.equal(daily.status, 200);
+	assert.equal(daily.headers["content-type"], "text/csv; charset=utf-8");
+	assert.equal(daily.headers["content-disposition"], 'attachment; filename="dsh-usage-daily.csv"');
+	assert.match(daily.body, /^\uFEFF"date","provider","model"/);
+	assert.doesNotMatch(daily.body, new RegExp(secret));
+
+	const sessions = makeResponse();
+	await routes.get(plugin.SESSIONS_EXPORT_PATH)(request(plugin.SESSIONS_EXPORT_PATH), sessions);
+	assert.equal(sessions.status, 200);
+	assert.match(sessions.body, /"'=1\+1 中文,""quoted"""/);
+	assert.doesNotMatch(sessions.body, new RegExp(secret));
+
+	const full = makeResponse();
+	await routes.get(plugin.JSON_EXPORT_PATH)(request(plugin.JSON_EXPORT_PATH), full);
+	assert.equal(full.status, 200);
+	assert.equal(full.headers["content-type"], "application/json; charset=utf-8");
+	const exported = JSON.parse(full.body);
+	assert.equal(exported.schemaVersion, "1.0.0");
+	assert.equal(exported.usage.sessions[0].title, "=1+1 中文,\"quoted\"");
+	assert.ok(Array.isArray(exported.accounts));
+	assert.doesNotMatch(full.body, new RegExp(secret));
+	assert.doesNotMatch(full.body, /apiKey|credential|authorization/i);
+
+	const foreign = makeResponse();
+	await routes.get(plugin.JSON_EXPORT_PATH)({ ...request(plugin.JSON_EXPORT_PATH), socket: { remoteAddress: "198.51.100.4" } }, foreign);
+	assert.equal(foreign.status, 403, "exports must preserve the loopback peer fence");
+	const post = makeResponse();
+	await routes.get(plugin.DAILY_EXPORT_PATH)({ ...request(plugin.DAILY_EXPORT_PATH), method: "POST" }, post);
+	assert.equal(post.status, 405, "exports must remain GET-only");
+
+	const failingRoutes = new Map();
+	const failingAccounts = {
+		validate: async () => {},
+		providerViews: async () => { throw new Error(`Authorization: Bearer ${secret}`); }
+	};
+	await plugin.apply(makeContext({
+		sessions: { list: () => [] },
+		persistence: { listSnapshots: async () => [], list: async () => [] },
+		routes: failingRoutes,
+		settings: { get: () => void 0 }
+	}), {}, { accounts: failingAccounts, disableBackgroundRefresh: true });
+	const failed = makeResponse();
+	await failingRoutes.get(plugin.JSON_EXPORT_PATH)(request(plugin.JSON_EXPORT_PATH), failed);
+	assert.equal(failed.status, 500);
+	assert.deepEqual(JSON.parse(failed.body), { ok: false, error: "internal", message: "export failed" });
+	assert.doesNotMatch(failed.body, new RegExp(secret), "export error responses must not reflect upstream diagnostics");
+}
+
+async function testMalformedCacheRebuild(root) {
+	const home = join(root, "malformed-cache");
+	const storage = join(home, "storages");
+	await mkdir(storage, { recursive: true });
+	await writeFile(join(storage, "usage-stats-cache.json"), "{malformed v0.2.10 cache", "utf8");
+	const plugin = await freshModule("malformed-cache", home);
+	const context = makeContext({
+		sessions: { list: () => [{ id: "recovered", events: [usageEvent(1, 17)] }] },
+		persistence: { listSnapshots: async () => [], list: async () => [] },
+		settings: { get: () => void 0 }
+	});
+	const usage = await plugin.collectUsage(context);
+	assert.equal(usage.total.tokens, 17, "a malformed cache must rebuild from authoritative session events");
+	const rebuilt = JSON.parse(await readFile(join(storage, "usage-stats-cache.json"), "utf8"));
+	assert.equal(rebuilt.version, 5);
+	assert.equal(rebuilt.sessions.recovered.consumed, 1);
 }
 
 async function testUsageBillingWire(root) {
@@ -630,6 +753,8 @@ try {
 	await testRuntimeProviderPricingIdentityChange(root);
 	await testConfigValidation(root);
 	await testUsageBillingWire(root);
+	await testExportRoutes(root);
+	await testMalformedCacheRebuild(root);
 	await testLegacyZaiSubscriptionId(root);
 	await testBackgroundRefresh(root);
 	await testDisabledAccountRefresh(root);


### PR DESCRIPTION
Closes #64
Closes #70
Closes #79
References #80
Reference #65

## Summary
- Add secret-free, versioned CSV and JSON usage exports.
- Add a default-on Current Session Pill display setting and remember the last valid provider locally.
- Harden v0.2.10 to v0.3.0 migration, malformed-cache recovery, and export security regressions.
- Add release metadata checks, version-sync tooling, README installation guidance, and an RC checklist.

## Scope
- Package version remains 0.2.10.
- No npm publish, tag, or GitHub Release.
- No new providers, pricing, FX, burn rate, notifications, or per-provider refresh policy.

## Validation
- npm run check
- npm test
- npm pack --json