### PR TITLE
fix: support current DSH sessions and reduce usage polling work

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -176,6 +176,37 @@ let loadedCache = null;
 let loadPromise = null;
 let inflight = null;
 
+// Runtime-only cache bookkeeping. Nothing in this WeakMap is serialized to
+// disk: the on-disk schema remains CACHE_VERSION=5. Keeping the aggregate and
+// dirty flags out of the persisted shape also means old cache files remain
+// valid while hot UI reads can skip redundant work.
+const cacheRuntime = new WeakMap();
+
+function runtimeOf(cache) {
+	let runtime = cacheRuntime.get(cache);
+	if (runtime === void 0) {
+		runtime = {
+			dirty: false,
+			aggregate: null,
+			aggregateDirty: true
+		};
+		cacheRuntime.set(cache, runtime);
+	}
+	return runtime;
+}
+
+function markCacheChanged(cache) {
+	const runtime = runtimeOf(cache);
+	runtime.dirty = true;
+	runtime.aggregateDirty = true;
+}
+
+function diagnostic(ctx, name) {
+	const stats = ctx?.__usageStatsDiagnostics;
+	if (stats === null || typeof stats !== "object") return;
+	stats[name] = (stats[name] ?? 0) + 1;
+}
+
 /** Serialize one session's fold state (Maps → plain objects). */
 function serializeSession(state) {
 	const days = {};
@@ -318,13 +349,15 @@ function freshCache(pricingFingerprintValue, previous = null, transitionAt = Dat
 		if (changedRoutes === null) pricingIdentityCutoffAll = Math.max(pricingIdentityCutoffAll ?? 0, transitionAt);
 		else for (const routeId of changedRoutes) pricingIdentityCutoffs[routeId] = Math.max(pricingIdentityCutoffs[routeId] ?? 0, transitionAt);
 	}
-	return {
+	const cache = {
 		version: CACHE_VERSION,
 		pricingFingerprint: pricingFingerprintValue,
 		pricingIdentityCutoffAll,
 		pricingIdentityCutoffs,
 		sessions: {}
 	};
+	runtimeOf(cache);
+	return cache;
 }
 
 function restoredCache(parsed, pricingFingerprintValue) {
@@ -332,7 +365,7 @@ function restoredCache(parsed, pricingFingerprintValue) {
 	for (const [id, entry] of Object.entries(parsed.sessions)) {
 		if (typeof id === "string" && id.length > 0) sessions[id] = parseSession(entry);
 	}
-	return {
+	const cache = {
 		version: CACHE_VERSION,
 		pricingFingerprint: pricingFingerprintValue,
 		pricingIdentityCutoffAll: Number.isFinite(parsed.pricingIdentityCutoffAll) && parsed.pricingIdentityCutoffAll >= 0
@@ -341,6 +374,8 @@ function restoredCache(parsed, pricingFingerprintValue) {
 		pricingIdentityCutoffs: parsePricingIdentityCutoffs(parsed.pricingIdentityCutoffs),
 		sessions
 	};
+	runtimeOf(cache);
+	return cache;
 }
 
 /** Load against the current runtime provider/pricing fingerprint. */
@@ -374,6 +409,8 @@ async function loadCache(pricingFingerprintValue) {
 
 /** Persist the cache atomically (temp + rename); failures are logged, never fatal. */
 async function saveCache(ctx, cache) {
+	const runtime = runtimeOf(cache);
+	if (!runtime.dirty) return false;
 	try {
 		const path = cachePath();
 		await mkdir(dirname(path), { recursive: true });
@@ -388,8 +425,12 @@ async function saveCache(ctx, cache) {
 		const tmp = `${path}.tmp`;
 		await writeFile(tmp, JSON.stringify(serialized), "utf8");
 		await rename(tmp, path);
+		runtime.dirty = false;
+		diagnostic(ctx, "cacheWrites");
+		return true;
 	} catch (error) {
 		ctx.logger.warn(`usage-stats: saving usage cache failed: ${String(error)}`);
+		return false;
 	}
 }
 
@@ -416,10 +457,47 @@ function withLock(run) {
  * to be contiguous with the last folded seq — a gap or an empty delta means
  * the log was truncated/rewritten, so the session is refolded from scratch.
  * Sessions that vanished are dropped, and a session switching between
- * live/persisted is refolded from scratch to stay exact.
+ * live/persisted is refolded from scratch to stay exact. High-frequency UI
+ * reads pass `{ scanPersisted: false }`: cached persisted folds remain in the
+ * aggregate, but the persistence backend is not enumerated or read. The
+ * five-minute background fold and exports use the default full scan.
  */
-export async function collectUsage(ctx, config = { monitors: {}, budgets: validateBudgetConfig() }) {
+function modernLiveSessionAPI(session) {
+	if (session === null || typeof session !== "object") throw new TypeError("live session must be an object");
+	const hasSnapshotEvents = typeof session.snapshotEvents === "function";
+	const hasSeq = "seq" in session;
+	if (hasSnapshotEvents || hasSeq) {
+		if (!hasSnapshotEvents || !hasSeq) throw new TypeError("live session exposes an incomplete snapshot API");
+		return true;
+	}
+	return false;
+}
+
+function liveSessionCount(session) {
+	if (modernLiveSessionAPI(session)) {
+		const count = session.seq;
+		if (!Number.isSafeInteger(count) || count < 0) throw new TypeError("live session seq must be a non-negative safe integer");
+		return count;
+	}
+	const events = session.events;
+	if (!Array.isArray(events)) throw new TypeError("legacy live session events must be an array");
+	return events.length;
+}
+
+function liveSessionTail(session, fromSeq) {
+	if (modernLiveSessionAPI(session)) {
+		const events = session.snapshotEvents(fromSeq);
+		if (!Array.isArray(events)) throw new TypeError("live session snapshotEvents() must return an array");
+		return events;
+	}
+	const events = session.events;
+	if (!Array.isArray(events)) throw new TypeError("legacy live session events must be an array");
+	return events.slice(fromSeq);
+}
+
+export async function collectUsage(ctx, config = { monitors: {}, budgets: validateBudgetConfig() }, options = {}) {
 	return withLock(async () => {
+		const scanPersisted = options?.scanPersisted !== false;
 		const providers = await configuredProviders(ctx);
 		const runtimePricingFingerprint = pricingFingerprint({ providers, config });
 		const cache = await loadCache(runtimePricingFingerprint);
@@ -437,13 +515,22 @@ export async function collectUsage(ctx, config = { monitors: {}, budgets: valida
 		if (live !== void 0) {
 			for (const session of live.list()) {
 				attached.add(session.id);
-				const state = cache.sessions[session.id] ?? createUsageState();
-				if (typeof session.title === "string") state.title = session.title;
+				let state = cache.sessions[session.id];
+				let stateChanged = false;
+				if (state === void 0) {
+					state = createUsageState();
+					stateChanged = true;
+				}
+				if (typeof session.title === "string" && state.title !== session.title) {
+					state.title = session.title;
+					stateChanged = true;
+				}
 				if (state.kind !== "live") {
 					// Live/persisted transition: refold the whole in-memory log.
 					resetUsageState(state);
+					stateChanged = true;
 				}
-				const count = session.events.length;
+				let count = liveSessionCount(session);
 				if (count < (state.consumed ?? 0)) {
 					// The in-memory log shrank below the folded cursor — DSH
 					// restores sessions from disk as compressed summaries after
@@ -452,45 +539,69 @@ export async function collectUsage(ctx, config = { monitors: {}, budgets: valida
 					// forever (#23). The cursor is meaningless against the
 					// rebuilt log: refold it from scratch.
 					resetUsageState(state);
+					stateChanged = true;
 				}
 				if ((state.consumed ?? 0) < count) {
-					applyUsageDelta(state, session.events.slice(state.consumed ?? 0), { estimateCost });
+					applyUsageDelta(state, liveSessionTail(session, state.consumed ?? 0), { estimateCost });
 					state.consumed = count;
+					stateChanged = true;
 				}
-				state.kind = "live";
+				if (state.kind !== "live") {
+					state.kind = "live";
+					stateChanged = true;
+				}
 				cache.sessions[session.id] = state;
+				if (stateChanged) markCacheChanged(cache);
 			}
 		}
 		const persistence = ctx.get("sessionPersistence");
 		const persistedIds = new Set();
-		if (persistence !== void 0) {
+		if (scanPersisted && persistence !== void 0) {
 			// Prefer the backend's opaque per-log revisions (no file I/O in the
 			// plugin, works for any backend that exposes listSnapshots).
 			let snapshots = null;
 			if (typeof persistence.listSnapshots === "function") {
 				try {
+					diagnostic(ctx, "listSnapshots");
 					snapshots = await persistence.listSnapshots();
 				} catch (error) {
 					ctx.logger.warn(`usage-stats: listSnapshots failed, falling back to list(): ${String(error)}`);
 				}
 			}
-			const metas = snapshots !== null ? snapshots.map((entry) => entry.header) : await persistence.list();
+			let metas;
+			if (snapshots !== null) metas = snapshots.map((entry) => entry.header);
+			else {
+				diagnostic(ctx, "list");
+				metas = typeof persistence.list === "function" ? await persistence.list() : [];
+			}
 			const revisionOf = new Map();
 			if (snapshots !== null) for (const entry of snapshots) revisionOf.set(entry.header.id, entry.revision);
 			for (const meta of metas) {
 				persistedIds.add(meta.id);
 				if (attached.has(meta.id)) continue;
-				const state = cache.sessions[meta.id] ?? createUsageState();
-				if (typeof meta.title === "string") state.title = meta.title;
+				let state = cache.sessions[meta.id];
+				let stateChanged = false;
+				if (state === void 0) {
+					state = createUsageState();
+					stateChanged = true;
+				}
+				if (typeof meta.title === "string" && state.title !== meta.title) {
+					state.title = meta.title;
+					stateChanged = true;
+				}
 				const revision = revisionOf.get(meta.id);
-				const changed = state.kind !== "persisted" || (revision !== void 0 && revision !== state.revision) || revision === void 0;
+				const revisionChanged = revision !== void 0 && revision !== state.revision;
+				const changed = state.kind !== "persisted" || revisionChanged || revision === void 0;
+				if (revisionChanged) stateChanged = true;
 				if (changed) {
 					try {
 						const wasPersisted = state.kind === "persisted";
 						const fromSeq = wasPersisted ? state.consumed : 0;
+						diagnostic(ctx, "readFrom");
 						const { events } = await persistence.readFrom(meta.id, fromSeq);
 						if (!wasPersisted) {
 							resetUsageState(state);
+							stateChanged = true;
 						}
 						const fresh = wasPersisted ? events.filter((event) => event.seq > (state.consumed ?? 0)) : events;
 						// readFrom is inclusive: an unchanged log returns exactly the
@@ -504,31 +615,51 @@ export async function collectUsage(ctx, config = { monitors: {}, budgets: valida
 						if (!contiguous && state.consumed > 0) {
 							// Log truncated or rewritten: refold the whole log.
 							resetUsageState(state);
+							stateChanged = true;
+							diagnostic(ctx, "readFrom");
 							const { events: allEvents } = await persistence.readFrom(meta.id, 0);
 							applyUsageDelta(state, allEvents, { estimateCost });
 							state.consumed = allEvents.length > 0 ? allEvents[allEvents.length - 1].seq : 0;
 						} else if (fresh.length > 0) {
 							applyUsageDelta(state, fresh, { estimateCost });
 							state.consumed = fresh[fresh.length - 1].seq;
+							stateChanged = true;
 						}
-						state.kind = "persisted";
-						if (revision !== void 0) state.revision = revision;
+						if (state.kind !== "persisted") {
+							state.kind = "persisted";
+							stateChanged = true;
+						}
+						if (revision !== void 0 && state.revision !== revision) {
+							state.revision = revision;
+							stateChanged = true;
+						}
 					} catch (error) {
 						ctx.logger.warn(`usage-stats: reading persisted session "${meta.id}" failed: ${String(error)}`);
 					}
 				}
 				cache.sessions[meta.id] = state;
+				if (stateChanged) markCacheChanged(cache);
 			}
+			for (const id of Object.keys(cache.sessions)) {
+				if (!attached.has(id) && !persistedIds.has(id)) {
+					delete cache.sessions[id];
+					markCacheChanged(cache);
+				}
 		}
-		for (const id of Object.keys(cache.sessions)) {
-			if (!attached.has(id) && !persistedIds.has(id)) delete cache.sessions[id];
 		}
-		const byDay = new Map();
-		const billingByDay = new Map();
-		for (const state of Object.values(cache.sessions)) {
-			mergeInto(byDay, state.days);
-			mergeBillingInto(billingByDay, state.billing.days);
+		const runtime = runtimeOf(cache);
+		if (runtime.aggregate === null || runtime.aggregateDirty) {
+			diagnostic(ctx, "aggregateRebuilds");
+			const byDay = new Map();
+			const billingByDay = new Map();
+			for (const state of Object.values(cache.sessions)) {
+				mergeInto(byDay, state.days);
+				mergeBillingInto(billingByDay, state.billing.days);
+			}
+			runtime.aggregate = { byDay, billingByDay };
+			runtime.aggregateDirty = false;
 		}
+		const { byDay, billingByDay } = runtime.aggregate;
 		// Keep the atomic cache write inside the single-flight section. Otherwise
 		// overlapping saves can race on the same temporary file.
 		await saveCache(ctx, cache);
@@ -545,7 +676,7 @@ export async function collectUsage(ctx, config = { monitors: {}, budgets: valida
 async function handleUsage(ctx, config, req, res) {
 	if (rejectForeignCaller(req, res)) return;
 	try {
-		const result = await collectUsage(ctx, config);
+		const result = await collectUsage(ctx, config, { scanPersisted: false });
 		json(res, 200, { ok: true, ...result });
 	} catch (error) {
 		ctx.logger.warn(`usage-stats: usage aggregation failed: ${String(error)}`);
@@ -562,7 +693,7 @@ function exportFailure(ctx, kind, error, res) {
 async function handleDailyExport(ctx, config, req, res) {
 	if (rejectForeignCaller(req, res)) return;
 	try {
-		attachment(res, "text/csv; charset=utf-8", "dsh-usage-daily.csv", dailyCsv(await collectUsage(ctx, config)));
+		attachment(res, "text/csv; charset=utf-8", "dsh-usage-daily.csv", dailyCsv(await collectUsage(ctx, config, { scanPersisted: true })));
 	} catch (error) {
 		exportFailure(ctx, "daily CSV", error, res);
 	}
@@ -571,7 +702,7 @@ async function handleDailyExport(ctx, config, req, res) {
 async function handleSessionsExport(ctx, config, req, res) {
 	if (rejectForeignCaller(req, res)) return;
 	try {
-		attachment(res, "text/csv; charset=utf-8", "dsh-usage-sessions.csv", sessionsCsv(await collectUsage(ctx, config)));
+		attachment(res, "text/csv; charset=utf-8", "dsh-usage-sessions.csv", sessionsCsv(await collectUsage(ctx, config, { scanPersisted: true })));
 	} catch (error) {
 		exportFailure(ctx, "session CSV", error, res);
 	}
@@ -580,7 +711,10 @@ async function handleSessionsExport(ctx, config, req, res) {
 async function handleJsonExport(ctx, config, accounts, req, res) {
 	if (rejectForeignCaller(req, res)) return;
 	try {
-		const [usage, providerViews] = await Promise.all([collectUsage(ctx, config), accounts.providerViews()]);
+		const [usage, providerViews] = await Promise.all([
+			collectUsage(ctx, config, { scanPersisted: true }),
+			accounts.providerViews()
+		]);
 		attachment(res, "application/json; charset=utf-8", "dsh-usage-stats.json", JSON.stringify(jsonExport(usage, providerViews)));
 	} catch (error) {
 		exportFailure(ctx, "JSON", error, res);
@@ -635,7 +769,7 @@ async function configuredProviders(ctx) {
  * events), and add no stream listener, provider request, cache, or usage ledger.
  */
 export async function collectSessionContext(ctx, sessionId, config = { monitors: {} }, selectedRoute = null) {
-	await collectUsage(ctx, config);
+	await collectUsage(ctx, config, { scanPersisted: false });
 	const sessions = ctx.get("sessions");
 	const live = sessions?.get?.(sessionId) ?? sessions?.list?.().find((session) => session.id === sessionId);
 	if (live === void 0) return null;
@@ -655,8 +789,8 @@ export async function collectSessionContext(ctx, sessionId, config = { monitors:
 }
 
 /** Resolve the current account ids for every live session without a new ledger or provider guess. */
-export async function collectActiveAccountIds(ctx, config = { monitors: {} }) {
-	await collectUsage(ctx, config);
+export async function collectActiveAccountIds(ctx, config = { monitors: {} }, options = { scanPersisted: false }) {
+	await collectUsage(ctx, config, options);
 	const sessions = ctx.get("sessions")?.list?.() ?? [];
 	const cache = loadedCache;
 	if (cache === null) return [];
@@ -917,8 +1051,8 @@ export function startBackgroundRefresh(ctx, accounts, deps = {}) {
 			const at = now();
 			if (force || at >= nextUsageAt) {
 				try {
-					if (accountRefreshEnabled) accounts.setActiveProviders(await collectActiveAccountIds(ctx, config));
-					else await collectUsage(ctx, config);
+					if (accountRefreshEnabled) accounts.setActiveProviders(await collectActiveAccountIds(ctx, config, { scanPersisted: true }));
+					else await collectUsage(ctx, config, { scanPersisted: true });
 				} catch (error) {
 					ctx.logger.warn(`usage-stats: background usage refresh failed: ${String(error)}`);
 				}

--- a/lib/index.js
+++ b/lib/index.js
@@ -439,13 +439,23 @@ async function saveCache(ctx, cache) {
 	}
 }
 
-/** Single-flight guard: concurrent requests share one aggregation run. */
-function withLock(run) {
-	if (inflight !== null) return inflight;
-	inflight = run().finally(() => {
-		inflight = null;
+/**
+ * Single-flight guard: concurrent requests share compatible aggregation work.
+ * A full persisted scan cannot be satisfied by an already-running live-only
+ * collection; it waits for that run and then performs its own full pass.
+ */
+function withCollectionLock(scanPersisted, run) {
+	if (inflight !== null) {
+		if (!scanPersisted || inflight.scanPersisted) return inflight.promise;
+		const waitForLive = () => withCollectionLock(true, run);
+		return inflight.promise.then(waitForLive, waitForLive);
+	}
+	const entry = { scanPersisted, promise: null };
+	entry.promise = run().finally(() => {
+		if (inflight === entry) inflight = null;
 	});
-	return inflight;
+	inflight = entry;
+	return entry.promise;
 }
 //#endregion
 
@@ -469,10 +479,8 @@ function withLock(run) {
  */
 function liveSessionAdapter(session) {
 	if (session === null || typeof session !== "object") throw new TypeError("live session must be an object");
-	const hasSnapshotEvents = typeof session.snapshotEvents === "function";
-	const hasSeq = "seq" in session;
-	if (hasSnapshotEvents || hasSeq) {
-		if (!hasSnapshotEvents || !hasSeq) throw new TypeError("live session exposes an incomplete snapshot API");
+	if (typeof session.snapshotEvents === "function") {
+		if (!("seq" in session)) throw new TypeError("live session exposes an incomplete snapshot API");
 		return {
 			count() {
 				const count = session.seq;
@@ -486,6 +494,8 @@ function liveSessionAdapter(session) {
 			}
 		};
 	}
+	const legacyEvents = session.events;
+	if (!Array.isArray(legacyEvents)) throw new TypeError("live session does not expose a supported snapshot API");
 	return {
 		count() {
 			const events = session.events;
@@ -501,8 +511,8 @@ function liveSessionAdapter(session) {
 }
 
 export async function collectUsage(ctx, config = { monitors: {}, budgets: validateBudgetConfig() }, options = {}) {
-	return withLock(async () => {
-		const scanPersisted = options?.scanPersisted !== false;
+	const scanPersisted = options?.scanPersisted !== false;
+	return withCollectionLock(scanPersisted, async () => {
 		const providers = await configuredProviders(ctx);
 		const runtimePricingFingerprint = pricingFingerprint({ providers, config });
 		const cache = await loadCache(runtimePricingFingerprint);

--- a/lib/index.js
+++ b/lib/index.js
@@ -340,6 +340,7 @@ function parsePricingIdentityCutoffs(raw) {
 }
 
 function freshCache(pricingFingerprintValue, previous = null, transitionAt = Date.now()) {
+	const fingerprintChanged = previous !== null && previous.pricingFingerprint !== pricingFingerprintValue;
 	const pricingIdentityCutoffs = parsePricingIdentityCutoffs(previous?.pricingIdentityCutoffs);
 	let pricingIdentityCutoffAll = Number.isFinite(previous?.pricingIdentityCutoffAll) && previous.pricingIdentityCutoffAll >= 0
 		? previous.pricingIdentityCutoffAll
@@ -356,7 +357,11 @@ function freshCache(pricingFingerprintValue, previous = null, transitionAt = Dat
 		pricingIdentityCutoffs,
 		sessions: {}
 	};
-	runtimeOf(cache);
+	const runtime = runtimeOf(cache);
+	// A pricing identity/catalog change invalidates all derived billing. Mark
+	// the replacement dirty even when the next collection deliberately avoids
+	// a persisted scan, so the stale fingerprint cannot survive a restart.
+	if (fingerprintChanged) runtime.dirty = true;
 	return cache;
 }
 
@@ -462,37 +467,37 @@ function withLock(run) {
  * aggregate, but the persistence backend is not enumerated or read. The
  * five-minute background fold and exports use the default full scan.
  */
-function modernLiveSessionAPI(session) {
+function liveSessionAdapter(session) {
 	if (session === null || typeof session !== "object") throw new TypeError("live session must be an object");
 	const hasSnapshotEvents = typeof session.snapshotEvents === "function";
 	const hasSeq = "seq" in session;
 	if (hasSnapshotEvents || hasSeq) {
 		if (!hasSnapshotEvents || !hasSeq) throw new TypeError("live session exposes an incomplete snapshot API");
-		return true;
+		return {
+			count() {
+				const count = session.seq;
+				if (!Number.isSafeInteger(count) || count < 0) throw new TypeError("live session seq must be a non-negative safe integer");
+				return count;
+			},
+			tail(fromSeq) {
+				const events = session.snapshotEvents(fromSeq);
+				if (!Array.isArray(events)) throw new TypeError("live session snapshotEvents() must return an array");
+				return events;
+			}
+		};
 	}
-	return false;
-}
-
-function liveSessionCount(session) {
-	if (modernLiveSessionAPI(session)) {
-		const count = session.seq;
-		if (!Number.isSafeInteger(count) || count < 0) throw new TypeError("live session seq must be a non-negative safe integer");
-		return count;
-	}
-	const events = session.events;
-	if (!Array.isArray(events)) throw new TypeError("legacy live session events must be an array");
-	return events.length;
-}
-
-function liveSessionTail(session, fromSeq) {
-	if (modernLiveSessionAPI(session)) {
-		const events = session.snapshotEvents(fromSeq);
-		if (!Array.isArray(events)) throw new TypeError("live session snapshotEvents() must return an array");
-		return events;
-	}
-	const events = session.events;
-	if (!Array.isArray(events)) throw new TypeError("legacy live session events must be an array");
-	return events.slice(fromSeq);
+	return {
+		count() {
+			const events = session.events;
+			if (!Array.isArray(events)) throw new TypeError("legacy live session events must be an array");
+			return events.length;
+		},
+		tail(fromSeq) {
+			const events = session.events;
+			if (!Array.isArray(events)) throw new TypeError("legacy live session events must be an array");
+			return events.slice(fromSeq);
+		}
+	};
 }
 
 export async function collectUsage(ctx, config = { monitors: {}, budgets: validateBudgetConfig() }, options = {}) {
@@ -515,6 +520,7 @@ export async function collectUsage(ctx, config = { monitors: {}, budgets: valida
 		if (live !== void 0) {
 			for (const session of live.list()) {
 				attached.add(session.id);
+				const liveAdapter = liveSessionAdapter(session);
 				let state = cache.sessions[session.id];
 				let stateChanged = false;
 				if (state === void 0) {
@@ -530,7 +536,7 @@ export async function collectUsage(ctx, config = { monitors: {}, budgets: valida
 					resetUsageState(state);
 					stateChanged = true;
 				}
-				let count = liveSessionCount(session);
+				const count = liveAdapter.count();
 				if (count < (state.consumed ?? 0)) {
 					// The in-memory log shrank below the folded cursor — DSH
 					// restores sessions from disk as compressed summaries after
@@ -542,7 +548,7 @@ export async function collectUsage(ctx, config = { monitors: {}, budgets: valida
 					stateChanged = true;
 				}
 				if ((state.consumed ?? 0) < count) {
-					applyUsageDelta(state, liveSessionTail(session, state.consumed ?? 0), { estimateCost });
+					applyUsageDelta(state, liveAdapter.tail(state.consumed ?? 0), { estimateCost });
 					state.consumed = count;
 					stateChanged = true;
 				}
@@ -645,7 +651,7 @@ export async function collectUsage(ctx, config = { monitors: {}, budgets: valida
 					delete cache.sessions[id];
 					markCacheChanged(cache);
 				}
-		}
+			}
 		}
 		const runtime = runtimeOf(cache);
 		if (runtime.aggregate === null || runtime.aggregateDirty) {

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -56,12 +56,13 @@ function makeResponse() {
 	};
 }
 
-function makeContext({ sessions, persistence, routes, settings } = {}) {
+function makeContext({ sessions, persistence, routes, settings, diagnostics } = {}) {
 	return {
 		logger: { warn: () => {} },
 		credentials: { resolve: async () => void 0 },
 		webServer: { register: (entry) => { routes?.set(entry.path, entry.handler); return () => {}; } },
 		effect: (register) => register(),
+		__usageStatsDiagnostics: diagnostics,
 		get: (name) => name === "sessions" ? sessions : name === "sessionPersistence" ? persistence : name === "settings" ? settings : void 0
 	};
 }
@@ -474,6 +475,36 @@ async function testPricingFingerprintInvalidatesDerivedCosts(root) {
 	assert.equal(rewritten.pricingIdentityCutoffAll, null, "catalog-only changes must not invent a provider identity cutoff");
 }
 
+async function testPricingFingerprintInvalidationWritesWithoutLive(root) {
+	const home = join(root, "pricing-fingerprint-no-live");
+	const storage = join(home, "storages");
+	await mkdir(storage, { recursive: true });
+	const oldFingerprint = pricingFingerprint({
+		providers: [{ id: "deepseek-official", displayName: "DeepSeek", baseURL: "https://api.deepseek.com" }],
+		config: { monitors: {} }
+	});
+	await writeFile(join(storage, "usage-stats-cache.json"), JSON.stringify({
+		version: 5,
+		pricingFingerprint: oldFingerprint,
+		sessions: {}
+	}), "utf8");
+	const plugin = await freshModule("pricing-fingerprint-no-live", home);
+	const diagnostics = zeroDiagnostics();
+	const context = makeContext({
+		sessions: { list: () => [] },
+		persistence: {
+			listSnapshots: async () => { throw new Error("UI invalidation must not scan persisted sessions"); },
+			list: async () => { throw new Error("UI invalidation must not list persisted sessions"); }
+		},
+		settings: { get: (name) => name === "llm-deepseek" ? { baseURL: "https://relay.invalid/v1" } : void 0 },
+		diagnostics
+	});
+	await plugin.collectUsage(context, { monitors: {} }, { scanPersisted: false });
+	const rewritten = JSON.parse(await readFile(join(storage, "usage-stats-cache.json"), "utf8"));
+	assert.notEqual(rewritten.pricingFingerprint, oldFingerprint, "a runtime pricing identity change must invalidate the disk fingerprint without live sessions");
+	assert.equal(diagnostics.cacheWrites, 1, "pricing invalidation must be persisted even when no session is attached");
+}
+
 async function testRuntimeProviderPricingIdentityChange(root) {
 	const home = join(root, "runtime-provider-pricing-identity");
 	const plugin = await freshModule("runtime-provider-pricing-identity", home);
@@ -811,9 +842,120 @@ async function testDisabledAccountRefresh(root) {
 	assert.notEqual(schedulerCleanup, void 0, "usage aggregation lifecycle must remain registered when account refresh is disabled");
 	await schedulerCleanup.ready;
 	assert.equal(adaptiveCalls, 0, "disabled mode must not start the adaptive account scheduler");
-	const cache = JSON.parse(await readFile(join(home, "storages", "usage-stats-cache.json"), "utf8"));
-	assert.equal(cache.version, 5, "the surviving usage lifecycle must still fold and persist usage");
+	assert.equal(await readFile(join(home, "storages", "usage-stats-cache.json"), "utf8").catch(() => null), null, "an unchanged empty collection must not create a cache write");
 	await schedulerCleanup();
+}
+
+function zeroDiagnostics() {
+	return {
+		listSnapshots: 0,
+		list: 0,
+		readFrom: 0,
+		aggregateRebuilds: 0,
+		cacheWrites: 0
+	};
+}
+
+async function testUsageScanDedup(root) {
+	const request = (path) => ({
+		method: "GET",
+		url: path,
+		headers: { host: "localhost:3080" },
+		socket: { remoteAddress: "127.0.0.1" }
+	});
+
+	// H1: warm cache + ten UI polls must not enumerate or read persisted logs,
+	// rebuild the aggregate, or write the cache again.
+	{
+		const plugin = await freshModule("scan-h1", join(root, "scan-h1"));
+		const routes = new Map();
+		const diagnostics = zeroDiagnostics();
+		const persistence = {
+			listSnapshots: async () => [{ header: { id: "warm-persisted" }, revision: "r1" }],
+			list: async () => [],
+			readFrom: async () => ({ events: [usageEvent(1, 10)] })
+		};
+		const accounts = { validate: async () => {}, providerViews: async () => [], get: async () => null, subscriptionAccounts: async () => [] };
+		const context = makeContext({
+			sessions: { list: () => [] }, persistence, routes, diagnostics,
+			settings: { get: () => void 0 }
+		});
+		await plugin.apply(context, {}, { disableBackgroundRefresh: true, accounts });
+		await plugin.collectUsage(context);
+		Object.keys(diagnostics).forEach((key) => { diagnostics[key] = 0; });
+		for (let index = 0; index < 10; index += 1) {
+			const response = makeResponse();
+			await routes.get(plugin.USAGE_PATH)(request(plugin.USAGE_PATH), response);
+			assert.equal(response.status, 200);
+			assert.equal(JSON.parse(response.body).total.tokens, 10);
+		}
+		assert.deepEqual(diagnostics, zeroDiagnostics(), "warm UI polls must be read-only against persisted state");
+	}
+
+	// H2: one live append is folded from the tail only and causes exactly one
+	// aggregate rebuild and one atomic cache write.
+	{
+		const plugin = await freshModule("scan-h2", join(root, "scan-h2"));
+		const routes = new Map();
+		const diagnostics = zeroDiagnostics();
+		let events = [usageEvent(0, 5)];
+		const session = { id: "live-append", get events() { return events; } };
+		const persistence = { listSnapshots: async () => [], list: async () => [] };
+		const accounts = { validate: async () => {}, providerViews: async () => [], get: async () => null, subscriptionAccounts: async () => [] };
+		const context = makeContext({ sessions: { list: () => [session] }, persistence, routes, diagnostics, settings: { get: () => void 0 } });
+		await plugin.apply(context, {}, { disableBackgroundRefresh: true, accounts });
+		assert.equal((await plugin.collectUsage(context)).total.tokens, 5);
+		Object.keys(diagnostics).forEach((key) => { diagnostics[key] = 0; });
+		events = [...events, usageEvent(1, 7)];
+		const response = makeResponse();
+		await routes.get(plugin.USAGE_PATH)(request(plugin.USAGE_PATH), response);
+		assert.equal(response.status, 200);
+		assert.equal(JSON.parse(response.body).total.tokens, 12);
+		assert.deepEqual(diagnostics, {
+			listSnapshots: 0,
+			list: 0,
+			readFrom: 0,
+			aggregateRebuilds: 1,
+			cacheWrites: 1
+		}, "a live append must not trigger a persisted scan");
+	}
+
+	// H3/H4: a large unchanged snapshot set is cheap, while one changed
+	// revision does one read/rebuild/write and preserves exact totals.
+	{
+		const plugin = await freshModule("scan-large", join(root, "scan-large"));
+		const diagnostics = zeroDiagnostics();
+		const ids = Array.from({ length: 10_000 }, (_, index) => `persisted-${index}`);
+		const revisions = new Map(ids.map((id) => [id, "r1"]));
+		const persistence = {
+			listSnapshots: async () => ids.map((id) => ({ header: { id }, revision: revisions.get(id) })),
+			list: async () => [],
+			readFrom: async (id) => revisions.get(id) === "r2" ? { events: [usageEvent(1, 7)] } : { events: [] }
+		};
+		const context = makeContext({ sessions: { list: () => [] }, persistence, diagnostics, settings: { get: () => void 0 } });
+		assert.equal((await plugin.collectUsage(context)).total.tokens, 0);
+		Object.keys(diagnostics).forEach((key) => { diagnostics[key] = 0; });
+		assert.equal((await plugin.collectUsage(context)).total.tokens, 0);
+		assert.deepEqual(diagnostics, {
+			listSnapshots: 1,
+			list: 0,
+			readFrom: 0,
+			aggregateRebuilds: 0,
+			cacheWrites: 0
+		}, "ten thousand unchanged snapshots must not rebuild or write");
+
+		revisions.set("persisted-0", "r2");
+		Object.keys(diagnostics).forEach((key) => { diagnostics[key] = 0; });
+		const changed = await plugin.collectUsage(context);
+		assert.equal(changed.total.tokens, 7);
+		assert.deepEqual(diagnostics, {
+			listSnapshots: 1,
+			list: 0,
+			readFrom: 1,
+			aggregateRebuilds: 1,
+			cacheWrites: 1
+		}, "one changed revision must perform one read/rebuild/write");
+	}
 }
 
 async function testPersistedToLive(root) {
@@ -938,6 +1080,7 @@ try {
 	await testModernLiveSessionAPI(root);
 	await testV4CacheUpgradeRefoldsBilling(root);
 	await testPricingFingerprintInvalidatesDerivedCosts(root);
+	await testPricingFingerprintInvalidationWritesWithoutLive(root);
 	await testRuntimeProviderPricingIdentityChange(root);
 	await testConfigValidation(root);
 	await testUsageBillingWire(root);
@@ -946,6 +1089,7 @@ try {
 	await testLegacyZaiSubscriptionId(root);
 	await testBackgroundRefresh(root);
 	await testDisabledAccountRefresh(root);
+	await testUsageScanDedup(root);
 	await testPersistedToLive(root);
 	await testRevisionRewrite(root);
 	await testFallbackIncremental(root);

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -323,6 +323,62 @@ async function testSessionContext(root) {
 	assert.equal(JSON.parse(ambiguous.body).error, "session-required");
 }
 
+async function testModernLiveSessionAPI(root) {
+	const plugin = await freshModule("modern-live-session", join(root, "modern-live-session"));
+	const routes = new Map();
+	const id = "modern-live-session";
+	let events = [routeEvent(0, "route-a", "modern-model"), usageEvent(1, 5)];
+	const snapshotCalls = [];
+	const session = {
+		id,
+		get seq() { return events.length; },
+		snapshotEvents(fromSeq = 0) {
+			snapshotCalls.push(fromSeq);
+			return Object.freeze(events.slice(fromSeq));
+		},
+		get events() {
+			throw new Error("modern DSH sessions must never read the removed events property");
+		}
+	};
+	const sessions = { list: () => [session], get: (sessionId) => sessionId === id ? session : void 0 };
+	const persistence = { listSnapshots: async () => [], list: async () => [] };
+	const context = makeContext({ sessions, persistence, routes });
+	const accounts = {
+		validate: async () => {},
+		providerViews: async () => [],
+		get: async () => null,
+		subscriptionAccounts: async () => []
+	};
+	await plugin.apply(context, {}, { disableBackgroundRefresh: true, accounts });
+
+	const first = await plugin.collectUsage(context);
+	assert.equal(first.total.tokens, 5, "modern snapshot API must fold the initial live tail");
+	assert.deepEqual(snapshotCalls, [0]);
+	const unchanged = await plugin.collectUsage(context);
+	assert.equal(unchanged.total.tokens, 5, "an unchanged modern live log must not refold");
+	assert.deepEqual(snapshotCalls, [0]);
+
+	events = [...events, usageEvent(2, 7)];
+	const appended = await plugin.collectUsage(context);
+	assert.equal(appended.total.tokens, 12, "modern snapshot API must fold only appended events");
+	assert.deepEqual(snapshotCalls, [0, 2]);
+
+	events = events.slice(0, 2);
+	const shrunk = await plugin.collectUsage(context);
+	assert.equal(shrunk.total.tokens, 5, "modern live log shrink must refold from seq zero");
+	assert.deepEqual(snapshotCalls, [0, 2, 0]);
+
+	const response = makeResponse();
+	await routes.get(plugin.USAGE_PATH)({
+		method: "GET",
+		url: plugin.USAGE_PATH,
+		headers: { host: "localhost:3080" },
+		socket: { remoteAddress: "127.0.0.1" }
+	}, response);
+	assert.equal(response.status, 200, "the HTTP usage route must support modern live sessions");
+	assert.equal(JSON.parse(response.body).total.tokens, 5);
+}
+
 async function testV4CacheUpgradeRefoldsBilling(root) {
 	const home = join(root, "v4-cache-upgrade");
 	const storage = join(home, "storages");
@@ -879,6 +935,7 @@ try {
 	await testRouteFence(root);
 	await testOrcaRouterIntegrationRoute(root);
 	await testSessionContext(root);
+	await testModernLiveSessionAPI(root);
 	await testV4CacheUpgradeRefoldsBilling(root);
 	await testPricingFingerprintInvalidatesDerivedCosts(root);
 	await testRuntimeProviderPricingIdentityChange(root);

--- a/scripts/test-server.mjs
+++ b/scripts/test-server.mjs
@@ -380,6 +380,50 @@ async function testModernLiveSessionAPI(root) {
 	assert.equal(JSON.parse(response.body).total.tokens, 5);
 }
 
+async function testLegacyLiveSessionAPI(root) {
+	const plugin = await freshModule("legacy-live-session", join(root, "legacy-live-session"));
+	const routes = new Map();
+	const id = "legacy-live-session";
+	let events = [routeEvent(0, "route-a", "legacy-model"), usageEvent(1, 5)];
+	const session = {
+		id,
+		get seq() { return events.length; },
+		get events() { return events; }
+	};
+	const sessions = { list: () => [session], get: (sessionId) => sessionId === id ? session : void 0 };
+	const persistence = { listSnapshots: async () => [], list: async () => [] };
+	const context = makeContext({ sessions, persistence, routes });
+	const accounts = {
+		validate: async () => {},
+		providerViews: async () => [],
+		get: async () => null,
+		subscriptionAccounts: async () => []
+	};
+	await plugin.apply(context, {}, { disableBackgroundRefresh: true, accounts });
+
+	const first = await plugin.collectUsage(context);
+	assert.equal(first.total.tokens, 5, "legacy rc.7 session shape must fold the initial live log");
+	assert.equal(typeof session.snapshotEvents, "undefined", "the legacy regression fixture must not expose snapshotEvents");
+
+	events = [...events, usageEvent(2, 7)];
+	const appended = await plugin.collectUsage(context);
+	assert.equal(appended.total.tokens, 12, "legacy sessions must fold appended events");
+
+	events = events.slice(0, 2);
+	const shrunk = await plugin.collectUsage(context);
+	assert.equal(shrunk.total.tokens, 5, "legacy live log shrink must refold from seq zero");
+
+	const response = makeResponse();
+	await routes.get(plugin.USAGE_PATH)({
+		method: "GET",
+		url: plugin.USAGE_PATH,
+		headers: { host: "localhost:3080" },
+		socket: { remoteAddress: "127.0.0.1" }
+	}, response);
+	assert.equal(response.status, 200, "the HTTP usage route must support rc.7 legacy live sessions");
+	assert.equal(JSON.parse(response.body).total.tokens, 5);
+}
+
 async function testV4CacheUpgradeRefoldsBilling(root) {
 	const home = join(root, "v4-cache-upgrade");
 	const storage = join(home, "storages");
@@ -958,6 +1002,35 @@ async function testUsageScanDedup(root) {
 	}
 }
 
+async function testScanModeSingleFlight(root) {
+	const collectPair = async (label, firstMode, secondMode) => {
+		const plugin = await freshModule(`scan-lock-${label}`, join(root, `scan-lock-${label}`));
+		const diagnostics = zeroDiagnostics();
+		const persistence = {
+			listSnapshots: async () => [],
+			list: async () => [],
+			readFrom: async () => ({ events: [] })
+		};
+		const context = makeContext({
+			sessions: { list: () => [] },
+			persistence,
+			diagnostics,
+			settings: { get: () => void 0 }
+		});
+		const first = plugin.collectUsage(context, { monitors: {} }, { scanPersisted: firstMode });
+		const second = plugin.collectUsage(context, { monitors: {} }, { scanPersisted: secondMode });
+		await Promise.all([first, second]);
+		assert.equal(diagnostics.listSnapshots, 1, `${label}: exactly one full collection must enumerate persisted snapshots`);
+	};
+
+	// A full refresh arriving behind a live-only UI request must wait for the
+	// first run and then execute its own persisted pass.
+	await collectPair("live-first", false, true);
+	// A live-only request arriving behind a full refresh may share the full run
+	// and must not trigger a second persisted enumeration.
+	await collectPair("full-first", true, false);
+}
+
 async function testPersistedToLive(root) {
 	const plugin = await freshModule("transition", join(root, "transition"));
 	const id = "transition-session";
@@ -1078,6 +1151,7 @@ try {
 	await testOrcaRouterIntegrationRoute(root);
 	await testSessionContext(root);
 	await testModernLiveSessionAPI(root);
+	await testLegacyLiveSessionAPI(root);
 	await testV4CacheUpgradeRefoldsBilling(root);
 	await testPricingFingerprintInvalidatesDerivedCosts(root);
 	await testPricingFingerprintInvalidationWritesWithoutLive(root);
@@ -1090,6 +1164,7 @@ try {
 	await testBackgroundRefresh(root);
 	await testDisabledAccountRefresh(root);
 	await testUsageScanDedup(root);
+	await testScanModeSingleFlight(root);
 	await testPersistedToLive(root);
 	await testRevisionRewrite(root);
 	await testFallbackIncremental(root);


### PR DESCRIPTION
Closes #95
Closes #94

Supports current DSH 0.1.2-alpha.4 sessions through the formal
seq/snapshotEvents API and avoids redundant persisted scans, aggregate
rebuilds, and cache writes during high-frequency usage polling.

No pricing changes.
No cost/budget work.
No new client polling.
No DSH private-storage access.
Package version remains 0.3.1.

The live-session adapter preserves the legacy events fallback only for
pre-snapshot session objects; current DSH sessions are read through the
public seq/snapshotEvents API. Background scans remain available for the
five-minute archive refresh/export path, while ordinary usage reads use the
live-only path.