### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dsh-usage-stats
 
-<!-- stable-version: 0.2.10 -->
+<!-- stable-version: 0.3.0 -->
 
 [![GitHub Release](https://img.shields.io/github/v/release/Ychris12138/dsh-usage-stats?display_name=tag&sort=semver&color=1f6feb)](https://github.com/Ychris12138/dsh-usage-stats/releases/latest)
 [![CI](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml/badge.svg)](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml)
@@ -35,7 +35,7 @@ Provider balances, subscription quotas, and token-usage analytics for the DeepSe
 稳定版优先安装 npm 上的精确版本；这也是 DSH Desktop Market 使用的同一个包：
 
 ```bash
-dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.2.10"
+dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.3.0"
 ```
 
 只有测试尚未发布的 source/RC 时才使用 `dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"`。GitHub `main` 可能领先 npm stable，不应把 source 安装当作市场安装验收。
@@ -49,7 +49,7 @@ dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.2.10"
 - `catalog/catalog-source.json` — 来源 manifest（`catalog-source.schema.json` v1.0.0）
 - `catalog/v1/plugins.json` — 标准 provider page（`catalog-provider-page.schema.json` v1.0.0）
 
-**使用前提（重要）**：市场托管安装只接受 npm registry 的精确稳定版本，git 条目仅可浏览。`dsh-usage-stats` 这个 npm 名已被其他项目占用，因此目录条目身份使用 `@ychris12138/dsh-usage-stats`。当前 stable/catalog 版本是 `0.2.10`；每个新版本都按以下顺序发布：
+**使用前提（重要）**：市场托管安装只接受 npm registry 的精确稳定版本，git 条目仅可浏览。`dsh-usage-stats` 这个 npm 名已被其他项目占用，因此目录条目身份使用 `@ychris12138/dsh-usage-stats`。当前 stable/catalog 版本是 `0.3.0`；每个新版本都按以下顺序发布：
 
 1. 运行 `npm run release:sync -- <version>` 同步 `package.json` / `package-lock.json` / `catalog/v1/plugins.json`，再由 `npm run check:release` 阻止身份或版本漂移。
 2. 发布 scoped 公共包：`npm publish --access public`。
@@ -355,7 +355,7 @@ Constraints:
 
 Procedure:
 1. Confirm node, npx, and dsh are available.
-2. Prefer the exact npm stable used by Desktop Market: `dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.2.10"` (or update the existing scoped package).
+2. Prefer the exact npm stable used by Desktop Market: `dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.3.0"` (or update the existing scoped package).
 3. Use `github:Ychris12138/dsh-usage-stats` only when I explicitly ask to test unreleased source/RC code.
 4. If dsh plugin is unavailable, use the compatible source installer only with my approval: `npx --yes github:Ychris12138/dsh-usage-stats`.
 5. Do not combine bundle installation with an existing manual dsh-usage-stats Cordis entry.
@@ -448,7 +448,7 @@ node scripts/check-balance.mjs
 
 ## 兼容性与致谢 / Compatibility & credits
 
-当前 npm stable 为 `0.2.10`；`v0.3.0` release candidate 的完整门禁见 [`docs/release-checklist.md`](docs/release-checklist.md)，变更摘要见 [`docs/release-notes-v0.3.0.md`](docs/release-notes-v0.3.0.md)。插件依赖 Harness 客户端模块加载器、Cordis 服务与 session persistence；Harness 预发布接口变化时可能需要同步适配。
+当前 npm stable 为 `0.3.0`；`v0.3.0` 的完整发布门禁见 [`docs/release-checklist.md`](docs/release-checklist.md)，变更摘要见 [`docs/release-notes-v0.3.0.md`](docs/release-notes-v0.3.0.md)。插件依赖 Harness 客户端模块加载器、Cordis 服务与 session persistence；Harness 预发布接口变化时可能需要同步适配。
 
 - [Javis603/token-monitor](https://github.com/Javis603/token-monitor)：参考多 provider 配额归一化与 Z.ai 限额解析。
 - [xiaoqi20/dsh-opencode-go-usage](https://github.com/xiaoqi20/dsh-opencode-go-usage)：参考 DSH 凭据接入、OpenCode `auth.json` 回退与 Bearer usage endpoint。

--- a/catalog/v1/plugins.json
+++ b/catalog/v1/plugins.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-22T06:49:00.000Z",
-  "revision": "0.2.10",
+  "generatedAt": "2026-08-26T17:17:24.850Z",
+  "revision": "0.3.0",
   "items": [
     {
       "id": "dsh-usage-stats",
@@ -10,7 +10,7 @@
       "summary": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI.",
       "description": "在 DSH 对话界面内展示 Token 用量热力图、各 provider 账户余额与订阅配额，数据来自持久化会话日志。catalog 条目身份与 npm 包 `@ychris12138/dsh-usage-stats` 对齐，发布后即可通过插件市场 GUI 直接安装。",
       "homepage": "https://github.com/Ychris12138/dsh-usage-stats",
-      "latestVersion": "0.2.10",
+      "latestVersion": "0.3.0",
       "license": "MIT",
       "categories": [
         "development",
@@ -40,7 +40,7 @@
           "dsh"
         ]
       },
-      "updatedAt": "2026-08-22T06:49:00.000Z"
+      "updatedAt": "2026-08-26T17:17:24.850Z"
     }
   ],
   "page": {}

--- a/docs/release-notes-v0.3.0.md
+++ b/docs/release-notes-v0.3.0.md
@@ -1,4 +1,4 @@
-# v0.3.0 release notes (release candidate)
+# v0.3.0 release notes
 
 `v0.3.0` turns dsh-usage-stats from an account/Token dashboard into a route-aware usage and cost observability layer while preserving the v0.2.x credential and loopback security boundaries.
 
@@ -11,6 +11,7 @@
 - New API balance display respects the instance's USD/CNY quota settings. Unsupported display types and invalid CNY exchange rates do not masquerade as money.
 - Daily CSV, session CSV, and versioned JSON exports use explicit secret-free projections, preserve Unicode, escape CSV safely, and omit incomplete cost amounts.
 - The account panel remembers its last valid provider in namespaced browser localStorage and falls back safely if that provider is removed.
+- Sidebar footer actions preserve the shared row layout and wrap full-width entries safely, preventing overlap or oversized entries when dsh-usage-stats is installed alongside other footer plugins (#82).
 
 ## Cost accuracy statement
 
@@ -22,7 +23,3 @@ All monetary values are **estimates**, not invoices. A sample is priced only whe
 - Older usage-cache schemas are invalidated and refolded from authoritative session events. Malformed cache JSON is ignored and rebuilt; it must not block DSH startup.
 - Existing account monitor configuration is normalized without writing credentials or inserting new monitor entries.
 - Browser provider selection is local UI state only; it creates no endpoint and no server-side setting.
-
-## Release status
-
-This document describes the `v0.3.0` release candidate. The package version remains `0.2.10` until maintainer review and the complete RC checklist pass. npm publish, tag creation, GitHub Release creation, Pages verification, and Desktop Market installation are separate final release steps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ychris12138/dsh-usage-stats",
-  "version": "0.2.10",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ychris12138/dsh-usage-stats",
-      "version": "0.2.10",
+      "version": "0.3.0",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ychris12138/dsh-usage-stats",
   "description": "Token usage, provider accounts, session cost estimates, budgets, and exports for the dsh web GUI",
-  "version": "0.2.10",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Ychris12138/dsh-usage-stats.git"


### PR DESCRIPTION
Reference #65
Reference #80

RC_BASE_SHA: 66b79d7cbd8dfb8814950dfa00c15becf2171589
RELEASE_SHA: be5f314c7db5f6e2257baabffae8529a960f5510

RC verdict: PASS WITH UNTESTED ENVIRONMENT ITEMS

This PR only freezes v0.3.0 release metadata.
It does not publish npm, create a tag, or create a GitHub Release.