### PR TITLE
feat: sidebar badge ??/???? + 10??????

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -31,6 +31,14 @@ window.__ModuleLoader__.load({
 			".usg_badgeOk{color:var(--dsw-alias-state-success-primary)}",
 			".usg_badgeBad{color:var(--dsw-alias-state-error-primary)}",
 			".usg_badgeCount{color:var(--dsw-alias-label-tertiary);font-variant-numeric:tabular-nums;flex:none;margin-left:auto;font-size:12px;line-height:16px}",
+			".usg_badgeStack{flex-direction:column;align-items:stretch;gap:4px;min-width:0;flex:1;display:flex}",
+			".usg_badgeRow{justify-content:flex-start;align-items:baseline;gap:10px;min-width:0;display:flex}",
+			".usg_badgeGroup{align-items:baseline;gap:3px;min-width:0;display:inline-flex;white-space:nowrap}",
+			".usg_badgeTag{color:var(--dsw-alias-label-tertiary);flex:none;font-size:10px;line-height:13px}",
+			".usg_badgeModel{color:var(--dsw-alias-label-primary);flex:none;font-size:11px;font-weight:600;line-height:13px;white-space:nowrap}",
+			".usg_badgePrice{color:var(--dsw-alias-state-success-primary);font-size:12px;font-weight:700;line-height:14px;font-variant-numeric:tabular-nums;white-space:nowrap}",
+			".usg_badgeCost{color:var(--dsw-alias-label-secondary);font-size:12px;line-height:14px;font-variant-numeric:tabular-nums;white-space:nowrap}",
+			".usg_badgeGap{color:var(--dsw-alias-label-caption)}",
 			".usg_sessionPill{box-sizing:border-box;max-width:220px;height:28px;color:var(--dsw-alias-label-tertiary);background:var(--dsw-alias-fill-l1,transparent);border:1px solid var(--dsw-alias-border-l2);border-radius:999px;align-items:center;gap:5px;padding:0 8px;font:inherit;font-size:11px;line-height:16px;cursor:pointer;display:inline-flex;white-space:nowrap;overflow:hidden}",
 			".usg_sessionPill:hover{background:var(--dsw-alias-interactive-bg-hover)}",
 			".usg_sessionPill:focus-visible{outline:2px solid var(--dsw-alias-state-business-primary);outline-offset:1px}",
@@ -170,7 +178,14 @@ window.__ModuleLoader__.load({
 			badgeOk: "usg_badgeOk",
 			badgeBad: "usg_badgeBad",
 			badgeCount: "usg_badgeCount",
-			sessionPill: "usg_sessionPill",
+			badgeStack: "usg_badgeStack",
+			badgeRow: "usg_badgeRow",
+			badgeModel: "usg_badgeModel",
+			badgePrice: "usg_badgePrice",
+			badgeCost: "usg_badgeCost",
+			badgeGap: "usg_badgeGap",
+			badgeGroup: "usg_badgeGroup",
+			badgeTag: "usg_badgeTag",
 			sessionPillProvider: "usg_sessionPillProvider",
 			sessionPillSeparator: "usg_sessionPillSeparator",
 			sessionPillValue: "usg_sessionPillValue",
@@ -987,10 +1002,21 @@ window.__ModuleLoader__.load({
 			}, [providerChoices, providersAuthoritative]);
 
 			react.useEffect(() => {
+				// Keep the collapsed sidebar badge fresh even when the panel is
+				// closed: refetch usage (price/today spend) and the selected
+				// provider account (balance) every 10 minutes.
+				const badgeTimer = window.setInterval(() => {
+					loadUsage();
+					if (selectedProvider !== null) loadAccount(selectedProvider, false, null);
+				}, 600000);
+				return () => window.clearInterval(badgeTimer);
+			}, [loadUsage, loadAccount, selectedProvider]);
+
+			react.useEffect(() => {
 				if (!open) return;
 				loadUsage();
 				loadProviders();
-				const usageTimer = window.setInterval(loadUsage, 60000);
+				const usageTimer = window.setInterval(loadUsage, 600000);
 				const providerTimer = window.setInterval(loadProviders, 300000);
 				return () => {
 					window.clearInterval(usageTimer);
@@ -1088,6 +1114,101 @@ window.__ModuleLoader__.load({
 			const badgeLabel = translate("panel.badge");
 			const badgeAmountText = badgeAmount !== null ? badgeAmount.display : null;
 			const badgeToneClass = badgeAmount === null ? null : (badgeWarn ? S.badgeBad : S.badgeOk);
+			// Price-per-1M-token for the CURRENT session's dominant model, and the
+			// current Beijing-time tariff (peak vs off-peak). DeepSeek prices are
+			// split into peak/off-peak windows; the badge shows the exact rate that
+			// applies RIGHT NOW, not a range.
+			//   Peak (offPeak x2): Mon–Fri 09:00–12:00 & 14:00–18:00 (Asia/Shanghai)
+			const CNY_REFERENCE = Object.freeze({
+				"deepseek-v4-flash-vision-exp": { short: "Vision", offInput: 1.5, offCache: 0.05, offOutput: 4.5, peakInput: 3.0, peakCache: 0.10, peakOutput: 9.0 },
+				"deepseek-v4-flash": { short: "Flash", offInput: 1.5, offCache: 0.05, offOutput: 4.5, peakInput: 3.0, peakCache: 0.10, peakOutput: 9.0 },
+				"deepseek-v4-pro": { short: "Pro", offInput: 4.5, offCache: 0.15, offOutput: 13.5, peakInput: 9.0, peakCache: 0.30, peakOutput: 27.0 }
+			});
+			/** True when the current Beijing time falls in a DeepSeek peak window. */
+			function isPeakNow() {
+				try {
+					const parts = Object.fromEntries(new Intl.DateTimeFormat("en-US", {
+						timeZone: "Asia/Shanghai", weekday: "short", hour: "2-digit", minute: "2-digit", hourCycle: "h23"
+					}).formatToParts(new Date()).filter((p) => p.type !== "literal").map((p) => [p.type, p.value]));
+					const weekday = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"].indexOf(parts.weekday);
+					if (weekday === 0 || weekday === 6) return false; // weekend off-peak
+					const minutes = Number(parts.hour) * 60 + Number(parts.minute);
+					return (minutes >= 9 * 60 && minutes < 12 * 60) || (minutes >= 14 * 60 && minutes < 18 * 60);
+				} catch { return false; }
+			}
+			const peakNow = isPeakNow();
+			const pricePerM = (() => {
+				try {
+					// Determine the dominant model of the current day.
+					let modelId = null;
+					let bestTokens = 0;
+					if (usage !== null && Array.isArray(usage.days) && usage.days.length > 0) {
+						const today = usage.days[usage.days.length - 1];
+						for (const row of (today.models ?? [])) {
+							if (typeof row.tokens === "number" && row.tokens > bestTokens) { bestTokens = row.tokens; modelId = row.model; }
+						}
+					}
+					const shortModel = typeof modelId === "string"
+						? (modelId.split("/").pop() ?? modelId)
+						: null;
+					const ref = shortModel !== null ? CNY_REFERENCE[shortModel] : null;
+					if (ref !== null) {
+						// Exact input (cache-miss) rate for the CURRENT tariff, CNY per M token.
+						const rate = peakNow ? ref.peakInput : ref.offInput;
+						return { label: `${rate}`, currency: "CNY", short: ref.short, peak: peakNow };
+					}
+					return null;
+				} catch { return null; }
+			})();
+			const priceText = pricePerM !== null
+				? `${pricePerM.currency === "CNY" ? "¥" : "$"}${pricePerM.label}/M${pricePerM.peak ? "·峰" : "·闲"}`
+				: null;
+			const modelShortText = pricePerM !== null ? pricePerM.short : null;
+			// Today's CNY cost and the ACTUAL blended per-M-token cost (今天总花费
+			// ÷ 今天总token×1M). The blended figure reflects the real mix of cheap
+			// cache-hits vs expensive misses/output, so it is far below the flat
+			// reference sticker price. Both update every 10 minutes.
+			let todayCny = 0;
+			let todayTokens = 0;
+			const sessionCostText = (() => {
+				try {
+					let sum = 0;
+					let any = false;
+					let tokens = 0;
+					if (usage !== null && Array.isArray(usage.days) && usage.days.length > 0) {
+						const today = usage.days[usage.days.length - 1];
+						for (const row of (today.models ?? [])) {
+							const shortModel = typeof row.model === "string" ? (row.model.split("/").pop() ?? row.model) : null;
+							const ref = shortModel !== null ? CNY_REFERENCE[shortModel] : null;
+							const m = 1e6;
+							const usePeak = peakNow;
+							const inRate = ref ? (usePeak ? ref.peakInput : ref.offInput) : CNY_REFERENCE["deepseek-v4-flash"].offInput;
+							const cacheRate = ref ? (usePeak ? ref.peakCache : ref.offCache) : 0.05;
+							const outRate = ref ? (usePeak ? ref.peakOutput : ref.offOutput) : 4.5;
+							const input = row.inputTokens ?? 0;
+							const output = row.outputTokens ?? 0;
+							const cacheRead = row.cacheReadTokens ?? 0;
+							const modelCost = input / m * inRate + cacheRead / m * cacheRate + output / m * outRate;
+							tokens += row.tokens ?? 0;
+							if (Number.isFinite(modelCost) && modelCost > 0) { sum += modelCost; any = true; }
+						}
+						todayCny = sum;
+						todayTokens = tokens;
+						if (any) return `¥${sum.toFixed(2)}`;
+					}
+					return null;
+				} catch { return null; }
+			})();
+			// Actual blended price per M token = todayCny / todayTokens * 1e6.
+			const actualPerM = (() => {
+				try {
+					if (todayCny > 0 && todayTokens > 0) {
+						return `${(todayCny / todayTokens * 1e6).toFixed(2)}`;
+					}
+					return null;
+				} catch { return null; }
+			})();
+			const actualPerMText = actualPerM !== null ? `¥${actualPerM}/M` : null;
 
 			const retry = () => {
 				loadUsage();
@@ -1333,9 +1454,33 @@ window.__ModuleLoader__.load({
 								react_jsx_runtime.jsx(primitives.IconDataOutline16, { size: wide ? 14 : 18 }),
 								wide && react_jsx_runtime.jsxs(react_jsx_runtime.Fragment, {
 									children: [
-										react_jsx_runtime.jsx("span", { className: S.badgeLabel, children: badgeLabel }),
-										badgeAmountText !== null && react_jsx_runtime.jsx("span", { className: badgeToneClass !== null ? `${S.badgeAmount} ${badgeToneClass}` : S.badgeAmount, children: badgeAmountText }),
-										badgeCount !== null && react_jsx_runtime.jsx("span", { className: S.badgeCount, children: badgeCount })
+										react_jsx_runtime.jsx("div", { className: S.badgeStack, children: [
+											react_jsx_runtime.jsxs("div", { className: S.badgeRow, children: [
+												react_jsx_runtime.jsx("span", { className: S.badgeModel, children: modelShortText }),
+												priceText !== null && react_jsx_runtime.jsxs("span", { className: S.badgeGroup, children: [
+													react_jsx_runtime.jsx("span", { className: S.badgeTag, children: "牌" }),
+													react_jsx_runtime.jsx("span", { className: S.badgePrice, children: priceText })
+												] }),
+												actualPerMText !== null && react_jsx_runtime.jsxs("span", { className: S.badgeGroup, children: [
+													react_jsx_runtime.jsx("span", { className: S.badgeTag, children: "实" }),
+													react_jsx_runtime.jsx("span", { className: S.badgeCost, children: actualPerMText })
+												] })
+											] }),
+											react_jsx_runtime.jsxs("div", { className: S.badgeRow, children: [
+												sessionCostText !== null && react_jsx_runtime.jsxs("span", { className: S.badgeGroup, children: [
+													react_jsx_runtime.jsx("span", { className: S.badgeTag, children: "耗" }),
+													react_jsx_runtime.jsx("span", { className: S.badgeCost, children: sessionCostText })
+												] }),
+												badgeCount !== null && react_jsx_runtime.jsxs("span", { className: S.badgeGroup, children: [
+													react_jsx_runtime.jsx("span", { className: S.badgeTag, children: "量" }),
+													react_jsx_runtime.jsx("span", { className: S.badgeCount, children: badgeCount })
+												] }),
+												badgeAmountText !== null && react_jsx_runtime.jsxs("span", { className: S.badgeGroup, children: [
+													react_jsx_runtime.jsx("span", { className: S.badgeTag, children: "余" }),
+													react_jsx_runtime.jsx("span", { className: badgeToneClass !== null ? `${S.badgeAmount} ${badgeToneClass}` : S.badgeAmount, children: badgeAmountText })
+												] })
+											] })
+										] })
 									]
 								})
 							]


### PR DESCRIPTION
Add price badge to sidebar: sticker price (peak/off-peak) + actual blended per-M cost + today spend + token count + balance; 10-min auto refresh. Only lib/client.js changed. Keep backend untouched.