### PR TITLE
chore: prepare v0.3.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dsh-usage-stats
 
-<!-- stable-version: 0.3.1 -->
+<!-- stable-version: 0.3.2 -->
 
 [![GitHub Release](https://img.shields.io/github/v/release/Ychris12138/dsh-usage-stats?display_name=tag&sort=semver&color=1f6feb)](https://github.com/Ychris12138/dsh-usage-stats/releases/latest)
 [![CI](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml/badge.svg)](https://github.com/Ychris12138/dsh-usage-stats/actions/workflows/ci.yml)
@@ -39,7 +39,7 @@ Provider balances, subscription quotas, and token-usage analytics for the DeepSe
 稳定版优先安装 npm 上的精确版本；这也是 DSH Desktop Market 使用的同一个包：
 
 ```bash
-dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.3.1"
+dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.3.2"
 ```
 
 只有测试尚未发布的 source/RC 时才使用 `dsh plugin --profile web add "github:Ychris12138/dsh-usage-stats"`。GitHub `main` 可能领先 npm stable，不应把 source 安装当作市场安装验收。
@@ -53,7 +53,7 @@ dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.3.1"
 - `catalog/catalog-source.json` — 来源 manifest（`catalog-source.schema.json` v1.0.0）
 - `catalog/v1/plugins.json` — 标准 provider page（`catalog-provider-page.schema.json` v1.0.0）
 
-**使用前提（重要）**：市场托管安装只接受 npm registry 的精确稳定版本，git 条目仅可浏览。`dsh-usage-stats` 这个 npm 名已被其他项目占用，因此目录条目身份使用 `@ychris12138/dsh-usage-stats`。当前 stable/catalog 版本是 `0.3.1`；每个新版本都按以下顺序发布：
+**使用前提（重要）**：市场托管安装只接受 npm registry 的精确稳定版本，git 条目仅可浏览。`dsh-usage-stats` 这个 npm 名已被其他项目占用，因此目录条目身份使用 `@ychris12138/dsh-usage-stats`。当前 stable/catalog 版本是 `0.3.2`；每个新版本都按以下顺序发布：
 
 1. 运行 `npm run release:sync -- <version>` 同步 `package.json` / `package-lock.json` / `catalog/v1/plugins.json`，再由 `npm run check:release` 阻止身份或版本漂移。
 2. 发布 scoped 公共包：`npm publish --access public`。
@@ -349,7 +349,7 @@ Constraints:
 
 Procedure:
 1. Confirm node, npx, and dsh are available.
-2. Prefer the exact npm stable used by Desktop Market: `dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.3.1"` (or update the existing scoped package).
+2. Prefer the exact npm stable used by Desktop Market: `dsh plugin --profile web add "@ychris12138/dsh-usage-stats@0.3.2"` (or update the existing scoped package).
 3. Use `github:Ychris12138/dsh-usage-stats` only when I explicitly ask to test unreleased source/RC code.
 4. If dsh plugin is unavailable, use the compatible source installer only with my approval: `npx --yes github:Ychris12138/dsh-usage-stats`.
 5. Do not combine bundle installation with an existing manual dsh-usage-stats Cordis entry.
@@ -444,7 +444,7 @@ node scripts/check-balance.mjs
 
 ## 兼容性与致谢 / Compatibility & credits
 
-当前 npm stable 为 `0.3.1`；`v0.3.1` 的完整发布门禁见 [`docs/release-checklist.md`](docs/release-checklist.md)，变更摘要见 [`docs/release-notes-v0.3.1.md`](docs/release-notes-v0.3.1.md)。插件依赖 Harness 客户端模块加载器、Cordis 服务与 session persistence；Harness 预发布接口变化时可能需要同步适配。
+当前 npm stable 为 `0.3.2`；`v0.3.2` 的完整发布门禁见 [`docs/release-checklist.md`](docs/release-checklist.md)，变更摘要见 [`docs/release-notes-v0.3.2.md`](docs/release-notes-v0.3.2.md)。插件依赖 Harness 客户端模块加载器、Cordis 服务与 session persistence；Harness 预发布接口变化时可能需要同步适配。
 
 `display.currentSessionPill` 作为 v0.3.0 legacy boolean 配置键继续被接受，避免旧配置导致启动失败；当前客户端不再注册任何 composer UI，因此该键不再产生可见效果。`session-context` 服务端 API 暂时保留原有响应语义，供 v0.3.0 API compatibility 与后续集成使用。
 

--- a/catalog/v1/plugins.json
+++ b/catalog/v1/plugins.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-08-28T08:03:09.971Z",
-  "revision": "0.3.1",
+  "generatedAt": "2026-09-02T11:48:50.687Z",
+  "revision": "0.3.2",
   "items": [
     {
       "id": "dsh-usage-stats",
@@ -10,7 +10,7 @@
       "summary": "Token usage heatmap, provider balances, and subscription quotas for the dsh web GUI.",
       "description": "在 DSH 对话界面内展示 Token 用量热力图、各 provider 账户余额与订阅配额，数据来自持久化会话日志。catalog 条目身份与 npm 包 `@ychris12138/dsh-usage-stats` 对齐，发布后即可通过插件市场 GUI 直接安装。",
       "homepage": "https://github.com/Ychris12138/dsh-usage-stats",
-      "latestVersion": "0.3.1",
+      "latestVersion": "0.3.2",
       "license": "MIT",
       "categories": [
         "development",
@@ -40,7 +40,7 @@
           "dsh"
         ]
       },
-      "updatedAt": "2026-08-28T08:03:09.971Z"
+      "updatedAt": "2026-09-02T11:48:50.687Z"
     }
   ],
   "page": {}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -46,6 +46,13 @@ npm pack --json
 
 ## 5. Real DSH release-candidate regression
 
+### v0.3.2-specific gates
+
+- [ ] Current DSH sessions use the public `seq` / `snapshotEvents()` API; no current-session path accesses the removed `session.events` property.
+- [ ] Legacy sessions exposing `seq` plus an `events` array, but no `snapshotEvents()`, remain supported.
+- [ ] UI steady state performs zero persisted `listSnapshots`, zero persisted `readFrom`, zero unchanged aggregate rebuilds, and zero unchanged cache writes.
+- [ ] Background refresh skips `readFrom` and cache writes for unchanged revisions, uses incremental reads for changed revisions, and full-refolds truncation or rewrite cases.
+
 - [ ] Test the latest supported `@deepseek-ai/dsh` Desktop/Web release candidate with an isolated profile.
 - [ ] Confirm DSH starts without `Failed to load plugins` or loader identity errors.
 - [ ] Confirm client bundle load and that `sidebar.footer.action` is the only extension point registered by dsh-usage-stats; verify panel open/close, provider switching, cost/budget states, and manual Retry.
@@ -61,8 +68,8 @@ npm pack --json
 Do not run this section until every release-candidate gate above passes and the maintainer approves preparing the release commit.
 
 - [ ] Create a release branch from the reviewed `main` at `RC_BASE_SHA`.
-- [ ] Run `npm run release:sync -- 0.3.1` once to update `package.json`, `package-lock.json`, the Community Market catalog, and documented stable-version references together.
-- [ ] Confirm the v0.3.1 release notes use final stable wording, preserve the historical v0.3.0 notes, and do not claim #84 fixed or include #88 behavior.
+- [ ] Run `npm run release:sync -- 0.3.2` once to update `package.json`, `package-lock.json`, the Community Market catalog, and documented stable-version references together.
+- [ ] Confirm the v0.3.2 release notes use final stable wording, preserve the historical v0.3.0/v0.3.1 notes, and do not claim #84 fixed or include #88 behavior.
 - [ ] Run the release gates again against the synchronized version:
 
 ```bash
@@ -71,20 +78,20 @@ npm test
 npm pack --json
 ```
 
-- [ ] Inspect the final pack manifest, then commit all version/release metadata changes with `chore: prepare v0.3.1 release`.
+- [ ] Inspect the final pack manifest, then commit all version/release metadata changes with `chore: prepare v0.3.2 release`.
 - [ ] Record that commit as `RELEASE_SHA`; this replaces `RC_BASE_SHA` as the only publish/tag identity.
 - [ ] Confirm the working tree is clean and `HEAD` equals `RELEASE_SHA`.
 - [ ] Confirm the committed package version, not merely the working-tree version:
 
 ```bash
-test "$(git show "$RELEASE_SHA:package.json" | jq -r .version)" = "0.3.1"
+test "$(git show "$RELEASE_SHA:package.json" | jq -r .version)" = "0.3.2"
 ```
 
 The release invariant is:
 
 ```text
 npm published source commit
-== v0.3.1 tag commit
+== v0.3.2 tag commit
 == GitHub Release commit
 == package/catalog version commit
 == RELEASE_SHA
@@ -98,14 +105,14 @@ Do not run this section until the immutable release commit exists and the mainta
 - [ ] From a clean checkout/worktree at exactly `RELEASE_SHA`, run `npm publish --access public --registry=https://registry.npmjs.org/`.
 - [ ] `npm view "@ychris12138/dsh-usage-stats" version --registry=https://registry.npmjs.org/` equals the target version.
 - [ ] Merge or push the release commit to `main` according to the chosen branch workflow; verify `main` contains the exact `RELEASE_SHA` without recreating the release changes.
-- [ ] Only after npm and `main` verification: create the signed/annotated `v0.3.1` tag pointing explicitly to `RELEASE_SHA`.
+- [ ] Only after npm and `main` verification: create the signed/annotated `v0.3.2` tag pointing explicitly to `RELEASE_SHA`.
 - [ ] Verify the tag resolves to the published source commit:
 
 ```bash
-test "$(git rev-parse v0.3.1^{commit})" = "$RELEASE_SHA"
+test "$(git rev-parse v0.3.2^{commit})" = "$RELEASE_SHA"
 ```
 
-- [ ] Create the GitHub Release from `v0.3.1`; verify it resolves to `RELEASE_SHA`.
+- [ ] Create the GitHub Release from `v0.3.2`; verify it resolves to `RELEASE_SHA`.
 - [ ] Verify the public Pages `catalog-source.json` and `/v1/plugins` response content type, package name, and exact version.
 - [ ] Install the exact npm version through DSH Desktop Community Market and restart the host.
 - [ ] Close the npm/market release issue only after the Desktop Market installation succeeds.

--- a/docs/release-notes-v0.3.2.md
+++ b/docs/release-notes-v0.3.2.md
@@ -1,0 +1,36 @@
+# v0.3.2 release notes
+
+`v0.3.2` is a focused maintenance release for current DSH session compatibility and lower steady-state usage aggregation overhead.
+
+## Highlights
+
+### Current DSH Session API compatibility
+
+- Fixes #95 for DSH builds where the public `Session.events` array has been replaced by `seq` and `snapshotEvents()`.
+- Current DSH sessions now use the formal `seq` / `snapshotEvents(fromSeq)` API and continue folding only the live event tail.
+- Older DSH session objects without `snapshotEvents()` retain the legacy `events` fallback.
+- Compatibility is capability-based rather than tied to a DSH version string.
+- Preserves live-log shrink recovery and conservative live/persisted refolding semantics.
+
+### Lower usage polling overhead
+
+- Fixes #94 by separating high-frequency UI usage reads from persisted archive refreshes.
+- Ordinary `/usage` requests fold live-session tails and reuse cached persisted aggregates instead of enumerating every archived session.
+- Persisted archive scanning remains on the existing background refresh path and explicit export paths.
+- Unchanged collections no longer rebuild global aggregates or rewrite `usage-stats-cache.json`.
+- Persisted sessions with unchanged revision tokens perform no event reads.
+- A changed persisted revision still uses the existing incremental cursor logic, with full refolding retained for truncation or rewrite recovery.
+- Scan-mode single-flight guarantees that a required full persisted refresh cannot be satisfied accidentally by an in-flight live-only request.
+
+## Compatibility and non-features
+
+- No frontend polling interval change and no additional timer or polling loop.
+- No pricing-rule or billing-semantics changes.
+- Pricing/provider fingerprint changes still invalidate and persist derived billing state safely.
+- No private JSONL/zstd reader or plugin-owned persistence index.
+- No attempt to optimize live-to-persisted transitions by trusting the previous live fold.
+- No DSH `sessionProjectionCache` migration or modification.
+- No cold-session eviction or bounded-cache redesign.
+- No provider or composer UI changes.
+- No #84 quota-precision change and no #93 feature work is included in this release.
+- JSONL suffix reads remain an upstream DSH concern; a changed large archive may still require the host persistence backend to decode more data than the logical suffix.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ychris12138/dsh-usage-stats",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ychris12138/dsh-usage-stats",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "bin": {
         "dsh-usage-stats-install": "scripts/install.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ychris12138/dsh-usage-stats",
   "description": "Token usage, provider accounts, session cost estimates, budgets, and exports for the dsh web GUI",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Ychris12138/dsh-usage-stats.git"
@@ -24,6 +24,7 @@
     "docs/release-checklist.md",
     "docs/release-notes-v0.3.0.md",
     "docs/release-notes-v0.3.1.md",
+    "docs/release-notes-v0.3.2.md",
     "scripts/install.mjs",
     "README.md",
     "LICENSE",


### PR DESCRIPTION
## Summary

Prepare the immutable v0.3.2 release metadata for the maintenance changes
already reviewed and merged into main.

v0.3.2 contains:

- #95: compatibility with current DSH sessions using `seq` / `snapshotEvents()`, while retaining the legacy session fallback;
- #94: lower steady-state usage aggregation overhead by separating UI live reads from persisted archive refreshes and skipping unchanged aggregate/cache work.

No functional code changes are included in this release PR.

## Release invariant

Once this PR is approved, its single release commit becomes `RELEASE_SHA`.

The npm publication, `v0.3.2` tag, GitHub Release, package/catalog version
and release source must all resolve to that exact commit.

This release PR must not be squash-merged or rebased after `RELEASE_SHA`
is frozen.

RC_BASE_SHA: `8d636da68a2bb9424686fbd3cf225068bc316a0f`
RELEASE_SHA: `d484e7de04cfc37d9c2272a23dbdf375a2e64761`

## Validation

- `npm ci`: PASS
- `npm run check`: PASS (`@ychris12138/dsh-usage-stats@0.3.2`)
- `npm test`: PASS (bundle, client, overlay, server, export, provider identity, OrcaRouter, pricing, billing, balance, subscriptions, accounts, and installer suites)
- `npm pack --json`: PASS; 23 files, including all three release notes; prohibited-path scan count 0
- `git diff --check`: PASS
- Targeted #95/#94 regressions: PASS, including modern and legacy session APIs, append/shrink recovery, HTTP `/usage`, live/full scan single-flight, dirty/aggregate cache, persisted truncation, fallback backend, and live-to-persisted transitions.

## Real DSH smoke

- DSH: `@deepseek-ai/dsh@0.1.2-alpha.4`; Node: `v24.14.1`
- Exact 0.3.2 tarball installed into an isolated profile.
- DSH started successfully; `/api/usage-stats/providers`, `/usage`, `/account`, `/subscriptions`, and `/session-context` returned expected HTTP responses; no plugin-loader failure or `reading length` error appeared in the process output.
- Built-in browser/sidebar smoke: NOT TESTED; Codex IAB blocked the isolated localhost port with `ERR_BLOCKED_BY_CLIENT`.
- REAL TOKEN/COST SMOKE: NOT TESTED (no model credentials in the isolated profile).

No pricing, billing, provider, client, or timer changes are included.
Do not publish npm, create a tag, or create a GitHub Release from this PR.